### PR TITLE
Ct 1478 update success message

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -230,7 +230,7 @@ class CasesController < ApplicationController
       if service.result == :ok
         flash[:notice] = t('.case_updated')
       elsif service.result == :no_changes
-        flash[:notice] = "No changes were made"
+        flash[:alert] = "No changes were made"
       end
 
       set_permitted_events

--- a/app/services/case_updater_service.rb
+++ b/app/services/case_updater_service.rb
@@ -16,7 +16,7 @@ class CaseUpdaterService
         @kase.assign_attributes(@params)
         if @kase.changed?
           @kase.save!
-          @kase.state_machine.edit_case!(@user, @team)
+          @kase.state_machine.edit_case!(acting_user: @user, acting_team: @team)
           @result = :ok
         else
           @result = :no_changes

--- a/app/state_machines/case/foi_state_machine.rb
+++ b/app/state_machines/case/foi_state_machine.rb
@@ -368,10 +368,10 @@ class Case::FOIStateMachine
              event:             :assign_responder
   end
 
-  def edit_case!(user, team)
+  def edit_case!(acting_user:, acting_team:)
     trigger! :edit_case,
-             acting_team_id:    team.id,
-             acting_user_id:    user.id,
+             acting_team_id:    acting_team.id,
+             acting_user_id:    acting_user.id,
              event:             :edit_case
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,7 +251,7 @@ en:
       It will now appear in <a href="%{case_list_url}">your cases</a>.
     assignment_rejected_html: |
       <strong>You've rejected this case</strong><br>
-      DACU BMT will assign the case to the appropriate business unit.
+      Disclosure BMT will assign the case to the appropriate business unit.
     assignment_already_rejected_html: |
       <strong>This case has already been rejected.</strong><br>
       This case will be reviewed and assigned the to appropriate unit.
@@ -450,7 +450,7 @@ en:
           <li>sent the response to the person who made the request</li>
         </ul>
     confirm_respond:
-      success: Response confirmed. The case is now with DACU.
+      success: Response confirmed. The case is now with Disclosure BMT.
 #    update:
 #      case_updated: Case updated
     close:

--- a/spec/features/cases/foi/case_assignment_responding_spec.rb
+++ b/spec/features/cases/foi/case_assignment_responding_spec.rb
@@ -50,7 +50,7 @@ feature 'respond to responder assignment' do
     expect(page).to have_content "You've rejected this case"
     expect(page).
       to have_content(
-        'DACU BMT will assign the case to the appropriate business unit.'
+        'Disclosure BMT will assign the case to the appropriate business unit.'
       )
 
     expect(assigned_case.reload.current_state).to eq 'unassigned'

--- a/spec/features/cases/foi/case_responding/mark_as_sent_spec.rb
+++ b/spec/features/cases/foi/case_responding/mark_as_sent_spec.rb
@@ -28,7 +28,7 @@ feature 'Mark response as sent' do
     cases_respond_page.mark_as_sent_button.click
 
     expect(cases_show_page).
-        to have_content('Response confirmed. The case is now with DACU.')
+        to have_content('Response confirmed. The case is now with Disclosure BMT.')
 
     login_as manager
     open_cases_page.load(timeliness: 'in_time')

--- a/spec/features/cases/foi/editing_case_spec.rb
+++ b/spec/features/cases/foi/editing_case_spec.rb
@@ -33,4 +33,58 @@ feature 'Closing a case' do
 
   end
 
+  scenario 'editing a case with no changes' do
+    kase =  create :accepted_case, received_date: 2.days.ago
+    open_cases_page.load(timeliness: 'in_time')
+    click_link kase.number
+    expect(cases_show_page).to be_displayed
+    click_link 'Edit case details'
+    expect(cases_edit_page).to be_displayed
+
+    cases_edit_page.submit_button.click
+
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page.alert.text).to eq 'No changes were made'
+  end
+
+  scenario 'editing a case' do
+    kase =  create :case, received_date: 2.days.ago
+    open_cases_page.load(timeliness: 'in_time')
+    click_link kase.number
+    expect(cases_show_page).to be_displayed
+    click_link 'Edit case details'
+    expect(cases_edit_page).to be_displayed
+
+    cases_edit_page.date_received_day.set(Date.today.day)
+    cases_edit_page.date_received_month.set(Date.today.month)
+    cases_edit_page.date_received_year.set(Date.today.year)
+    cases_edit_page.subject.set('Aardvarks for sale')
+    cases_edit_page.full_request.set('I have heard that prisoners are selling baby aardvarks.  Is that true?')
+    cases_edit_page.full_name.set('John Doe')
+    cases_edit_page.email.set('john.doe@moj.com')
+    cases_edit_page.submit_button.click
+
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page.notice.text).to eq 'Case updated'
+    expect(cases_show_page.page_heading.heading.text).to eq 'Case subject, Aardvarks for sale'
+    expect(cases_show_page.case_details.basic_details.date_received.data.text).to eq Date.today.strftime(Settings.default_date_format)
+    expect(cases_show_page.case_details.basic_details.name.data.text).to eq 'John Doe'
+    expect(cases_show_page.case_details.basic_details.email.data.text).to eq 'john.doe@moj.com'
+
+  end
+
+  scenario 'editing a case with no changes' do
+    kase =  create :case
+    open_cases_page.load(timeliness: 'in_time')
+    click_link kase.number
+    expect(cases_show_page).to be_displayed
+    click_link 'Edit case details'
+    expect(cases_edit_page).to be_displayed
+
+    cases_edit_page.submit_button.click
+
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page.alert.text).to eq 'No changes were made'
+  end
+
 end

