### PR TITLE
CT-1307 Allow users to remove links between cases

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -6,7 +6,8 @@ class CasesController < ApplicationController
                   :extend_for_pit,
                   :execute_extend_for_pit,
                   :execute_new_case_link,
-                  :new_case_link
+                  :new_case_link,
+                  :destroy_case_link
                 ]
   # As per the Draper documentation, we really shouldn't be decorating @case at
   # the beginning of controller actions (see:
@@ -439,6 +440,24 @@ class CasesController < ApplicationController
     end
   end
 
+  def destroy_case_link
+    authorize @case, :new_case_link?
+
+    linked_case_number = params[:linked_case_number]
+
+    service = CaseLinkingService.new current_user, @case, linked_case_number
+
+    result = service.destroy
+
+    if result == :ok
+      flash[:notice] = "The link to case #{linked_case_number} has been removed."
+      redirect_to case_path(@case)
+    else
+      flash[:alert] = "Unable to remove the link to case #{linked_case_number}"
+      redirect_to case_path(@case)
+    end
+  end
+
   private
 
   def prepare_select_type
@@ -479,7 +498,7 @@ class CasesController < ApplicationController
   def set_permitted_events
     @permitted_events = @case.state_machine.permitted_events(current_user.id)
     @permitted_events ||= []
-    @filtered_permitted_events = @permitted_events - [:extend_for_pit, :request_further_clearance, :link_a_case]
+    @filtered_permitted_events = @permitted_events - [:extend_for_pit, :request_further_clearance, :link_a_case, :remove_linked_case]
   end
 
   def process_closure_params(correspondence_type)

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -423,7 +423,7 @@ class CasesController < ApplicationController
 
     service = CaseLinkingService.new current_user, @case, link_case_number
 
-    result = service.call
+    result = service.create
 
 
     if result == :ok

--- a/app/decorators/case/base_decorator.rb
+++ b/app/decorators/case/base_decorator.rb
@@ -1,5 +1,6 @@
 class Case::BaseDecorator < Draper::Decorator
   delegate_all
+  decorates_association :linked_cases
 
   # if the case is with a responding team and the current user is a responder
   # in that team, display the name of the specific user it's with instead of

--- a/app/decorators/case_transition_decorator.rb
+++ b/app/decorators/case_transition_decorator.rb
@@ -31,6 +31,8 @@ class CaseTransitionDecorator < Draper::Decorator
     case object.event
     when 'assign_responder'
       "Assigned to #{object.target_team.name}"
+    when 'remove_linked_case'
+      "Removed the link to <strong>#{Case::Base.find(object.linked_case_id).number}</strong>"
     when 'add_responses',
          'add_response_to_flagged_case',
          'approve_and_bypass',

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -169,6 +169,14 @@ module CasesHelper
             id: 'action--link-a-case'
   end
 
+  def action_link_for_destroy_case_link(kase, linked_case)
+    link_to t('common.case.remove_linked_case_html', case_number: linked_case.number),
+            destroy_link_on_case_path(id: kase.id,
+                                      linked_case_number: linked_case.number),
+            data: { confirm: "Are you sure?" },
+            method: :delete
+  end
+
   def request_details_html(kase)
     content_tag(:strong, "#{kase.subject} ", class: 'strong') +
         content_tag(:div, kase.name, class: 'case-name-detail')

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -449,6 +449,16 @@ class Case::Base < ApplicationRecord
     end
   end
 
+  def remove_linked_case(linked_case)
+    ActiveRecord::Base.transaction do
+
+      self.linked_cases.destroy(linked_case)
+
+      linked_case.linked_cases.destroy(self)
+
+    end
+  end
+
   def is_internal_review?
     self.is_a?(Case::FOI::InternalReview)
   end

--- a/app/services/case_linking_service.rb
+++ b/app/services/case_linking_service.rb
@@ -34,6 +34,34 @@ class CaseLinkingService
     @result = :error
   end
 
+  def destroy
+    ActiveRecord::Base.transaction do
+      # find the linked case
+      @link_case = Case::Base.where(number: @link_case_number).first
+
+      # Destroy the links
+      @case.remove_linked_case(@link_case)
+
+      # Log event in both cases
+      @case.state_machine.remove_linked_case!(acting_user: @user,
+                                       acting_team: @user.teams_for_case(@case).first,
+                                       linked_case_id: @link_case.id)
+      @link_case.state_machine.remove_linked_case!(acting_user: @user,
+                                            acting_team: @user.teams_for_case(@case).first,
+                                            linked_case_id: @case.id)
+
+      @result = :ok
+
+    end
+
+    @result
+  rescue => err
+    Rails.logger.error err.to_s
+    Rails.logger.error err.backtrace.join("\n\t")
+    @error = err
+    @result = :error
+  end
+
   private
 
   def validate_params

