### PR TITLE
CT-1611 search design

### DIFF
--- a/app/assets/stylesheets/ie_shame.css
+++ b/app/assets/stylesheets/ie_shame.css
@@ -2,7 +2,7 @@
 .js-enabled .block-label.selection-button-radio::before,
 .js-enabled .block-label.selection-button-radio::after,
 .js-enabled .block-label.selection-button-checkbox::before,
-.js-enabled .block-label.selection-button-checkbox::after,{
+.js-enabled .block-label.selection-button-checkbox::after {
   display: none;
 }
 

--- a/app/assets/stylesheets/moj/_buttons.scss
+++ b/app/assets/stylesheets/moj/_buttons.scss
@@ -21,6 +21,12 @@
   margin-left: $gutter;
 }
 
+.button.button-no-margin{
+  margin: 0;
+  margin-left: 5px;
+  line-height: 1.15;
+}
+
 .secondard-action-link {
   margin-left: $gutter;
   line-height: 2.0em;

--- a/app/assets/stylesheets/moj/_layout.scss
+++ b/app/assets/stylesheets/moj/_layout.scss
@@ -59,41 +59,6 @@
   @include grid-column( 1/3 );
 }
 
-.case-sidebar__group {
-  margin-bottom: $gutter;
-
-  a.button {
-    margin-bottom: $gutter-half;
-  }
-}
-
-.case-sidebar__group--hr {
-  @extend .case-sidebar__group;
-  padding-bottom: $gutter-half;
-  border-bottom : 1px solid $border-colour;
-  margin-bottom : $gutter;
-}
-
-.case-sidebar__heading {
-  @include core-19();
-}
-
-.case-sidebar__data {
-  @include bold-24();
-  a{
-    @include core-19();
-  }
-}
-
-.case-sidebar__data--contact {
-  @include core-19();
-  margin-top   : $gutter-half;
-  margin-bottom: $gutter-half;
-  div {
-    margin-bottom: $gutter-half;
-  }
-}
-
 .request--heading {
   @include bold-24();
 
@@ -114,12 +79,6 @@
     @include pre-wrap();
   }
 }
-
-
-table#response-details {
-  margin-bottom: $gutter;
-}
-
 
 .closed-case-report th {
   text-align: left;
@@ -181,6 +140,7 @@ table#response-details {
     text-align: right;
   }
 }
+
 td.clearance-actions {
   text-align: right;
 }

--- a/app/assets/stylesheets/moj/_typography.scss
+++ b/app/assets/stylesheets/moj/_typography.scss
@@ -136,3 +136,21 @@ table caption{
   @include bold-24();
   margin-bottom: $gutter-half;
 }
+
+.search-results-summary {
+  @include core-19();
+  margin-top: $gutter-half;
+  margin-bottom: $gutter;
+  strong {
+    @include bold-24();
+  }
+}
+
+.search-no-results {
+  p:first-child {
+    margin-bottom: 0;
+  }
+  ul {
+    margin-bottom: $gutter;
+  }
+}

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -285,17 +285,14 @@ class CasesController < ApplicationController
 
   def search
     @query = params[:query]
-    @current_tab_name = 'search'
     if @query.present?
       @query.strip!
       @cases = policy_scope(Case::Base).search(@query).page(params[:page]).decorate
       if @cases.empty?
-        flash.now[:alert] = 'No cases found'
+        @cases = nil
       end
-    else
-      @cases = nil
     end
-    render :index
+    render :search
   end
 
   def remove_clearance

--- a/app/views/cases/index.html.slim
+++ b/app/views/cases/index.html.slim
@@ -3,25 +3,12 @@
 
 = render partial: 'layouts/header'
 
-- if current_page?(search_cases_path)
-  .grid-row
-    .column-full.button-holder
-      = form_tag search_cases_path, method: :get
-        .form-group
-          = label_tag :query, 'Case number', class: 'form-label-bold'
-          p.form-hint
-            = 'For example, 170113001'
-          = search_field_tag :query, @query, class: 'form-control'
-        = submit_tag 'Search', class: 'button'
-
-- elsif @can_add_case
+- if @can_add_case
   .grid-row
     .column-full.button-holder
       = link_to t('common.new_case_button'), new_case_path, class: 'button'
 
