### PR TITLE
CT-1571 always use our version of log/parallel_runtime_rspec.log

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+log/parallel_runtime_rspec.log merge=ours


### PR DESCRIPTION
We use this file so that Travis can balance out the tests between processes
better and so that they run more quickly. However, because it changes every time
we run the tests, this causes merge conflicts ... this change allows us to avoid
conflicts by using a merge strategy that will always choose our local version.
To work fully, developers should run this command to ensure the merge driver
defined in this file exists:

    $ git config --local merge.ours.driver true