--- a/app/services/case_linking_service.rb
+++ b/app/services/case_linking_service.rb
@@ -37,7 +37,7 @@ class CaseLinkingService
   def destroy
     ActiveRecord::Base.transaction do
       # find the linked case
-      @link_case = Case::Base.where(number: @link_case_number).first
+      @link_case = @case.linked_cases.find_by(number: @link_case_number).first
 
       # Destroy the links
       @case.remove_linked_case(@link_case)

--- a/app/services/case_linking_service.rb
+++ b/app/services/case_linking_service.rb
@@ -9,7 +9,7 @@ class CaseLinkingService
     @result = :incomplete
   end
 
-  def call
+  def create
     if validate_params
       ActiveRecord::Base.transaction do
 

--- a/app/services/case_linking_service.rb
+++ b/app/services/case_linking_service.rb
@@ -37,7 +37,7 @@ class CaseLinkingService
   def destroy
     ActiveRecord::Base.transaction do
       # find the linked case
-      @link_case = @case.linked_cases.find_by(number: @link_case_number).first
+      @link_case = @case.linked_cases.find_by(number: @link_case_number)
 
       # Destroy the links
       @case.remove_linked_case(@link_case)

--- a/app/state_machines/case/foi/standard_state_machine.rb
+++ b/app/state_machines/case/foi/standard_state_machine.rb
@@ -306,6 +306,18 @@ class Case::FOI::StandardStateMachine
     transition from: :closed,                           to: :closed
   end
 
+  event :remove_linked_case do
+    transition from: :unassigned,                       to: :unassigned
+    transition from: :awaiting_responder,               to: :awaiting_responder
+    transition from: :drafting,                         to: :drafting
+    transition from: :awaiting_dispatch,                to: :awaiting_dispatch
+    transition from: :pending_dacu_clearance,           to: :pending_dacu_clearance
+    transition from: :pending_press_office_clearance,   to: :pending_press_office_clearance
+    transition from: :pending_private_office_clearance, to: :pending_private_office_clearance
+    transition from: :responded,                        to: :responded
+    transition from: :closed,                           to: :closed
+  end
+
   def accept_approver_assignment!(acting_user:, acting_team:)
     trigger! :accept_approver_assignment,
              acting_team_id:    acting_team.id,
@@ -544,6 +556,14 @@ class Case::FOI::StandardStateMachine
              acting_team_id: acting_team.id,
              linked_case_id: linked_case_id,
              event:          :link_a_case
+  end
+
+  def remove_linked_case!(acting_user:, acting_team:, linked_case_id:)
+    trigger! :remove_linked_case,
+             acting_user_id: acting_user.id,
+             acting_team_id: acting_team.id,
+             linked_case_id: linked_case_id,
+             event:          :remove_linked_case
   end
 
   private

--- a/app/views/cases/_linked_cases.html.slim
+++ b/app/views/cases/_linked_cases.html.slim
@@ -12,6 +12,8 @@
             = 'Case type'
           th
             = 'Request'
+          th
+            = "Action"
       tbody
         - if case_details.linked_cases.any?
           - case_details.linked_cases.each do |linked_case|
@@ -22,13 +24,15 @@
                     = t('common.view_case')
                   = linked_case.number
               td
-                = "FOI "
-                = case_details.trigger_case_marker
+                = "#{linked_case.pretty_type} "
+                = linked_case.trigger_case_marker
               td
                 = request_details_html(linked_case)
+              td
+                = action_link_for_destroy_case_link(case_details, linked_case)
         - else
           tr
-            td colspan=3
+            td colspan=4
               = "No linked cases"
 
     = action_links_for_allowed_events(case_details, :new_case_link).join(' | ').html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -350,6 +350,8 @@ en:
       reassign_case: "Change team member"
       remove_link_html: |
         Remove <span class="visuallyhidden">file %{filename}</span>
+      remove_linked_case_html: |
+        Remove link<span class="visuallyhidden"> to %{case_number}</span>
       responding_team: Business unit
       responders:
         one: Information Officer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,6 +220,7 @@ Rails.application.routes.draw do
     patch :request_further_clearance, on: :member
     get :new_case_link, on: :member
     post :execute_new_case_link, on: :member
+    delete 'destroy_link/:linked_case_number' => 'cases#destroy_case_link' , on: :member, as: 'destroy_link_on'
 
     resources :assignments, except: :create  do
       patch 'accept_or_reject', on: :member

--- a/config/state_machine/moj.yml
+++ b/config/state_machine/moj.yml
@@ -55,6 +55,7 @@ case_types:
           - reassign_user
           - reject_responder_assignment
           - remove_last_response
+          - remove_linked_case
           - remove_response
           - request_amends
           - request_further_clearance
@@ -78,6 +79,7 @@ case_types:
                 edit_case:
                 flag_for_clearance:
                 link_a_case:
