### PR TITLE
CT-1600 requires missing CTS constants file

### DIFF
--- a/app/controllers/admin/cases_controller.rb
+++ b/app/controllers/admin/cases_controller.rb
@@ -1,4 +1,6 @@
 require 'cts/cases/create'
+require 'cts/cases/constants'
+
 
 class Admin::CasesController < ApplicationController
   before_action :authorize_admin


### PR DESCRIPTION
This fixes up the basic FOI case creation on the Admin pages but the page still needs
some work when it comes to SARs like missing fields on the page and the
odd FOI case creation issue.

At least its not just an error page you see.