### PR TITLE
CT-1572 copy latest version of repo to docker image when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN touch /etc/inittab
 
 EXPOSE $PUMA_PORT
 
+COPY . /usr/src/app
+
 RUN bundle exec rake assets:precompile assets:non_digested RAILS_ENV=production \
   SECRET_KEY_BASE=required_but_does_not_matter_for_assets
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,9 +1,11 @@
 FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
 
+WORKDIR /usr/src/app
+
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(bin/codename.sh)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
     cat /etc/apt/sources.list.d/pgdg.list && \
-    apt-get update && \
+    apt-get update -y && \
     apt-get install -y ca-certificates \
                        less \
                        libreoffice \
@@ -11,4 +13,4 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     rm -rf /var/lib/apt/lists/* && \
     truncate -s 0 /var/log/*log
 
-RUN bash -c 'shopt -s extglob ; eval "rm -rf /usr/src/app/!(.|..|.bash*|.profile)"'
+RUN bash -c 'shopt -s extglob ; eval "rm -rf !(.|..|.bash*|.profile)"'

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,4 +13,12 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     rm -rf /var/lib/apt/lists/* && \
     truncate -s 0 /var/log/*log
 
+# Terrible hack below, but the base image's ONBUILD copies over our SRC dir,
+# which isn't what we want to do at this point, it's when we build the app
+# docker image (using Dockerfile) that we want to do that. A possibly better way
+# to do this is to use the ruby:2.3.1 base image instead of the "webapp-onbuild"
+# one and to do the ONBUILD, and everything else, in this Dockerfile.
+#
+# https://github.com/ministryofjustice/docker-templates/blob/master/ruby/2.3.1/webapp-onbuild/Dockerfile
+#
 RUN bash -c 'shopt -s extglob ; eval "rm -rf !(.|..|.bash*|.profile)"'

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -10,3 +10,5 @@ RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
                        postgresql-client-9.5 && \
     rm -rf /var/lib/apt/lists/* && \
     truncate -s 0 /var/log/*log
+
+RUN bash -c 'shopt -s extglob ; eval "rm -rf /usr/src/app/!(.|..|.bash*|.profile)"'

--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ export RAILS_ENV=production
 export SETTINGS__GIT_COMMIT="$APP_GIT_COMMIT"
 export SETTINGS__BUILD_DATE="$APP_BUILD_DATE"
 export SETTINGS__GIT_SOURCE="$APP_BUILD_TAG"
-cd /usr/src/app
+
 case ${DOCKER_STATE} in
 create)
     echo "running create"


### PR DESCRIPTION
Apparently our base image has the context automatically copied, while subsequent
images we create from it do not, so we have to add an explicit COPY command to
ensure the code is up-to-date in the new image we build with Dockerfile