+                remove_linked_case:
                 unflag_for_clearance:
                   if: Case::FOI::StandardPolicy#unflag_for_clearance_from_unassigned_to_unassigned?
 
@@ -131,6 +133,7 @@ case_types:
                 destroy_case:
                 edit_case:
                 link_a_case:
+                remove_linked_case:
 
               awaiting_responder:
                 add_message_to_case:
@@ -139,6 +142,7 @@ case_types:
                 edit_case:
                 flag_for_clearance:
                 link_a_case:
+                remove_linked_case:
 
               drafting:
                 add_message_to_case:
@@ -146,11 +150,13 @@ case_types:
                 destroy_case:
                 edit_case:
                 link_a_case:
+                remove_linked_case:
 
               closed:
                 destroy_case:
                 edit_case:
                 link_a_case:
+                remove_linked_case:
 
           ########################### SAR :: STANDARD WORKFLOW :: RESPONDER ########################
           responder:

--- a/spec/controllers/cases_controller/destroy_case_link_spec.rb
+++ b/spec/controllers/cases_controller/destroy_case_link_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe CasesController, type: :controller do
+  describe 'DELETE destroy_case_link' do
+    let(:kase)      { create :case }
+    let(:link_case) { create :case }
+    let(:manager)  { find_or_create :disclosure_bmt_user }
+    let(:delete_params)       { { id: kase.id,
+                                 linked_case_number: link_case.number
+                                 }
+    }
+
+    let(:service) { double(CaseLinkingService, destroy: :ok) }
+
+    before do
+      allow(CaseLinkingService).to receive(:new).and_return(service)
+      sign_in manager
+    end
+
+    it 'authorizes' do
+      expect {
+        delete :destroy_case_link, params: delete_params
+      } .to require_permission(:new_case_link?)
+              .with_args(manager, kase)
+    end
+
+    it 'calls the CaseLinkingService destroy method' do
+      delete :destroy_case_link, params: delete_params
+      expect(CaseLinkingService)
+        .to have_received(:new).with(manager,
+                                     kase,
+                                     delete_params[:linked_case_number])
+
+      expect(service).to have_received(:destroy)
+    end
+
+    it 'notifies the user of the success' do
+      delete :destroy_case_link, params: delete_params
+      expect(flash[:notice])
+        .to eq "The link to case #{ link_case.number } has been removed."
+    end
+
+    context 'failed request' do
+      let(:service) { double(CaseLinkingService, destroy: :failed) }
+
+      it 'notifies the user of the failure' do
+        delete :destroy_case_link, params: delete_params
+        expect(flash[:alert])
+          .to eq "Unable to remove the link to case #{ link_case.number }"
+        expect(:result).to redirect_to(case_path(kase.id))
+      end
+    end
+
+  end
+end

--- a/spec/controllers/cases_controller/execute_new_link_spec.rb
+++ b/spec/controllers/cases_controller/execute_new_link_spec.rb
@@ -11,7 +11,7 @@ describe CasesController, type: :controller do
                                  }
     }}
 
-    let(:service) { double(CaseLinkingService, call: :ok) }
+    let(:service) { double(CaseLinkingService, create: :ok) }
 
     before do
       allow(CaseLinkingService).to receive(:new).and_return(service)
@@ -25,14 +25,14 @@ describe CasesController, type: :controller do
               .with_args(manager, kase)
     end
 
-    it 'calls the CaseLinkingService' do
+    it 'calls the CaseLinkingService create method' do
       post :execute_new_case_link, params: post_params
       expect(CaseLinkingService)
         .to have_received(:new).with(manager,
                                      kase,
                                      post_params[:case][:linked_case_number])
 
-      expect(service).to have_received(:call)
+      expect(service).to have_received(:create)
     end
 
     it 'notifies the user of the success' do
@@ -42,7 +42,7 @@ describe CasesController, type: :controller do
     end
 
     context 'validation error' do
-      let(:service) { double(CaseLinkingService, call: :validation_error) }
+      let(:service) { double(CaseLinkingService, create: :validation_error) }
 
       it 'renders the new_link page' do
         post :execute_new_case_link, params: post_params
@@ -51,7 +51,7 @@ describe CasesController, type: :controller do
     end
 
     context 'failed request' do
-      let(:service) { double(CaseLinkingService, call: :error) }
+      let(:service) { double(CaseLinkingService, create: :error) }
 
       it 'notifies the user of the failure' do
         post :execute_new_case_link, params: post_params

--- a/spec/controllers/cases_controller/show_spec.rb
+++ b/spec/controllers/cases_controller/show_spec.rb
@@ -149,6 +149,7 @@ describe CasesController, type: :controller do
                                                     :edit_case,
                                                     :flag_for_clearance,
                                                     :link_a_case,
