### PR TITLE
CT-1553 sar deadline calculation

### DIFF
--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -468,10 +468,10 @@ class Case::Base < ApplicationRecord
   end
 
   def deadline_calculator
-    case correspondence_type.time_limit_type
-    when 'business_days' then DeadlineCalculator::BusinessDays.new(self)
-    when 'calendar_days' then DeadlineCalculator::CalendarDays.new(self)
-    end
+    klass = DeadlineCalculator.const_get(
+      correspondence_type.deadline_calculator_class
+    )
+    klass.new(self)
   end
 
   private

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -467,6 +467,13 @@ class Case::Base < ApplicationRecord
     type_abbreviation == 'SAR'
   end
 
+  def deadline_calculator
+    case correspondence_type.time_limit_type
+    when 'business_days' then DeadlineCalculator::BusinessDays.new(self)
+    when 'calendar_days' then DeadlineCalculator::CalendarDays.new(self)
+    end
+  end
+
   private
   # determines whether or not the BU responded to flagged cases in time (NOT
   # whether the case was responded to in time!) calculated as the time between
@@ -482,7 +489,7 @@ class Case::Base < ApplicationRecord
       acting_team_id: default_clearance_team.id
     ).last.created_at.to_date
 
-    internal_deadline = DeadlineCalculator.internal_deadline_for_date(
+    internal_deadline = deadline_calculator.internal_deadline_for_date(
       correspondence_type, responding_team_acceptance_date
     )
 
@@ -520,15 +527,15 @@ class Case::Base < ApplicationRecord
   end
 
   def set_deadlines
-    self.escalation_deadline = DeadlineCalculator.escalation_deadline(self)
-    self.internal_deadline = DeadlineCalculator.internal_deadline(self)
-    self.external_deadline = DeadlineCalculator.external_deadline(self)
+    self.escalation_deadline = deadline_calculator.escalation_deadline
+    self.internal_deadline = deadline_calculator.internal_deadline
+    self.external_deadline = deadline_calculator.external_deadline
   end
 
   def update_deadlines
     if changed.include?('received_date')  && !extended_for_pit?
-      self.internal_deadline = DeadlineCalculator.internal_deadline(self)
-      self.external_deadline = DeadlineCalculator.external_deadline(self)
+      self.internal_deadline = deadline_calculator.internal_deadline
+      self.external_deadline = deadline_calculator.external_deadline
     end
   end
 

--- a/app/models/correspondence_type.rb
+++ b/app/models/correspondence_type.rb
@@ -15,10 +15,21 @@ class CorrespondenceType < ApplicationRecord
   jsonb_accessor :properties,
                  internal_time_limit: :integer,
                  external_time_limit: :integer,
-                 escalation_time_limit: :integer
+                 escalation_time_limit: :integer,
+                 time_limit_type: :string
 
-  validates :name, :abbreviation, :escalation_time_limit, :internal_time_limit,
-    :external_time_limit, presence: true, on: :create
+  enum time_limit_type: {
+         business_days: 'business_days',
+         calendar_days: 'calendar_days'
+       }
+
+  validates_presence_of :name,
+                        :abbreviation,
+                        :escalation_time_limit,
+                        :internal_time_limit,
+                        :external_time_limit,
+                        :time_limit_type,
+                        on: :create
 
   has_many :cases,
            class_name: 'Case::Base'

--- a/app/models/correspondence_type.rb
+++ b/app/models/correspondence_type.rb
@@ -16,11 +16,11 @@ class CorrespondenceType < ApplicationRecord
                  internal_time_limit: :integer,
                  external_time_limit: :integer,
                  escalation_time_limit: :integer,
-                 time_limit_type: :string
+                 deadline_calculator_class: :string
 
-  enum time_limit_type: {
-         business_days: 'business_days',
-         calendar_days: 'calendar_days'
+  enum deadline_calculator_class: {
+         'BusinessDays' => 'BusinessDays',
+         'CalendarDays' => 'CalendarDays',
        }
 
   validates_presence_of :name,
@@ -28,7 +28,7 @@ class CorrespondenceType < ApplicationRecord
                         :escalation_time_limit,
                         :internal_time_limit,
                         :external_time_limit,
-                        :time_limit_type,
+                        :deadline_calculator_class,
                         on: :create
 
   has_many :cases,

--- a/app/services/deadline_calculator/business_days.rb
+++ b/app/services/deadline_calculator/business_days.rb
@@ -1,13 +1,17 @@
-class DeadlineCalculator
+module DeadlineCalculator
+  class BusinessDays
+    attr_reader :kase
 
-  class << self
+    def initialize(kase)
+      @kase = kase
+    end
 
-    def escalation_deadline(kase, start_from=kase.created_at.to_date)
+    def escalation_deadline(start_from=kase.created_at.to_date)
       days_after_day_one = kase.correspondence_type.escalation_time_limit - 1
       days_after_day_one.business_days.after(start_date(start_from))
     end
 
-    def internal_deadline(kase)      # aka draft deadline
+    def internal_deadline      # aka draft deadline
       internal_deadline_for_date(kase.correspondence_type,
                                  start_date(kase.received_date))
     end
@@ -17,10 +21,12 @@ class DeadlineCalculator
       days_after_day_one.business_days.after(date)
     end
 
-    def external_deadline(kase)
+    def external_deadline
       days_after_day_one = kase.correspondence_type.external_time_limit - 1
       days_after_day_one.business_days.after(start_date(kase.received_date))
     end
+
+    private
 
     def start_date(received_date)
       date = received_date + 1
@@ -28,6 +34,4 @@ class DeadlineCalculator
       date
     end
   end
-
-  private_class_method :start_date
 end

--- a/app/services/deadline_calculator/calendar_days.rb
+++ b/app/services/deadline_calculator/calendar_days.rb
@@ -1,0 +1,31 @@
+module DeadlineCalculator
+  class CalendarDays
+
+    attr_reader :kase
+
+    def initialize(kase)
+      @kase = kase
+    end
+
+    def escalation_deadline
+      calculate_days_from kase.correspondence_type.escalation_time_limit.days,
+                          kase.created_at.to_date
+    end
+
+    def internal_deadline     # aka draft deadline
+      calculate_days_from kase.correspondence_type.internal_time_limit.days,
+                          kase.received_date
+    end
+
+    def external_deadline
+      calculate_days_from kase.correspondence_type.external_time_limit.days,
+                          kase.received_date
+    end
+
+    private
+
+    def calculate_days_from(days, start_date)
+      days.since start_date
+    end
+  end
+end

--- a/app/services/request_further_clearance_service.rb
+++ b/app/services/request_further_clearance_service.rb
@@ -34,7 +34,7 @@ class RequestFurtherClearanceService
 
       # update the escalation deadline to the new clearance deadline
       # Enabled press/private to view this case in their Case list
-      @kase.update( escalation_deadline: DeadlineCalculator.escalation_deadline(@kase, Date.today))
+      @kase.update( escalation_deadline: @kase.deadline_calculator.escalation_deadline(Date.today))
 
       @result = :ok
     end

--- a/db/migrate/20180208161547_add_time_limit_type_to_correspondence_types.rb
+++ b/db/migrate/20180208161547_add_time_limit_type_to_correspondence_types.rb
@@ -1,11 +1,11 @@
 class AddTimeLimitTypeToCorrespondenceTypes < ActiveRecord::Migration[5.0]
   def up
     CorrespondenceType.find_by(abbreviation: 'FOI')
-                      &.update time_limit_type: 'business_days'
+                      &.update deadline_calculator_class: 'BusinessDays'
     CorrespondenceType.find_by(abbreviation: 'GQ')
-                      &.update time_limit_type: 'business_days'
+                      &.update deadline_calculator_class: 'BusinessDays'
     CorrespondenceType.find_by(abbreviation: 'SAR')
-                      &.update time_limit_type: 'calendar_days',
+                      &.update deadline_calculator_class: 'CalendarDays',
                                external_time_limit: 40
   end
 

--- a/db/migrate/20180208161547_add_time_limit_type_to_correspondence_types.rb
+++ b/db/migrate/20180208161547_add_time_limit_type_to_correspondence_types.rb
@@ -1,0 +1,14 @@
+class AddTimeLimitTypeToCorrespondenceTypes < ActiveRecord::Migration[5.0]
+  def up
+    CorrespondenceType.find_by(abbreviation: 'FOI')
+                      &.update time_limit_type: 'business_days'
+    CorrespondenceType.find_by(abbreviation: 'GQ')
+                      &.update time_limit_type: 'business_days'
+    CorrespondenceType.find_by(abbreviation: 'SAR')
+                      &.update time_limit_type: 'calendar_days',
+                               external_time_limit: 40
+  end
+
+  def down
+  end
+end

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -7,18 +7,18 @@ class CorrespondenceTypeSeeder
                                           escalation_time_limit: 3,
                                           internal_time_limit: 10,
                                           external_time_limit: 20,
-                                          time_limit_type: 'business_days'
+                                          deadline_calculator_class: 'BusinessDays'
     CorrespondenceType.find_or_create_by! name: 'General enquiry',
                                           abbreviation: 'GQ',
                                           escalation_time_limit: 0,
                                           internal_time_limit: 10,
                                           external_time_limit: 15,
-                                          time_limit_type: 'business_days'
+                                          deadline_calculator_class: 'BusinessDays'
     CorrespondenceType.find_or_create_by! name: 'Subject Access Request',
                                           abbreviation: 'SAR',
                                           escalation_time_limit: 0,
                                           internal_time_limit: 10,
                                           external_time_limit: 40,
-                                          time_limit_type: 'calendar_days'
+                                          deadline_calculator_class: 'CalendarDays'
   end
 end

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -8,12 +8,6 @@ class CorrespondenceTypeSeeder
                                           internal_time_limit: 10,
                                           external_time_limit: 20,
                                           deadline_calculator_class: 'BusinessDays'
-    CorrespondenceType.find_or_create_by! name: 'General enquiry',
-                                          abbreviation: 'GQ',
-                                          escalation_time_limit: 0,
-                                          internal_time_limit: 10,
-                                          external_time_limit: 15,
-                                          deadline_calculator_class: 'BusinessDays'
     CorrespondenceType.find_or_create_by! name: 'Subject Access Request',
                                           abbreviation: 'SAR',
                                           escalation_time_limit: 0,

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -6,16 +6,19 @@ class CorrespondenceTypeSeeder
                                           abbreviation: 'FOI',
                                           escalation_time_limit: 3,
                                           internal_time_limit: 10,
-                                          external_time_limit: 20
+                                          external_time_limit: 20,
+                                          time_limit_type: 'business_days'
     CorrespondenceType.find_or_create_by! name: 'General enquiry',
                                           abbreviation: 'GQ',
                                           escalation_time_limit: 0,
                                           internal_time_limit: 10,
-                                          external_time_limit: 15
+                                          external_time_limit: 15,
+                                          time_limit_type: 'business_days'
     CorrespondenceType.find_or_create_by! name: 'Subject Access Request',
                                           abbreviation: 'SAR',
                                           escalation_time_limit: 0,
                                           internal_time_limit: 10,
-                                          external_time_limit: 15
+                                          external_time_limit: 40,
+                                          time_limit_type: 'calendar_days'
   end
 end

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -21,9 +21,9 @@ end
 
 def update_dates(kase, date)
   kase.created_at = kase.received_date = date
-  kase.escalation_deadline = DeadlineCalculator.escalation_deadline(kase)
-  kase.internal_deadline = DeadlineCalculator.internal_deadline(kase)
-  kase.external_deadline = DeadlineCalculator.external_deadline(kase)
+  kase.escalation_deadline = kase.deadline_calculator.escalation_deadline
+  kase.internal_deadline = kase.deadline_calculator.internal_deadline
+  kase.external_deadline = kase.deadline_calculator.external_deadline
   kase.save!
 end
 

--- a/lib/tasks/sar.rake
+++ b/lib/tasks/sar.rake
@@ -32,7 +32,7 @@ namespace :sar do
           internal_time_limit: 10,
           external_time_limit: 40,
           escalation_time_limit: 0,
-          time_limit_type: 'calendar_days'
+          deadline_calculator_class: 'CalendarDays'
       )
     else
       CorrespondenceType.sar

--- a/spec/factories/correspondence_types.rb
+++ b/spec/factories/correspondence_types.rb
@@ -18,7 +18,7 @@ FactoryGirl.define do
     escalation_time_limit 3
     internal_time_limit 10
     external_time_limit 20
-    time_limit_type 'business_days'
+    deadline_calculator_class 'BusinessDays'
 
     initialize_with { CorrespondenceType.find_or_create_by(name: name) }
   end
@@ -29,7 +29,8 @@ FactoryGirl.define do
     escalation_time_limit 3
     internal_time_limit 10
     external_time_limit 40
-    time_limit_type 'calendar_days'
+    deadline_calculator_class 'CalendarDays'
+
 
     initialize_with { CorrespondenceType.find_or_create_by(name: name) }
   end
@@ -39,16 +40,16 @@ FactoryGirl.define do
     abbreviation "GQ"
     escalation_time_limit 0
     external_time_limit 15
-    time_limit_type :business_days
+    deadline_calculator_class 'BusinessDays'
 
     initialize_with { CorrespondenceType.find_or_create_by(name: name) }
   end
 
   trait :business_days do
-    time_limit_type :business_days
+    deadline_calculator_class 'BusinessDays'
   end
 
   trait :calendar_days do
-    time_limit_type :calendar_days
+    deadline_calculator_class 'CalendarDays'
   end
 end

--- a/spec/factories/correspondence_types.rb
+++ b/spec/factories/correspondence_types.rb
@@ -18,6 +18,7 @@ FactoryGirl.define do
     escalation_time_limit 3
     internal_time_limit 10
     external_time_limit 20
+    time_limit_type 'business_days'
 
     initialize_with { CorrespondenceType.find_or_create_by(name: name) }
   end
@@ -27,7 +28,8 @@ FactoryGirl.define do
     abbreviation 'SAR'
     escalation_time_limit 3
     internal_time_limit 10
-    external_time_limit 20
+    external_time_limit 40
+    time_limit_type 'calendar_days'
 
     initialize_with { CorrespondenceType.find_or_create_by(name: name) }
   end
@@ -37,7 +39,16 @@ FactoryGirl.define do
     abbreviation "GQ"
     escalation_time_limit 0
     external_time_limit 15
+    time_limit_type :business_days
 
     initialize_with { CorrespondenceType.find_or_create_by(name: name) }
+  end
+
+  trait :business_days do
+    time_limit_type :business_days
+  end
+
+  trait :calendar_days do
+    time_limit_type :calendar_days
   end
 end

--- a/spec/features/cases/foi/case_viewing/viewing_spec.rb
+++ b/spec/features/cases/foi/case_viewing/viewing_spec.rb
@@ -6,13 +6,6 @@ feature 'viewing details of case in the system' do
   given(:responder) { create :responder }
   given(:responding_team) { responder.responding_teams.first }
 
-  given(:internal_gq_deadline) do
-    DeadlineCalculator.internal_deadline(gq).strftime(Settings.default_date_format)
-  end
-  given(:external_gq_deadline) do
-    DeadlineCalculator.external_deadline(gq).strftime(Settings.default_date_format)
-  end
-
   background do
     login_as responder
   end
@@ -65,10 +58,14 @@ feature 'viewing details of case in the system' do
     foi.received_date.strftime(Settings.default_date_format)
   end
   given(:foi_escalation_deadline) do
-    DeadlineCalculator.escalation_deadline(foi).strftime(Settings.default_date_format)
+    foi.deadline_calculator
+      .escalation_deadline
+      .strftime(Settings.default_date_format)
   end
   given(:external_foi_deadline) do
-    DeadlineCalculator.external_deadline(foi).strftime(Settings.default_date_format)
+    foi.deadline_calculator
+      .external_deadline
+      .strftime(Settings.default_date_format)
   end
 
 

--- a/spec/features/cases/sar/case_creating/creating_spec.rb
+++ b/spec/features/cases/sar/case_creating/creating_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+feature 'SAR Case creation by a manager' do
+
+  given(:responder)       { create(:responder) }
+  given(:responding_team) { create :responding_team, responders: [responder] }
+  given(:manager)         { create :disclosure_bmt_user }
+  given(:managing_team)   { create :managing_team, managers: [manager] }
+
+  background do
+    responding_team
+    find_or_create :team_dacu_disclosure
+    login_as manager
+    cases_page.load
+  end
+
+  scenario 'creating a case that does not need clearance', js: true do
+    create_sar_case_step
+
+    assign_case_step business_unit: responder.responding_teams.first
+
+  end
+
+  # scenario 'creating a case with request attachments', js: true  do
+  #   stub_s3_uploader_for_all_files!
+  #   request_attachment = Rails.root.join('spec', 'fixtures', 'request-1.pdf')
+
+  #   create_sar_case_step uploaded_request_files: [request_attachment]
+
+  #   new_case = Case::Base.last
+  #   request_attachment = new_case.attachments.request.first
+  #   expect(request_attachment.key).to match %{/request-1.pdf$}
+  # end
+end

--- a/spec/models/correspondence_type_spec.rb
+++ b/spec/models/correspondence_type_spec.rb
@@ -19,4 +19,38 @@ describe CorrespondenceType, type: :model do
   it { should validate_presence_of(:escalation_time_limit) }
   it { should validate_presence_of(:internal_time_limit) }
   it { should validate_presence_of(:external_time_limit) }
+
+  describe 'deadline_calculator_class' do
+    it { should validate_presence_of(:deadline_calculator_class) }
+    it 'allows the value CalendarDays' do
+      ct = CorrespondenceType.new name: 'Calendar Days Test',
+                                  abbreviation: 'CDT',
+                                  escalation_time_limit: 1,
+                                  internal_time_limit: 1,
+                                  external_time_limit: 1,
+                                  deadline_calculator_class: 'CalendarDays'
+      expect(ct).to be_valid
+    end
+
+    it 'allows the value BusinessDays' do
+      ct = CorrespondenceType.new name: 'Business Days Test',
+                                  abbreviation: 'BDT',
+                                  escalation_time_limit: 1,
+                                  internal_time_limit: 1,
+                                  external_time_limit: 1,
+                                  deadline_calculator_class: 'BusinessDays'
+      expect(ct).to be_valid
+    end
+
+    it 'does not allow other values' do
+      expect {
+        CorrespondenceType.new name: 'Invalid Class Test',
+                               abbreviation: 'IDT',
+                               escalation_time_limit: 1,
+                               internal_time_limit: 1,
+                               external_time_limit: 1,
+                               deadline_calculator_class: 'Invalid Class'
+      }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/services/deadline_calculator/business_days_spec.rb
+++ b/spec/services/deadline_calculator/business_days_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe DeadlineCalculator do
+describe DeadlineCalculator::BusinessDays do
 
   context 'FOI requests' do
 
@@ -8,6 +8,7 @@ describe DeadlineCalculator do
                            received_date: Date.today,
                            created_at: Date.today
     }
