### PR TITLE
CT-1476 BUGFIX Prevent add_message_to_case being called with wrong team

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -23,4 +23,3 @@ class MessagesController < ApplicationController
   end
 
 end
-

--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -56,7 +56,7 @@ module ConfigurableStateMachine
     def method_missing(method, *args)
       if method.to_s =~ /(.+)!$/
         event_name = $1
-        trigger_event(event: event_name, params: args.first)
+        trigger_event(event: event_name.to_sym, params: args.first)
       else
         super
       end
@@ -99,7 +99,7 @@ module ConfigurableStateMachine
       raise InvalidEventError.new(kase: @kase, user: params[:acting_user], event: event) if user_role_config.nil?
       state_config = user_role_config.states[@kase.current_state]
       if state_config.nil? || !state_config.to_hash.keys.include?(event)
-        raise InvalidEventError.new(kase: @kase, user: params[:acting_user], event: event) if state_config.nil?
+        raise InvalidEventError.new(kase: @kase, user: params[:acting_user], event: event)
       end
       event_config = state_config[event]
       if can_trigger_event?(event_name: event, metadata: params)

--- a/config/state_machine/moj.yml
+++ b/config/state_machine/moj.yml
@@ -39,7 +39,6 @@ case_types:
             states:
               unassigned:
                 add_message_to_case:
-                  if: Case::FOIPolicy#can_add_message_to_case?
                 assign_responder:
                   transition_to: awaiting_responder
                 destroy_case:
@@ -52,5 +51,10 @@ case_types:
           approver:
             states:
               unassigned:
+                add_message_to_case:
                 flag_for_clearance:
 
+          responder:
+            states:
+              unassigned:
+                add_message_to_case:

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -470,8 +470,9 @@ RSpec.describe CasesController, type: :controller do
       context 'as a responder' do
         let(:user) { create(:responder) }
 
-        it 'permitted_events to be empty' do
-          expect(assigns(:permitted_events)).to be_empty
+
+        it 'permitted_events to be add_message_to_case' do
+          expect(assigns(:permitted_events)).to eq [:add_message_to_case]
         end
 
         it 'renders case details page' do

--- a/spec/state_machines/configurable_state_machine/machine_spec.rb
+++ b/spec/state_machines/configurable_state_machine/machine_spec.rb
@@ -348,7 +348,7 @@ module ConfigurableStateMachine
         user = double User
         team = double BusinessUnit
         metadata = { acting_user: user, acting_team: team }
-        expect(machine).to receive(:trigger_event).with(event: 'dummy_event', params: metadata)
+        expect(machine).to receive(:trigger_event).with(event: :dummy_event, params: metadata)
         machine.dummy_event!(metadata)
       end
 


### PR DESCRIPTION
This is a temporary fix to solve the problem of calling an event on a state machine
and passing in an acting team which doesn't have the right to execute that event.

In this case, it is the messages controller, which determines the acting team with:

team = current_user.teams_for_case(@case).first

In the old code, this would have returned one of the teams that was common across
both the case and the user.  If it was the Disclosure team
first, rather than the Disclosure BMT team, then an error occurs because the state
machine rightly says that the action isn't allowed for Disclosure team.

This is a temporary fix to ensure that the messages controller passes in the first
team after they have been ordered in priority 'manager', 'approver', 'responder', which
will work in this case.

But we need to find a more generalised and permanent solution - perhaps asking the
state machine which of the teams has this right.