+                                                    :remove_linked_case,
                                                     :request_further_clearance]
           expect(assigns(:filtered_permitted_events)).to eq [:add_message_to_case, :assign_to_new_team, :destroy_case, :edit_case, :flag_for_clearance]
         end
@@ -194,7 +195,7 @@ describe CasesController, type: :controller do
         let(:user) { another_responder }
 
         it 'permitted_events to be empty' do
-          expect(assigns(:permitted_events)).to match_array [:link_a_case, :request_further_clearance]
+          expect(assigns(:permitted_events)).to match_array [:link_a_case, :remove_linked_case, :request_further_clearance]
           expect(assigns(:filtered_permitted_events)).to be_empty
         end
 
@@ -260,7 +261,7 @@ describe CasesController, type: :controller do
         let(:user) { create(:responder) }
 
         it 'permitted_events to be empty' do
-          expect(assigns(:permitted_events)).to match_array [:extend_for_pit, :link_a_case, :request_further_clearance]
+          expect(assigns(:permitted_events)).to match_array [:extend_for_pit, :link_a_case, :remove_linked_case, :request_further_clearance]
           expect(assigns(:filtered_permitted_events)).to be_empty
         end
 
@@ -323,7 +324,7 @@ describe CasesController, type: :controller do
         let(:user) { create(:responder) }
 
         it 'permitted_events to be empty' do
-          expect(assigns(:permitted_events)).to match_array [:extend_for_pit, :link_a_case, :request_further_clearance]
+          expect(assigns(:permitted_events)).to match_array [:extend_for_pit, :link_a_case, :remove_linked_case, :request_further_clearance]
           expect(assigns(:filtered_permitted_events)).to be_empty
         end
 
@@ -371,7 +372,7 @@ describe CasesController, type: :controller do
         let(:user) { responder }
 
         it 'permitted_events to be empty' do
-          expect(assigns(:permitted_events)).to match_array [:extend_for_pit, :link_a_case]
+          expect(assigns(:permitted_events)).to match_array [:extend_for_pit, :link_a_case, :remove_linked_case]
           expect(assigns(:filtered_permitted_events)).to be_empty
         end
 
@@ -384,7 +385,7 @@ describe CasesController, type: :controller do
         let(:user) { create(:responder) }
 
         it 'permitted_events to be empty' do
-          expect(assigns(:permitted_events)).to match_array [:extend_for_pit, :link_a_case]
+          expect(assigns(:permitted_events)).to match_array [:extend_for_pit, :link_a_case, :remove_linked_case]
           expect(assigns(:filtered_permitted_events)).to be_empty
         end
 

--- a/spec/lib/permitted_event_expected_results.yml
+++ b/spec/lib/permitted_event_expected_results.yml
@@ -8,6 +8,7 @@
     - :edit_case
     - :flag_for_clearance
     - :link_a_case
+    - :remove_linked_case
 
 - - manager
   - flagged_unassigned_case
@@ -17,6 +18,7 @@
     - :edit_case
     - :flag_for_clearance
     - :link_a_case
+    - :remove_linked_case
     - :unflag_for_clearance
 
 - - manager
@@ -27,6 +29,7 @@
     - :edit_case
     - :flag_for_clearance                   # don't think this should be here, and no button is displayed for it.
     - :link_a_case
+    - :remove_linked_case
 
 - - manager
   - flagged_awaiting_responder_case
@@ -36,6 +39,7 @@
     - :edit_case
     - :flag_for_clearance                   # don't think this should be here, and no button is displayed for it.
     - :link_a_case
+    - :remove_linked_case
     - :unflag_for_clearance
 
 - - manager
@@ -47,6 +51,7 @@
     - :extend_for_pit
     - :flag_for_clearance                   # don't think this should be here, and no button is displayed for it.
     - :link_a_case
+    - :remove_linked_case
 
 - - manager
   - unflagged_case_with_response
@@ -56,6 +61,7 @@
     - :extend_for_pit
     - :flag_for_clearance                   # don't think this should be here, and no button is displayed for it.
     - :link_a_case
+    - :remove_linked_case
 
 - - manager
   - accepted_pending_dacu_clearance_case
@@ -64,6 +70,7 @@
     - :edit_case
     - :extend_for_pit
     - :link_a_case
+    - :remove_linked_case
     - :unflag_for_clearance                 # don't think this should be here, and no button is displayed for it.
 
 - - manager
@@ -73,6 +80,7 @@
     - :edit_case
     - :extend_for_pit
     - :link_a_case
+    - :remove_linked_case
     - :unflag_for_clearance                 # don't think this should be here, and no button is displayed for it.
 
 ##################################### UNASSIGNED RESPONDER #########################
@@ -80,10 +88,12 @@
 - - unassigned_responder
   - unflagged_awaiting_responder_case
   - - :link_a_case
+    - :remove_linked_case
 
 - - unassigned_responder
   - flagged_awaiting_responder_case
   - - :link_a_case