-
-
-= render partial: 'state_filter_form' unless (params[:action] == 'search' || request.path == '/cases/my_open')
+= render partial: 'state_filter_form' unless request.path == '/cases/my_open'
 
 - if @global_nav_manager.current_page.tabs.present?
   .grid-row
@@ -34,7 +21,7 @@
                          count: tab.cases.count),
                         tab.fullpath_with_query
 
-- if !current_page?(search_cases_path) || !@cases.nil?
+- if !@cases.nil?
   .grid-row
     .column-full.table-container.container
       table.report.table-font-xsmall

--- a/app/views/cases/search.html.slim
+++ b/app/views/cases/search.html.slim
@@ -1,0 +1,42 @@
+- content_for :heading
+  = t(".heading")
+
+= render partial: 'layouts/header'
+
+.grid-row
+  .column-full.button-holder
+    = form_tag search_cases_path, method: :get
+      = label_tag :query, 'Case number, requester name or keyword', class: 'form-label-bold'
+      = search_field_tag :query, @query, class: 'form-control'
+      = submit_tag 'Search', class: 'button button-no-margin'
+
+
+- if !@cases.nil?
+  = render partial: 'cases/shared/case_list'
+
+- if @cases.nil? && params[:query].present?
+  .grid-row
+    .column-full
+      .search-results-summary
+        strong
+          | 0
+        = " cases found"
+
+  .grid-row
+    .column-full.search-no-results
+      p
+        strong
+          = "Please try "
+          span.visually-hidden
+            = "some of these options "
+      ul.list-bullet
+        li
+          = "check if you've entered in the requestor's name correctly."
+        li
+          = "searching by a case number or keyword instead."
+
+      p
+        strong.strong-block
+          = "Older cases "
+        = "Cases dating before 1 September 2017 are not stored in this system."
+

--- a/app/views/cases/shared/_case_list.html.slim
+++ b/app/views/cases/shared/_case_list.html.slim
@@ -1,0 +1,61 @@
+.grid-row
+  .column-full.table-container.container
+    table.report.table-font-xsmall
+      colgroup
+        col
+        col
+        col
+        col
+        col
+        col
+        col
+        col
+      caption
+        .search-results-summary
+          strong
+            = @cases.total_count
+          = " #{ 'case'.pluralize(@cases.total_count)} found"
+      thead
+        th scope='col'
+          = t('common.case_list.number_html')
+        th scope='col'
+          = t('common.case_list.type')
+        th scope='col'
+          = t('common.case_list.request')
+        th scope='col'
+          = t('common.case_list.draft_deadline')
+        th scope='col'
+          = t('common.case_list.external_deadline')
+        th scope='col'
+          = t('common.case_list.status')
+        th scope='col'
+          = t('common.case_list.who_its_with')
+        th scope='col'
+          span.visually-hidden
+            = t('common.case_list.message_notification')
+      tbody
+        - @cases.each do |kase|
+          tr
+            td aria-label="#{t('common.case_list.number')}"
+              span.visually-hidden
+                = t('common.case_list.view_case')
+              = link_to kase.number, case_path(kase.id)
+            td aria-label="#{t('common.case_list.type')}"
+              = "#{kase.pretty_type} "
+              = kase.trigger_case_marker
+            td aria-label="#{t('common.case_list.request_detail')}"
+              = request_details_html(kase)
+            td aria-label="#{t('common.case_list.draft_deadline')}"
+              = kase.internal_deadline
+            td aria-label="#{t('common.case_list.external_deadline')}"
+              = kase.external_deadline
+            td aria-label="#{t('common.case_list.status')}"
+              = t("state.#{kase.current_state}")
+            td aria-label="#{t('common.case_list.who_its_with')}"
+              = kase.who_its_with
+            td aria-label="#{t('common.case_list.message_notification')}"
+              - if kase.message_notification_visible?(current_user)
+                img { src=image_path('icons/message-bubble.svg')
+                      class="notification-speech-bubble"
+                      alt= "New notifications for case #{kase.number}" }
+    = paginate @cases

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,7 +286,7 @@ en:
           manager: Case management
       team_property:
         value: "Add area"
-        
+
 
   alerts:
     assignment_accepted_html: |
