### PR TITLE
CT-1222 Improves user journeys

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -62,7 +62,8 @@ class AssignmentsController < ApplicationController
     service = AssignNewTeamService.new(current_user, params)
     service.call
     if service.result == :ok
-      redirect_to root_open_cases_path
+      flash[:notice] = "Case has been assigned to a new team"
+      redirect_to case_path @case
     else
       flash[:alert] = "Unable to assign to this team"
       redirect_to action: 'assign_to_new_team'

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -216,7 +216,7 @@ class CasesController < ApplicationController
     when :ok
       flash[:notice] = t('notices.response_uploaded')
       set_permitted_events
-      redirect_to cases_path
+      redirect_to case_path @case
     end
   end
 
@@ -296,8 +296,8 @@ class CasesController < ApplicationController
                                       message: params[:message])
     service.call
     if service.result == :ok
-      flash[:notice] = "Clearance removed for case #{@case.number}"
-      redirect_to cases_path
+      flash[:notice] = "Clearance removed for this case."
+      redirect_to case_path(@case)
     end
   end
 
@@ -333,7 +333,7 @@ class CasesController < ApplicationController
     service.call
     if service.result == :ok
       flash[:notice] = "You have cleared case #{@case.number} - #{@case.subject}."
-      redirect_to cases_path
+      redirect_to case_path(@case)
     else
       flash[:alert] = service.error_message
       render :approve_response_interstitial
@@ -344,8 +344,8 @@ class CasesController < ApplicationController
     authorize @case
     @case.request_amends_comment = params[:case][:request_amends_comment]
     CaseRequestAmendsService.new(user: current_user, kase: @case).call
-    flash[:notice] = "You have requested amends to case #{@case.number} - #{@case.subject}."
-    redirect_to cases_path
+    flash[:notice] = 'You have requested amends to this case\'s response.'
+    redirect_to case_path(@case)
   end
 
   def extend_for_pit

--- a/app/views/cases/approve_response_interstitial.html.slim
+++ b/app/views/cases/approve_response_interstitial.html.slim
@@ -4,12 +4,11 @@
 
 
 - content_for :sub_heading
-span.visually-hidden
-  = t('common.case.header_case_number')
-= @case.number
+  span.visually-hidden
+    = t('common.case.header_case_number')
+  = @case.number
 
 = render partial: 'layouts/header'
-br
 
 .clearance-copy
   p
@@ -17,7 +16,6 @@ br
     strong.strong-block
       = @case.subject
 
-br
 
 = form_tag execute_response_approval_case_path(@case)
   - if @case.allow_event?(current_user, :approve_and_bypass)

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -560,7 +560,8 @@ RSpec.describe AssignmentsController, type: :controller do
         expect(service).to receive(:call)
         expect(service).to receive(:result).and_return(:ok)
         patch :execute_assign_to_new_team, params: params.to_unsafe_hash
-        expect(response).to redirect_to root_open_cases_path
+        expect(flash[:notice]).to eq 'Case has been assigned to a new team'
+        expect(response).to redirect_to case_path kase
       end
 
       it 'sets flash and returns to assign_new_team action if service fails' do

--- a/spec/controllers/cases_controller/execute_request_amends_spec.rb
+++ b/spec/controllers/cases_controller/execute_request_amends_spec.rb
@@ -33,15 +33,13 @@ RSpec.describe CasesController, type: :controller do
       patch :execute_request_amends,
             params: { id: pending_private_clearance_case, case: {request_amends_comment: "Oh my!"} }
       expect(flash[:notice])
-        .to eq "You have requested amends to case " +
-               "#{pending_private_clearance_case.number}" +
-               " - #{pending_private_clearance_case.subject}."
+        .to eq 'You have requested amends to this case\'s response.'
     end
 
-    it 'redirects to cases page' do
+    it 'redirects to case detail page' do
       patch :execute_request_amends,
             params: { id: pending_private_clearance_case, case: {request_amends_comment: "Oh my!"} }
-      expect(response).to redirect_to(cases_path)
+      expect(response).to redirect_to(case_path(pending_private_clearance_case))
     end
   end
 end

--- a/spec/controllers/cases_controller/execute_response_approval_spec.rb
+++ b/spec/controllers/cases_controller/execute_response_approval_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe CasesController, type: :controller do
                " - #{responded_trigger_case.subject}."
     end
 