+    - :remove_linked_case
 
 - - unassigned_responder
   - unflagged_drafting_case
@@ -92,6 +102,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
 
 - - unassigned_responder
   - unaccepted_pending_dacu_clearance_case
@@ -99,6 +110,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
 
 - - unassigned_responder
   - accepted_pending_dacu_clearance_case
@@ -106,6 +118,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
 
 
 
@@ -118,6 +131,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
 
 - - assigned_responder
   - accepted_pending_dacu_clearance_case
@@ -125,6 +139,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
 
 
 
@@ -136,6 +151,7 @@
     - :add_message_to_case
     - :extend_for_pit
     - :link_a_case
+    - :remove_linked_case
     - :unflag_for_clearance                 # no button showing up for this
 
 - - unassigned_dacu_disclosure_specialist
@@ -144,6 +160,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
     - :unflag_for_clearance                 # what about take case on?
 
 
@@ -155,6 +172,7 @@
     - :add_message_to_case
     - :extend_for_pit
     - :link_a_case
+    - :remove_linked_case
     - :unflag_for_clearance                 # no button showing up for this
 
 - - assigned_dacu_disclosure_specialist
@@ -164,6 +182,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
     - :unaccept_approver_assignment
     - :unflag_for_clearance                   # no button showing up for this
     - :upload_response_and_approve
@@ -180,6 +199,7 @@
     - :edit_case
     - :extend_for_pit
     - :link_a_case
+    - :remove_linked_case
     - :unflag_for_clearance                 # no button showing up for this
 
 - - unassigned_dacu_disclosure_specialist_bmt
@@ -190,6 +210,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
     - :unflag_for_clearance                 # what about take case on?
 
 
@@ -203,6 +224,7 @@
     - :edit_case
     - :extend_for_pit
     - :link_a_case
+    - :remove_linked_case
     - :unflag_for_clearance                 # no button showing up for this
 
 - - assigned_dacu_disclosure_specialist_bmt
@@ -214,6 +236,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
     - :unaccept_approver_assignment
     - :unflag_for_clearance                   # no button showing up for this
     - :upload_response_and_approve
@@ -226,6 +249,7 @@
   - unflagged_case_within_escalation_period
   - - :flag_for_clearance                     # no button showing up for this (Thank God!)
     - :link_a_case
+    - :remove_linked_case
     - :take_on_for_approval                   # shows on /cases/incoming but not detail page
 
 - - unassigned_press_officer
@@ -234,6 +258,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
 
 
 
@@ -247,6 +272,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
     - :request_amends
 
 #################################### UNASSIGNED PRIVATE OFFICER #########################
@@ -255,6 +281,7 @@
   - unflagged_case_within_escalation_period
   - - :flag_for_clearance                     # no button showing up for this (Thank God!)
     - :link_a_case
+    - :remove_linked_case
     - :take_on_for_approval                   # shows on /cases/incoming but not detail page
 
 - - unassigned_private_officer
@@ -263,6 +290,7 @@
     - :extend_for_pit
     - :link_a_case
     - :reassign_user
+    - :remove_linked_case
 
 
 

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -1135,6 +1135,33 @@ RSpec.describe Case::Base, type: :model do
     end
   end
 
+
+  describe '#remove_linked_case' do
+    let(:kase_1) { create :case }
+    let(:kase_2) { create :case }
+
+    describe 'removes a link between two cases' do
+      before(:each) do
+        kase_1.linked_cases << kase_2
+        kase_2.linked_cases << kase_1
+      end
+
+      it 'removes two entries in the linked case table' do
+        kase_1.remove_linked_case(kase_2)
+        expect(kase_1.linked_cases).to be_empty
+        expect(kase_2.linked_cases).to be_empty
+      end
+
+      it 'does not fail if the links does not exist' do
+        kase_1.remove_linked_case(kase_2)
+        kase_2.remove_linked_case(kase_1)
+        expect(kase_1.linked_cases).to be_empty
+        expect(kase_2.linked_cases).to be_empty
+      end
+
+    end
+  end
+
   context 'updating deadlines after updates' do
     context 'received_date is updated' do
       context 'case has not been extended for pit' do

--- a/spec/services/case_linking_service_spec.rb
+++ b/spec/services/case_linking_service_spec.rb
@@ -37,11 +37,11 @@ describe CaseLinkingService do
 
   end
 
-  describe '#call' do
+  describe '#create' do
 
     context 'NON-SAR cases' do
 
-      before(:each)  { service.call }
+      before(:each)  { service.create }
 
       it 'creates a link to the linked case' do
         expect(kase.linked_cases).to eq [link_case]
@@ -52,7 +52,7 @@ describe CaseLinkingService do
       end
 
       it 'sets result to :ok and returns same' do
-        result = service.call
+        result = service.create
         expect(result).to eq :ok
         expect(service.result).to eq :ok
       end