@@ -373,6 +373,18 @@ en:
       clear_response: Clear response
       request_amends: Request amends
       upload_approve: 'Upload response and clear'
+    case_list:
+      view_case: "Link to case "
+      message_notification: Conversations
+      number: Case number
+      number_html: 'Case <abbr title="number">No.</abbr>'
+      type: 'Type'
+      request: 'Request'
+      request_detail: Request detail
+      draft_deadline: Draft deadline
+      external_deadline: Final deadline
+      status: Status
+      who_its_with: With
     new_case_button: Create case
     phase_banner: |
       This is a new service.
@@ -446,7 +458,6 @@ en:
       extension_date: Date of extension deadline
       extension_date_hint: Cannot be more than %{extension_limit} working days beyond the final deadline.
     index: &cases_list
-      heading_search: Search
       heading_all_cases: All open cases
       heading_my_cases: My open cases
       view_case: "Link to case "
@@ -522,7 +533,8 @@ en:
       close_form:
         close_date: Date response sent
         date_example: For example, 30 1 2017
-
+    search:
+      heading: Search
 
     remove_clearance:
       heading: 'Remove Clearance'

--- a/spec/controllers/cases_controller/search_spec.rb
+++ b/spec/controllers/cases_controller/search_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe CasesController, type: :controller do
+
+  let(:responder)             { create :responder }
+  let(:responding_team)       { responder.responding_teams.first }
+  let(:unassigned_case)       { create(:case) }
+  let(:assigned_case)         { create :assigned_case,
+                                        responding_team: responding_team }
+
+  describe 'GET search' do
+    before(:each) do
+      sign_in responder
+    end
+
+    it 'renders the index template' do
+      get :search
+      expect(response).to render_template(:search)
+    end
+
+    it 'finds a case by number' do
+      get :search, params: { query: assigned_case.number }
+      expect(assigns[:cases]).to eq [assigned_case]
+    end
+
+    it 'finds a case by text' do
+      assigned_case
+      unassigned_case
+      get :search, params: { query: 'assigned' }
+      expect(assigns[:cases]).to eq [assigned_case]
+    end
+
+    it 'ignores leading or trailing whitespace' do
+      get :search, params: { query: " #{assigned_case.number} " }
+      expect(assigns[:cases]).to eq [assigned_case]
+    end
+    it 'uses the policy scope' do
+      allow(controller).to receive(:policy_scope).and_return(Case::Base.none)
+      get :search, params: { query: assigned_case.number }
+      expect(controller).to have_received(:policy_scope).with(Case::Base)
+    end
+
+    it 'passes the page param to the paginator' do
+      paged_cases = double('Paged Cases', decorate: [])
+      cases = double('Cases', page: paged_cases, empty?: true)
+      allow(Case::Base).to receive(:search).and_return(cases)
+      get :search, params: { query: assigned_case.number, page: 'our_pages' }
+      expect(cases).to have_received(:page).with('our_pages')
+    end
+  end
+end

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -1268,47 +1268,6 @@ RSpec.describe CasesController, type: :controller do
     end
   end
 
-  describe 'GET search' do
-    before(:each) do
-      sign_in responder
-    end
-
-    it 'renders the index template' do
-      get :search
-      expect(response).to render_template(:index)
-    end
-
-    it 'finds a case by number' do
-      get :search, params: { query: assigned_case.number }
-      expect(assigns[:cases]).to eq [assigned_case]
-    end
-
-    it 'finds a case by text' do
-      assigned_case
-      unassigned_case
-      get :search, params: { query: 'assigned' }
-      expect(assigns[:cases]).to eq [assigned_case]
-    end
-
-    it 'ignores leading or trailing whitespace' do
-      get :search, params: { query: " #{assigned_case.number} " }
-      expect(assigns[:cases]).to eq [assigned_case]
-    end
-    it 'uses the policy scope' do
-      allow(controller).to receive(:policy_scope).and_return(Case::Base.none)
-      get :search, params: { query: assigned_case.number }
-      expect(controller).to have_received(:policy_scope).with(Case::Base)
-    end
-
-    it 'passes the page param to the paginator' do
-      paged_cases = double('Paged Cases', decorate: [])
-      cases = double('Cases', page: paged_cases, empty?: true)
-      allow(Case::Base).to receive(:search).and_return(cases)
-      get :search, params: { query: assigned_case.number, page: 'our_pages' }
-      expect(cases).to have_received(:page).with('our_pages')
-    end
-  end
-
   describe 'GET edit' do
     let(:kase) { create :accepted_case }
 