--- a/spec/features/cases/foi/editing_case_spec.rb
+++ b/spec/features/cases/foi/editing_case_spec.rb
@@ -8,46 +8,6 @@ feature 'Closing a case' do
   end
 
   scenario 'editing a case' do
-    kase =  create :accepted_case, received_date: 2.days.ago
-    open_cases_page.load(timeliness: 'in_time')
-    click_link kase.number
-    expect(cases_show_page).to be_displayed
-    click_link 'Edit case details'
-    expect(cases_edit_page).to be_displayed
-
-    cases_edit_page.date_received_day.set(Date.today.day)
-    cases_edit_page.date_received_month.set(Date.today.month)
-    cases_edit_page.date_received_year.set(Date.today.year)
-    cases_edit_page.subject.set('Aardvarks for sale')
-    cases_edit_page.full_request.set('I have heard that prisoners are selling baby aardvarks.  Is that true?')
-    cases_edit_page.full_name.set('John Doe')
-    cases_edit_page.email.set('john.doe@moj.com')
-    cases_edit_page.submit_button.click
-
-    expect(cases_show_page).to be_displayed
-    expect(cases_show_page.notice.text).to eq 'Case updated'
-    expect(cases_show_page.page_heading.heading.text).to eq 'Case subject, Aardvarks for sale'
-    expect(cases_show_page.case_details.basic_details.date_received.data.text).to eq Date.today.strftime(Settings.default_date_format)
-    expect(cases_show_page.case_details.basic_details.name.data.text).to eq 'John Doe'
-    expect(cases_show_page.case_details.basic_details.email.data.text).to eq 'john.doe@moj.com'
-
-  end
-
-  scenario 'editing a case with no changes' do
-    kase =  create :accepted_case, received_date: 2.days.ago
-    open_cases_page.load(timeliness: 'in_time')
-    click_link kase.number
-    expect(cases_show_page).to be_displayed
-    click_link 'Edit case details'
-    expect(cases_edit_page).to be_displayed
-
-    cases_edit_page.submit_button.click
-
-    expect(cases_show_page).to be_displayed
-    expect(cases_show_page.alert.text).to eq 'No changes were made'
-  end
-
-  scenario 'editing a case' do
     kase =  create :case, received_date: 2.days.ago
     open_cases_page.load(timeliness: 'in_time')
     click_link kase.number
@@ -74,7 +34,7 @@ feature 'Closing a case' do
   end
 
   scenario 'editing a case with no changes' do
-    kase =  create :case
+    kase =  create :accepted_case, received_date: 2.days.ago
     open_cases_page.load(timeliness: 'in_time')
     click_link kase.number
     expect(cases_show_page).to be_displayed

--- a/spec/services/case_updater_service_spec.rb
+++ b/spec/services/case_updater_service_spec.rb
@@ -22,7 +22,7 @@ describe CaseUpdaterService do
       end
 
       it 'transitions the cases state' do
-        expect(state_machine).to receive(:edit_case!).with(user, team)
+        expect(state_machine).to receive(:edit_case!).with(acting_user: user, acting_team: team)
         @service.call
       end
 

--- a/spec/site_prism/page_objects/pages/cases/show_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/show_page.rb
@@ -12,6 +12,7 @@ module PageObjects
         element :happy_action_notice, '.alert-green'
         element :escalation_notice, '.alert-orange'
         element :notice, '.notice-summary-heading'
+        element :alert, '.error-summary-heading'
 
         section :page_heading,
                 PageObjects::Sections::PageHeadingSection, '.page-heading'

--- a/spec/state_machines/cases/foi_state_machine_spec.rb
+++ b/spec/state_machines/cases/foi_state_machine_spec.rb
@@ -812,8 +812,8 @@ RSpec.describe Case::FOIStateMachine, type: :model do
       it 'triggers an edit_case event' do
         expect {
           state_machine.edit_case!(
-            manager,
-            team
+            acting_user: manager,
+            acting_team: team
           )
         }.to trigger_the_event(:edit_case)
                .on_state_machine(state_machine)

--- a/spec/support/features/steps/cases/responding_steps.rb
+++ b/spec/support/features/steps/cases/responding_steps.rb
@@ -16,7 +16,7 @@ def mark_case_as_sent_step
   cases_respond_page.mark_as_sent_button.click
 
   expect(open_cases_page)
-    .to have_content("Response confirmed. The case is now with DACU.")
+    .to have_content("Response confirmed. The case is now with Disclosure BMT.")
   expect(cases_show_page.case_status.details.who_its_with.text)
     .to eq 'Disclosure BMT'
   expect(cases_show_page.case_status.details.copy.text).to eq 'Ready to close'

--- a/spec/views/assignments/show_rejected_page_spec.rb
+++ b/spec/views/assignments/show_rejected_page_spec.rb
@@ -15,7 +15,7 @@ describe 'assignments/show_rejected.html.slim', type: :view do
     page = assignment_rejected_page
 
     expect(page.new_rejection_notice.text).
-        to eq "You've rejected this case\nDACU BMT will assign the case to the appropriate business unit.\n"
+        to eq "You've rejected this case\nDisclosure BMT will assign the case to the appropriate business unit.\n"
 
     expect(page.page_heading.heading.text).to eq rejected_case.subject
     expect(page.page_heading.sub_heading.text)


### PR DESCRIPTION
Fixes an issue where cases in unassigned state were not redirecting after being edited