@@ -84,7 +84,7 @@ describe CaseLinkingService do
       describe 'linking a sar case to a  non sar case' do
         it 'errors' do
           service = CaseLinkingService.new(manager, sar_case_1, foi_case.number)
-          service.call
+          service.create
           expect(service.result).to eq :validation_error
           expect(sar_case_1.errors[:linked_case_number]).to eq ["can't link a SAR case to a non-SAR case"]
         end
@@ -93,7 +93,7 @@ describe CaseLinkingService do
       describe 'linking a non-sar case to a sar case' do
         it 'errors' do
           service = CaseLinkingService.new(manager, foi_case, sar_case_1.number)
-          service.call
+          service.create
           expect(service.result).to eq :validation_error
           expect(foi_case.errors[:linked_case_number]).to eq ["can't link a non-SAR case to a SAR case"]
         end
@@ -102,7 +102,7 @@ describe CaseLinkingService do
       describe 'linking a non-sar case to a sar case' do
         it 'does not error' do
           service = CaseLinkingService.new(manager, sar_case_1, sar_case_2.number)
-          service.call
+          service.create
           expect(service.result).to eq :ok
           expect(sar_case_1).to be_valid
         end
@@ -119,13 +119,13 @@ describe CaseLinkingService do
                                         nil)}
 
       it 'sets result to validation error and returns same' do
-        result = service.call
+        result = service.create
         expect(result).to eq :validation_error
         expect(service.result).to eq :validation_error
       end
 
       it 'adds an error to the case' do
-        service.call
+        service.create
         expect(kase.errors[:linked_case_number])
           .to eq ["can't be blank"]
       end
@@ -137,13 +137,13 @@ describe CaseLinkingService do
                                         kase.number)}
 
       it 'sets result to :validation error and returns same' do
-        result = service.call
+        result = service.create
         expect(result).to eq :validation_error
         expect(service.result).to eq :validation_error
       end
 
       it 'adds an error to the case' do
-        service.call
+        service.create
         expect(kase.errors[:linked_case_number])
           .to eq ["can't link to the same case"]
       end
@@ -155,13 +155,13 @@ describe CaseLinkingService do
                                         11111)}
 
       it 'sets result to validation error and returns same' do
-        result = service.call
+        result = service.create
         expect(result).to eq :validation_error
         expect(service.result).to eq :validation_error
       end
 
       it 'adds an error to the case' do
-        service.call
+        service.create
         expect(kase.errors[:linked_case_number])
           .to eq ["does not exist"]
       end
@@ -171,7 +171,7 @@ describe CaseLinkingService do
   context 'when an error occurs' do
     it 'rolls back changes' do
       allow(kase).to receive(:add_linked_case).and_throw(RuntimeError)
-      service.call
+      service.create
 
       cases_transitions = kase.transitions.where(
         event: 'link_a_case'
@@ -186,7 +186,7 @@ describe CaseLinkingService do
 
     it 'sets result to :error and returns same' do
       allow(kase).to receive(:add_linked_case).and_throw(RuntimeError)
-      result = service.call
+      result = service.create
       expect(result).to eq :error
       expect(service.result).to eq :error
     end

--- a/spec/services/case_linking_service_spec.rb
+++ b/spec/services/case_linking_service_spec.rb
@@ -116,10 +116,10 @@ describe CaseLinkingService do
 
       before(:each)  {
         service.create
-        service.destroy
       }
 
       it 'destroys the link between the two cases' do
+        service.destroy
         expect(kase.linked_cases).to be_empty
         expect(link_case.linked_cases).to be_empty
       end
@@ -131,6 +131,7 @@ describe CaseLinkingService do
       end
 
       it 'has created a transition on the linking case' do
+        service.destroy
         transition = kase.transitions.last
         expect(transition.event).to eq 'remove_linked_case'
         expect(transition.to_state).to eq kase.current_state
@@ -140,6 +141,7 @@ describe CaseLinkingService do
       end
 
       it 'has created a transition on the linked case' do
+        service.destroy
         transition = link_case.transitions.last
         expect(transition.event).to eq 'remove_linked_case'
         expect(transition.to_state).to eq link_case.current_state
@@ -152,15 +154,16 @@ describe CaseLinkingService do
     context 'SAR cases' do
       let(:sar_case_1)      { create :sar_case }
       let(:sar_case_2)      { create :sar_case }
+      let(:service)         { CaseLinkingService.new(manager,
+                                                     sar_case_1,
+                                                     sar_case_2.number)}
 
       before(:each)  {
         service.create
-        service.destroy
       }
 
       describe 'linking a non-sar case to a sar case' do
         it 'does not error' do
-          service = CaseLinkingService.new(manager, sar_case_1, sar_case_2.number)
           service.destroy
           expect(service.result).to eq :ok
           expect(sar_case_1).to be_valid

--- a/spec/site_prism/page_objects/sections/cases/linked_cases_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/linked_cases_section.rb
@@ -8,7 +8,8 @@ module PageObjects
           element :link, 'td:nth-child(1) a'
           element :case_type, 'td:nth-child(2)'
           element :request, 'td:nth-child(3)'
-          element :no_linked_cases, 'td[colspan="3"]'
+          element :remove_link, 'td:nth-child(4) a'
+          element :no_linked_cases, 'td[colspan="4"]'
         end
 
         element :action_link, '#action--link-a-case'

--- a/spec/state_machines/foi_permitted_events_spec.rb
+++ b/spec/state_machines/foi_permitted_events_spec.rb
@@ -15,7 +15,8 @@ describe Case::FOI::StandardStateMachine do
                                                                    :destroy_case,
                                                                    :edit_case,
                                                                    :flag_for_clearance,
-                                                                   :link_a_case]
+                                                                   :link_a_case,
+                                                                   :remove_linked_case]
         end
       end
 