+    let(:deadline_calculator) { described_class.new foi_case }
 
     context 'received on a workday' do
       let(:thu_may_18) { Time.utc(2017, 5, 18, 12, 0, 0) }
@@ -18,7 +19,8 @@ describe DeadlineCalculator do
       describe '.escalation_deadline' do
         it 'is 3 days after created date' do
           Timecop.freeze thu_may_18 do
-            expect(DeadlineCalculator.escalation_deadline(foi_case)).to eq tue_may_23.to_date
+            expect(deadline_calculator.escalation_deadline)
+              .to eq tue_may_23.to_date
           end
         end
       end
@@ -26,7 +28,8 @@ describe DeadlineCalculator do
       describe '.external_deadline' do
         it 'is 20 working days after received_date - not counting bank holiday Mon May 29' do
           Timecop.freeze thu_may_18 do
-            expect(DeadlineCalculator.external_deadline(foi_case)).to eq fri_jun_16.to_date
+            expect(deadline_calculator.external_deadline)
+              .to eq fri_jun_16.to_date
           end
         end
       end
@@ -34,7 +37,8 @@ describe DeadlineCalculator do
       describe '.internal_deadline' do
         it 'is 10 working days after received_date - not counting bank holiday Mon May 29' do
           Timecop.freeze thu_may_18 do