--- a/spec/features/cases/foi/case_search_spec.rb
+++ b/spec/features/cases/foi/case_search_spec.rb
@@ -18,6 +18,7 @@ feature 'Searching for cases' do
     cases_search_page.search_button.click
     expect(cases_search_page).to be_displayed
     expect(cases_search_page).not_to have_notices
+    expect(cases_search_page.search_results_count.text).to eq "1 case found"
     expect(cases_search_page.case_list.count).to eq 1
     expect(cases_search_page.case_list.first.number).to have_text kase.number
   end
@@ -31,6 +32,7 @@ feature 'Searching for cases' do
     cases_search_page.search_button.click
     expect(cases_search_page).to be_displayed
     expect(cases_search_page.case_list.count).to eq 1
+    expect(cases_search_page.search_results_count.text).to eq "1 case found"
     expect(cases_search_page.case_list.first.number).to have_text kase.number
   end
 
@@ -43,6 +45,7 @@ feature 'Searching for cases' do
     cases_search_page.search_button.click
     expect(cases_search_page).to be_displayed
     expect(cases_search_page.case_list.count).to eq 1
+    expect(cases_search_page.search_results_count.text).to eq "1 case found"
     expect(cases_search_page.case_list.first.number).to have_text kase.number
   end
 end

--- a/spec/features/cases/sar/case_search_spec.rb
+++ b/spec/features/cases/sar/case_search_spec.rb
@@ -18,6 +18,7 @@ feature 'searching for SAR cases' do
       cases_search_page.search_button.click
       expect(cases_search_page).to be_displayed
       expect(cases_search_page).not_to have_notices
+      expect(cases_search_page.search_results_count.text).to eq "1 case found"
       expect(cases_search_page.case_list.count).to eq 1
       expect(cases_search_page.case_list.first.number).to have_text kase.number
     end
@@ -37,6 +38,7 @@ feature 'searching for SAR cases' do
       cases_search_page.search_button.click
       expect(cases_search_page).to be_displayed
       expect(cases_search_page).not_to have_notices
+      expect(cases_search_page.search_results_count.text).to eq "1 case found"
       expect(cases_search_page.case_list.count).to eq 1
       expect(cases_search_page.case_list.first.number).to have_text kase.number
     end
@@ -52,6 +54,8 @@ feature 'searching for SAR cases' do
       cases_search_page.search_button.click
       expect(cases_search_page).to be_displayed
       expect(cases_search_page).not_to have_notices
+      expect(cases_search_page.search_results_count.text).to eq "0 cases found"
+      expect(cases_search_page).to have_found_no_results_copy
       expect(cases_search_page.case_list.count).to eq 0
       expect(cases_search_page.case_list).not_to have_text kase.number
     end

--- a/spec/site_prism/page_objects/pages/cases/search_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/search_page.rb
@@ -11,7 +11,9 @@ module PageObjects
         element :search_query, 'input[type="search"]'
         element :search_button, 'input.button'
 
-        sections :case_list, '.case_row' do
+        element :search_results_count, '.search-results-summary'
+
+        sections :case_list, '.report tbody tr' do
           element :number, 'td[aria-label="Case number"]'
           element :request_detail, 'td[aria-label="Request detail"]'
           element :draft_deadline, 'td[aria-label="Draft deadline"]'
@@ -19,6 +21,8 @@ module PageObjects
           element :status, 'td[aria-label="Status"]'
           element :who_its_with, 'td[aria-label="With"]'
         end
+
+        element :found_no_results_copy, '.search-no-results'
       end
     end
   end


### PR DESCRIPTION
This commit updates the search page design:

- move the search submit button so that it appears next to the search field
- display number of cases found
- update the copy of the search field
- add copy for no results to help users try other search terms
- removes the report columns if not returns are found
- removes the flash message if no results found

Tech tidy up:
- remove unused css classes
- split the existing case index view into a separate search and index view this was done to help simplify the view and remove the logic used between the two views.