@@ -30,6 +31,7 @@ describe Case::FOI::StandardStateMachine do
                                                                       :edit_case,
                                                                       :flag_for_clearance,
                                                                       :link_a_case,
+                                                                      :remove_linked_case,
                                                                       :request_further_clearance]
         end
       end
@@ -45,6 +47,7 @@ describe Case::FOI::StandardStateMachine do
                                                                       :extend_for_pit,
                                                                       :flag_for_clearance,
                                                                       :link_a_case,
+                                                                      :remove_linked_case,
                                                                       :request_further_clearance]
         end
       end
@@ -59,6 +62,7 @@ describe Case::FOI::StandardStateMachine do
                                                                       :extend_for_pit,
                                                                       :flag_for_clearance,
                                                                       :link_a_case,
+                                                                      :remove_linked_case,
                                                                       :request_further_clearance]
         end
       end
@@ -72,7 +76,8 @@ describe Case::FOI::StandardStateMachine do
                                                                       :destroy_case,
                                                                       :edit_case,
                                                                       :extend_for_pit,
-                                                                      :link_a_case]
+                                                                      :link_a_case,
+                                                                      :remove_linked_case]
         end
       end
 
@@ -80,7 +85,7 @@ describe Case::FOI::StandardStateMachine do
         it 'shows events' do
           k = create :closed_case
           expect(k.current_state).to eq 'closed'
-          expect(k.state_machine.permitted_events(manager.id)).to eq [:destroy_case, :edit_case, :link_a_case]
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:destroy_case, :edit_case, :link_a_case,:remove_linked_case]
         end
       end
 
@@ -112,7 +117,7 @@ describe Case::FOI::StandardStateMachine do
             k = create :awaiting_responder_case
             expect(k.current_state).to eq 'awaiting_responder'
             permitted_events = k.state_machine.permitted_events(responder.id) - [:request_further_clearance]
-            expect(permitted_events).to eq [:link_a_case]
+            expect(permitted_events).to eq [:link_a_case, :remove_linked_case]
           end
         end
 
@@ -122,6 +127,7 @@ describe Case::FOI::StandardStateMachine do
             expect(k.current_state).to eq 'awaiting_dispatch'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:extend_for_pit,
                                                                           :link_a_case,
+                                                                          :remove_linked_case,
                                                                           :request_further_clearance]
           end
         end
@@ -130,7 +136,7 @@ describe Case::FOI::StandardStateMachine do
           it 'shows events' do
             k = create :responded_case
             expect(k.current_state).to eq 'responded'
-            expect(k.state_machine.permitted_events(responder.id)).to eq [:extend_for_pit, :link_a_case]
+            expect(k.state_machine.permitted_events(responder.id)).to eq [:extend_for_pit, :link_a_case, :remove_linked_case]
           end
         end
       end
@@ -147,7 +153,8 @@ describe Case::FOI::StandardStateMachine do
             expect(permitted_events).to eq [:accept_responder_assignment,
                                             :add_message_to_case,
                                             :link_a_case,
-                                            :reject_responder_assignment]
+                                            :reject_responder_assignment,
+                                            :remove_linked_case]
 
           end
         end
@@ -162,6 +169,7 @@ describe Case::FOI::StandardStateMachine do
                                                                           :extend_for_pit,
                                                                           :link_a_case,
                                                                           :reassign_user,
+                                                                          :remove_linked_case,
                                                                           :request_further_clearance]
           end
         end
@@ -176,6 +184,7 @@ describe Case::FOI::StandardStateMachine do
                                                                           :extend_for_pit,
                                                                           :link_a_case,
                                                                           :remove_last_response,
+                                                                          :remove_linked_case,
                                                                           :remove_response,
                                                                           :request_further_clearance,
                                                                           :respond]