-    it 'redirects to cases page' do
+    it 'redirects to case detail page' do
       patch :execute_response_approval, params: { id: responded_trigger_case }
-      expect(response).to redirect_to(cases_path)
+      expect(response).to redirect_to(case_path(responded_trigger_case))
     end
   end
 end

--- a/spec/controllers/cases_controller/unflag_for_clearance_spec.rb
+++ b/spec/controllers/cases_controller/unflag_for_clearance_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe CasesController, type: :controller do
 
       it 'redirects to case list' do
         patch :unflag_taken_on_case_for_clearance, params: params
-        expect(response).to redirect_to(cases_path)
+        expect(response).to redirect_to(case_path(flagged_case))
       end
 
       it 'displays a flash notice' do
         patch :unflag_taken_on_case_for_clearance, params: params
-        expect(flash[:notice]).to eq "Clearance removed for case #{flagged_case.number}"
+        expect(flash[:notice]).to eq "Clearance removed for this case."
       end
     end
 

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -1028,7 +1028,14 @@ RSpec.describe CasesController, type: :controller do
         allow_any_instance_of(CasesController).to receive(:flash).and_return(flash)
         expect(ResponseUploaderService).to receive(:new).and_return(response_uploader)
         do_upload_responses
-        expect(response).to redirect_to(cases_path)
+        expect(response).to redirect_to(case_path(kase))
+      end
+
+      it 'sets a flash message' do
+        allow_any_instance_of(CasesController).to receive(:flash).and_return(flash)
+        expect(ResponseUploaderService).to receive(:new).and_return(response_uploader)
+        do_upload_responses
+        expect(flash[:notice]).to eq "You have uploaded the response for this case."
       end
 
       context 'no files specified' do

--- a/spec/features/cases/foi/case_approvals/disclosure_specialist_approval_spec.rb
+++ b/spec/features/cases/foi/case_approvals/disclosure_specialist_approval_spec.rb
@@ -232,7 +232,7 @@ feature 'cases requiring clearance by disclosure specialist' do
     expect(page).to have_current_path(remove_clearance_case_path(kase))
     fill_in 'Reason for removing clearance', :with => "reason"
     cases_remove_clearance_form_page.submit_button.click
-    expect(cases_show_page.notice.text).to eq "Clearance removed for case #{kase.number}"
+    expect(cases_show_page.notice.text).to eq "Clearance removed for this case."
   end
 
   scenario 'upload a response and return for redraft', js: true do

--- a/spec/features/cases/foi/case_approvals/press_office_approvals_spec.rb
+++ b/spec/features/cases/foi/case_approvals/press_office_approvals_spec.rb
@@ -92,9 +92,10 @@ feature 'cases requiring clearance by press office' do
                    expected_action: 'requesting amends for',
                    expected_team: dacu_disclosure,
                    expected_status: 'Pending clearance'
