### PR TITLE
CT-1499 New SAR journey for reponder

### DIFF
--- a/app/policies/case/sar_policy.rb
+++ b/app/policies/case/sar_policy.rb
@@ -1,3 +1,9 @@
 class Case::SARPolicy < Case::BasePolicy
 
+
+  def can_respond?
+    clear_failed_checks
+    self.case.drafting? &&
+        user.responding_teams.include?(self.case.responding_team)
+  end
 end

--- a/config/state_machine/moj.yml
+++ b/config/state_machine/moj.yml
@@ -155,9 +155,9 @@ case_types:
               drafting:
                 add_message_to_case:
                   if: Predicates#responder_is_member_of_assigned_team?
-                add_responses:
+                respond:
                   if: Predicates#responder_is_member_of_assigned_team?
-                  transition_to: awaiting_dispatch
+                  transition_to: responded
                 link_a_case:
                 reassign_user:
                   if: Predicates#responder_is_member_of_assigned_team?

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.6
--- Dumped by pg_dump version 9.5.6
+-- Dumped from database version 9.5.10
+-- Dumped by pg_dump version 9.5.10
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/spec/features/user_journeys/sar/non_offender_non_trigger_e2e_spec.rb
+++ b/spec/features/user_journeys/sar/non_offender_non_trigger_e2e_spec.rb
@@ -52,13 +52,9 @@ feature 'SAR NonOffender case that does not require clearance' do
                         message: 'This. Is. A. Test.',
                         do_logout: false
 
-    upload_response kase: kase,
-                    user: responder,
-                    file: UPLOAD_RESPONSE_DOCX_FIXTURE,
-                    do_login: false
-
     mark_case_as_sent kase: kase,
-                      user: responder
+                      user: responder,
+                      do_login: false
 
     close_case kase: kase,
                user: manager

--- a/spec/state_machines/sar_permitted_events_spec.rb
+++ b/spec/state_machines/sar_permitted_events_spec.rb
@@ -149,9 +149,9 @@ describe ConfigurableStateMachine::Machine do
           responder = responder_in_assigned_team(k)
           expect(k.current_state).to eq 'drafting'
           expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                        :add_responses,
                                                                         :link_a_case,
-                                                                        :reassign_user]
+                                                                        :reassign_user,
+                                                                        :respond]
         end
       end
 

--- a/spec/support/features/steps/cases/taking_on_and_escalating_case_steps.rb
+++ b/spec/support/features/steps/cases/taking_on_and_escalating_case_steps.rb
@@ -1,7 +1,7 @@
 def take_on_case_step(kase:)
   row = incoming_cases_page.row_for_case_number(kase.number)
   row.actions.take_on_case.click
-  row.actions.wait_until_take_on_case_invisible
+  row.actions.wait_until_take_on_case_invisible(5)
   expect(row.actions.success_message.text)
     .to eq "Case taken on Undo taking on of case #{kase.number}"
 end


### PR DESCRIPTION
This PR implements the new responder journey for SAR cases.  The response is NOT uploaded, instead the responder marks it as sent.

Note, there is still more to do on this journey (the responder has to enter the date responded Plus other details - there are still to be confirmed by User Research and Design).