@@ -187,7 +196,7 @@ describe Case::FOI::StandardStateMachine do
             k = create :responded_case
             responder = responder_in_assigned_team(k)
             expect(k.current_state).to eq 'responded'
-            expect(k.state_machine.permitted_events(responder.id)).to eq [:extend_for_pit, :link_a_case]
+            expect(k.state_machine.permitted_events(responder.id)).to eq [:extend_for_pit, :link_a_case, :remove_linked_case]
           end
         end
       end

--- a/spec/state_machines/sar_permitted_events_spec.rb
+++ b/spec/state_machines/sar_permitted_events_spec.rb
@@ -13,7 +13,8 @@ describe ConfigurableStateMachine::Machine do
                                                                       :assign_responder,
                                                                       :destroy_case,
                                                                       :edit_case,
-                                                                      :link_a_case]
+                                                                      :link_a_case,
+                                                                      :remove_linked_case]
         end
       end
 
@@ -26,7 +27,8 @@ describe ConfigurableStateMachine::Machine do
                                                                       :destroy_case,
                                                                       :edit_case,
                                                                       :flag_for_clearance,
-                                                                      :link_a_case]
+                                                                      :link_a_case,
+                                                                      :remove_linked_case]
         end
       end
 
@@ -38,17 +40,19 @@ describe ConfigurableStateMachine::Machine do
                                                                       :assign_to_new_team,
                                                                       :destroy_case,
                                                                       :edit_case,
-                                                                      :link_a_case]
+                                                                      :link_a_case,
+                                                                      :remove_linked_case]
         end
       end
-      
+
       context 'closed' do
         it "should show permitted events" do
           k = create :closed_sar
           expect(k.current_state).to eq 'closed'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:destroy_case,
                                                                       :edit_case,
-                                                                      :link_a_case]
+                                                                      :link_a_case,
+                                                                      :remove_linked_case]
         end
       end
     end

--- a/spec/views/cases/_linked_cases_html_slim_spec.rb
+++ b/spec/views/cases/_linked_cases_html_slim_spec.rb
@@ -56,9 +56,7 @@ describe 'cases/linked_cases.html.slim', type: :view do
         expect(row.case_type.text).to eq 'FOI '
         expect(row.request.text)
             .to eq "#{ linked_case.subject } #{ linked_case.name }"
-
-        # annoyingly had to add \n below because of how locales using html is handled
-        expect(row.remove_link.text).to eq "Remove link to #{linked_case.number}\n"
+        expect(row.remove_link.text.strip).to eq "Remove link to #{linked_case.number}"
         expect(row.remove_link['href'])
             .to eq destroy_link_on_case_path(id: main_case.id,
                                              linked_case_number: linked_case.number)

--- a/spec/views/cases/_linked_cases_html_slim_spec.rb
+++ b/spec/views/cases/_linked_cases_html_slim_spec.rb
@@ -19,15 +19,20 @@ describe 'cases/linked_cases.html.slim', type: :view do
                                 name:'Hello 1',
                                 subject: 'Case 1',
                                 trigger_case_marker: '',
+                                pretty_type: 'FOI',
                                 linked_cases: [])}
     let(:linked_case_2){ double(Case::Base, id: 2,
                                 number: '222222',
                                 subject: 'Case 2',
-                                name:'Hello 2', linked_cases: [])}
+                                name:'Hello 2',
+                                trigger_case_marker: '',
+                                pretty_type: 'FOI',
+                                linked_cases: [])}
     let(:main_case)    { double(Case::Base, id: 3,
                                 number: '333333',
                                 name:'Hello',
                                 subject: 'Case 3',
+                                pretty_type: 'FOI',
                                 trigger_case_marker: '',
                                 linked_cases: [linked_case_1,
                                                linked_case_2 ])}
@@ -39,7 +44,7 @@ describe 'cases/linked_cases.html.slim', type: :view do
 
       render partial: 'cases/linked_cases.html.slim',
              locals:{ case_details: main_case}
-      
+
       partial = linked_cases_section(rendered)
 
       expect(partial.section_heading.text).to eq 'Linked cases'
@@ -51,6 +56,12 @@ describe 'cases/linked_cases.html.slim', type: :view do
         expect(row.case_type.text).to eq 'FOI '
         expect(row.request.text)
             .to eq "#{ linked_case.subject } #{ linked_case.name }"
+
+        # annoyingly had to add \n below because of how locales using html is handled
+        expect(row.remove_link.text).to eq "Remove link to #{linked_case.number}\n"
+        expect(row.remove_link['href'])
+            .to eq destroy_link_on_case_path(id: main_case.id,
+                                             linked_case_number: linked_case.number)
       end
     end
   end


### PR DESCRIPTION
- the "Remove link" on the case detail page
- the remove_linked_case method to Case::Base model
- The controller action to remove the link.
- add destroy method to case linking service
- add new event to the state machine.
- trigger the event from CaseLinkingService#destroy