-    execute_request_amends kase: pending_press_clearance_case
+    execute_request_amends
     go_to_case_details_step(
       kase: pending_press_clearance_case,
+      find_details_page: false,
       expected_team: dacu_disclosure,
       expected_history: [
         "#{press_officer.full_name}#{press_office.name}Request amends"

--- a/spec/features/cases/foi/case_approvals/private_office_approvals_spec.rb
+++ b/spec/features/cases/foi/case_approvals/private_office_approvals_spec.rb
@@ -86,11 +86,12 @@ feature 'cases requiring clearance by press office' do
                    expected_action: 'requesting amends for',
                    expected_team:   dacu_disclosure,
                    expected_status: 'Pending clearance'
-    execute_request_amends kase: pending_private_clearance_case
+    execute_request_amends
     go_to_case_details_step(
-      kase:             pending_private_clearance_case,
-      expected_team:    dacu_disclosure,
-      expected_history: ["#{assigned_private_officer.full_name}#{private_office.name}Request amends"]
+      kase:              pending_private_clearance_case,
+      find_details_page: false,
+      expected_team:     dacu_disclosure,
+      expected_history:  ["#{assigned_private_officer.full_name}#{private_office.name}Request amends"]
     )
   end
 end

--- a/spec/support/features/interactions.rb
+++ b/spec/support/features/interactions.rb
@@ -70,6 +70,7 @@ module Features
       cases_show_page.load(id: kase.id)
       upload_response_step file: file
       go_to_case_details_step kase: kase.reload,
+                              find_details_page: false,
                               expected_response_files: [File.basename(file)]
       logout_step if do_logout
     end

--- a/spec/support/features/steps/cases/approval_steps.rb
+++ b/spec/support/features/steps/cases/approval_steps.rb
@@ -9,7 +9,8 @@ def approve_case_step(kase:, expected_team:, expected_status:)
   end
 
   approve_response_interstitial_page.clear_response_button.click
-  expect(open_cases_page).to be_displayed
+  expect(cases_show_page).to be_displayed(id: kase.id)
+  open_cases_page.load
   case_row = open_cases_page.case_list.detect{ |r| r.number.text == "Link to case #{kase.number}" }
   expect(case_row.who_its_with.text).to eq expected_team.name
   expect(case_row.status.text).to eq expected_status
@@ -26,7 +27,8 @@ def approve_case_with_bypass(kase:, expected_team:, expected_status:)
   approve_response_interstitial_page.bypass_press_option.bypass_reason_text.set 'No Presss office approval required'
   approve_response_interstitial_page.clear_response_button.click
 
-  expect(open_cases_page).to be_displayed
+  expect(cases_show_page).to be_displayed(id: kase.id)
+  open_cases_page.load
   case_row = open_cases_page.case_list.detect{ |r| r.number.text == "Link to case #{kase.number}" }
   expect(case_row.who_its_with.text).to eq expected_team.name
   expect(case_row.status.text).to eq expected_status
@@ -53,10 +55,10 @@ def approve_response(kase:)
     .to have_text "You have cleared case #{kase.number} - #{kase.subject}"
 end
 
-def execute_request_amends(kase:)
+def execute_request_amends
   request_amends_page.submit_button.click
-  expect(open_cases_page).to be_displayed
-  expect(open_cases_page.notices.first)
-    .to have_text "You have requested amends to case #{kase.number} - #{kase.subject}"
+  expect(cases_show_page).to be_displayed
+  expect(cases_show_page.notice)
+    .to have_text 'You have requested amends to this case\'s response.'
 end
 

--- a/spec/support/features/steps/cases/responding_steps.rb
+++ b/spec/support/features/steps/cases/responding_steps.rb
@@ -5,8 +5,8 @@ def upload_response_step(file: UPLOAD_RESPONSE_DOCX_FIXTURE)
   cases_show_page.actions.upload_response.click
   cases_new_response_upload_page.drop_in_dropzone(file)
   cases_new_response_upload_page.upload_response_button.click
-  expect(open_cases_page).to be_displayed
-  expect(open_cases_page.notices.first.heading)
+  expect(cases_show_page).to be_displayed
+  expect(cases_show_page.notice)
     .to have_text 'You have uploaded the response for this case.'
 end
 

--- a/spec/support/features/steps/cases/viewing_steps.rb
+++ b/spec/support/features/steps/cases/viewing_steps.rb
@@ -1,12 +1,17 @@
+# rubocop:disable Metrics/ParameterLists
 def go_to_case_details_step(kase:,
                             page: nil,
                             expected_response_files: nil,
                             expected_team: nil,
-                            expected_history: nil)
-  page ||= cases_page
-  page.click_on kase.number
+                            expected_history: nil,
+                            find_details_page: true)
+  if find_details_page
+    page ||= cases_page
+    page.click_on kase.number
+  end
+
   expect(cases_show_page.displayed? || assignments_edit_page.displayed?)
-    .to be_truthy
+      .to be_truthy
 
   if expected_response_files.present?
     expected_response_files.each do |file|
@@ -27,6 +32,7 @@ def go_to_case_details_step(kase:,
     end
   end
 end
+# rubocop:enable Metrics/ParameterLists
 
 def go_to_incoming_cases_step expect_not_to_see_cases: []
   cases_page.primary_navigation.new_cases.click


### PR DESCRIPTION
At the moment there is an inconsistent behaviour after a user takes an
action on a case, sometimes they are taken back to the case details page
and some times they are taken back to the case list page. In general
all actions should redirect the user back the the case details page.
After this commit the only time the user will be redirected to the case
list page is if the case has been deleted.

THe following journeys were affected

- BMT reassigns a case to another team
- Disclosure/Press/Private Office approve a cases response.
- Kilo uploads a response to a non-trigger case.
- Disclosure/Press/Private Office requests amendments to the response
  before clearing.
- Disclosure unflags a trigger case.