-            expect(DeadlineCalculator.internal_deadline(foi_case)).to eq fri_jun_02.to_date
+            expect(deadline_calculator.internal_deadline)
+              .to eq fri_jun_02.to_date
           end
         end
       end
@@ -50,7 +54,8 @@ describe DeadlineCalculator do
       describe '.escalation_deadline' do
         it 'is 6 days after first working day after received date' do
           Timecop.freeze sat_jul_01 do
-            expect(DeadlineCalculator.escalation_deadline(foi_case)).to eq wed_jul_05.to_date
+            expect(deadline_calculator.escalation_deadline)
+              .to eq wed_jul_05.to_date
           end
         end
       end
@@ -58,7 +63,8 @@ describe DeadlineCalculator do
       describe '.external_deadline' do
         it 'is 20 working days first working day after received date' do
           Timecop.freeze sat_jul_01 do
-            expect(DeadlineCalculator.external_deadline(foi_case)).to eq fri_jul_28.to_date
+            expect(deadline_calculator.external_deadline)
+              .to eq fri_jul_28.to_date
           end
         end
       end
@@ -66,7 +72,8 @@ describe DeadlineCalculator do
       describe '.internal_deadline' do
         it 'is 10 working days first working day after received date' do
           Timecop.freeze sat_jul_01 do
-            expect(DeadlineCalculator.internal_deadline(foi_case)).to eq fri_jul_14.to_date
+            expect(deadline_calculator.internal_deadline)
+              .to eq fri_jul_14.to_date
           end
         end
       end
@@ -77,7 +84,8 @@ describe DeadlineCalculator do
       let(:tue_may_23) { Time.utc(2017, 5, 23, 12, 0, 0) }
 
       it 'accepts an optional date param' do
-        expect(DeadlineCalculator.escalation_deadline(foi_case, thu_may_18.to_date)).to eq tue_may_23.to_date
+        expect(deadline_calculator.escalation_deadline(thu_may_18.to_date))
+          .to eq tue_may_23.to_date
       end
     end
   end

--- a/spec/services/deadline_calculator/calendar_days_spec.rb
+++ b/spec/services/deadline_calculator/calendar_days_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe DeadlineCalculator::CalendarDays do
+  let(:sar)                 { find_or_create :sar_correspondence_type }
+  let(:sar_case)            { create :sar_case }
+  let(:deadline_calculator) { described_class.new sar_case }
+
+  context 'SAR case' do
+    describe 'escalation deadline' do
+      it 'is 3 calendar days after the date of creation' do
+        expect(deadline_calculator.escalation_deadline)
+          .to eq 3.days.since(sar_case.created_at.to_date)
+      end
+    end
+
+    describe 'internal deadline' do
+      it 'is 10 calendar days after the date received' do
+        expect(deadline_calculator.internal_deadline)
+          .to eq 10.days.since(sar_case.received_date)
+      end
+    end
+
+    describe 'external deadline' do
+      it 'is 40 calendar days after the date received' do
+        expect(deadline_calculator.external_deadline)
+          .to eq 40.days.since(sar_case.received_date)
+      end
+    end
+  end
+end


### PR DESCRIPTION
SAR cases have their external deadlines calculated using calendar days instead
of business days as FOI cases do. As we could only parameterise on the number of
days up until now, this change adds a new kind of deadline calculator to handle
calendar days, and refactors the deadline calculators to accomodate this.