### PR TITLE
CT-1672 Record filters in search_queries table for search/filtering m…

### DIFF
--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -4,14 +4,14 @@ module CasesHelper
     Settings.case_uploads_accepted_types.join ','
   end
 
-  def case_link_with_hash(kase, field, query_hash, page, position)
+  def case_link_with_hash(kase, field, page, position)
     page = 1 if page.blank?
-    if query_hash.nil?
+    if position.nil?
       link_to kase.__send__(field), case_path(kase.id)
     else
       position += 1
       page_offset = Kaminari.config[:default_per_page] * (page.to_i - 1)
-      link_to kase.__send__(field), case_path(kase.id, hash: query_hash, pos: page_offset + position)
+      link_to kase.__send__(field), case_path(kase.id, pos: page_offset + position)
     end
 
   end

--- a/app/models/search_query.rb
+++ b/app/models/search_query.rb
@@ -3,9 +3,12 @@
 # Table name: search_queries
 #
 #  id               :integer          not null, primary key
-#  query_hash       :string           not null
 #  user_id          :integer          not null
+#  parent_id        :integer
+#  query_type       :enum             default("search"), not null
+#  filter_type      :string
 #  query            :string           not null
+#  query_hash       :string           not null
 #  num_results      :integer          not null
 #  num_clicks       :integer          default(0), not null
 #  highest_position :integer
@@ -16,39 +19,88 @@
 class SearchQuery < ApplicationRecord
 
   belongs_to :user
+  belongs_to :parent, class_name: 'SearchQuery'
+  has_many   :children, class_name: 'SearchQuery'
 
+  enum query_type: {
+      search: 'search',
+      filter: 'filter'
+  }
+
+  acts_as_tree
+
+  def self.by_query_hash!(query_hash)
+    self.find_by!(query_hash: query_hash)
+  end
+
+  def self.by_query_hash_with_ancestors!(query_hash)
+    record = by_query_hash!(query_hash)
+    record.ancestors.reverse + [record]
+  end
+
+  def self.new_from_search_service(case_search_service)
+    if case_search_service.filter?
+      new_filter_record(case_search_service)
+    else
+      new_search_record(case_search_service)
+    end
+  end
 
   def self.create_from_search_service(case_search_service)
-    if SearchQuery.find_by(query_hash: case_search_service.query_hash).nil?
-      create!(
-          query_hash:     case_search_service.query_hash,
-          user_id:        case_search_service.current_user.id,
-          query:          case_search_service.query,
-          num_results:    case_search_service.unpaginated_result_set.size
+    new_from_search_service(case_search_service).save!
+  end
+
+  def self.new_search_record(service)
+    search_query = SearchQuery.find_by(query_hash: service.query_hash)
+    if search_query.nil?
+      self.new(
+              query_type:     'search',
+              query_hash:     service.query_hash,
+              user_id:        service.current_user.id,
+              query:          service.query,
+              parent_id:      parent_search_query_id(service),
+              num_results:    service.unpaginated_result_set.size
       )
+    else
+      search_query
+    end
+  end
+
+  def self.new_filter_record(service)
+    search_query = SearchQuery.find_by(query_hash: service.query_hash)
+    if search_query.nil?
+      self.new(
+              query_type:     'filter',
+              filter_type:    service.filter_type,
+              query_hash:     service.query_hash,
+              user_id:        service.current_user.id,
+              parent_id:      parent_search_query_id(service),
+              query:          service.query,
+              num_results:    service.unpaginated_result_set.size
+      )
+    else
+      search_query
     end
   end
 
 
-  def self.update_for_click(params, flash)
-    if params[:hash] == flash[:query_hash]
-      record_click(params)
-    end
-  end
-
-
-
-  def self.record_click(params)
-    record = SearchQuery.find_by(query_hash: params[:hash])
+  def self.update_for_click(query_hash, position)
+    record = SearchQuery.find_by(query_hash: query_hash)
     unless record.nil?
-      record.num_clicks +=1
-      if record.highest_position.nil? || record.highest_position > params[:pos].to_i
-        record.highest_position = params[:pos].to_i
+      record.num_clicks += 1
+      if record.highest_position.nil? || record.highest_position > position
+        record.highest_position = position
       end
       record.save!
     end
   end
 
-  private_class_method :record_click
+  def self.parent_search_query_id(case_search_service)
+    if case_search_service.child?
+      self.by_query_hash!(case_search_service.parent_hash).id
+    else
+      nil
+    end
+  end
 
 end

--- a/app/services/case_filter_service.rb
+++ b/app/services/case_filter_service.rb
@@ -1,0 +1,21 @@
+class CaseFilterService
+
+  def initialize(arel, search_query)
+    @arel = arel
+    @filter_type = search_query.filter_type
+    @query = search_query.query
+  end
+
+  def call
+    result = nil
+    case @query
+      when 'internal_review'
+        result = @arel.where(type: ['Case::FOI::TimelinessReview', 'Case::FOI::ComplianceReview'])
+      when 'timeliness'
+        result = @arel.where(type: 'Case::FOI::TimelinessReview')
+      when 'compliance'
+        result = @arel.where(type: 'Case::FOI::ComplianceReview')
+    end
+    result
+  end
+end

--- a/app/services/case_search_service.rb
+++ b/app/services/case_search_service.rb
@@ -2,19 +2,37 @@ class CaseSearchService
 
   attr_reader :current_user,
               :error_message,
+              :filter_type,
               :result_set,
               :query,
               :query_hash,
+              :parent_hash,
               :unpaginated_result_set
 
-  def initialize(current_user, params)
+  def initialize(current_user, params, parent_hash = nil)
     @current_user = current_user
-    @query = params[:query]
+    @policy_scope = Pundit.policy_scope!(@current_user, Case::Base)
+    @query = params[:query].strip
     @page = params[:page]
     @error = false
     @error_message = nil
     @result_set = []
-    @query_hash = Digest::SHA256.hexdigest("#{@current_user.id}:#{Date.today}:#{@query}")
+    @unpaginated_result_set = []
+
+    if parent_hash.nil?
+      @query_type = :search
+      @parent_hash = nil
+    else
+      @filter_type = params[:filter]
+      @query_type = :filter
+      @parent_hash = parent_hash
+    end
+
+    @query_hash = CaseSearchService.generate_query_hash(@current_user, @query_type, @filter_type, @query)
+  end
+
+  def self.generate_query_hash(user, query_type, filter_type, query, date = Date.today)
+    Digest::SHA256.hexdigest("#{user.id}:#{date.to_date}:#{query_type}:#{filter_type}:#{query}")
   end
 
 
@@ -23,8 +41,21 @@ class CaseSearchService
       @error_message = 'Specify what you want to search for'
       @error = true
     else
-      execute_search
+      search_and_filter
+      @result_set = @unpaginated_result_set.page(@page).decorate
     end
+  end
+
+  def filter?
+   @query_type == :filter
+  end
+
+  def search?
+    @query_type == :search
+  end
+
+  def child?
+    @parent_hash.present?
   end
 
   def error?
@@ -33,11 +64,35 @@ class CaseSearchService
 
   private
 
-  def execute_search
-    @query.strip!
-    policy_scope = Pundit.policy_scope!(@current_user, Case::Base)
-    @unpaginated_result_set = policy_scope.search(@query)
-    @result_set = @unpaginated_result_set.page(@page).decorate
+  def search_and_filter
+    @unpaginated_result_set = child? ? child_search : root_search
     SearchQuery.create_from_search_service(self)
   end
+
+  def root_search
+    @policy_scope.search(@query)
+  end
+
+  def child_search
+    ancestor_search_queries = SearchQuery.by_query_hash_with_ancestors!(@parent_hash)
+    ancestor_search_queries.each do |search_query|
+      if search_query.search?
+        @unpaginated_result_set = @policy_scope.search(search_query.query)
+      else
+        @unpaginated_result_set = CaseFilterService.new(@unpaginated_result_set, search_query).call
+      end
+    end
+    #
+    # now we've got the result set that we had before the this filter was applied,
+    # so all we have to do now is to apply the filter and store search_query_record
+    # in the database
+    #
+    new_search_query = SearchQuery.new_from_search_service(self)
+    @unpaginated_result_set = CaseFilterService.new(@unpaginated_result_set, new_search_query).call
+    new_search_query.num_results = @unpaginated_result_set.size
+    new_search_query.save!
+    @unpaginated_result_set
+  end
 end
+
+

--- a/app/views/cases/search.html.slim
+++ b/app/views/cases/search.html.slim
@@ -10,7 +10,29 @@
       p.form-hint
         = 'For example, 170113001, John Smith or prison meals'
       = search_field_tag :query, @query, class: 'form-control'
-      = submit_tag 'Search', class: 'button button-no-margin'
+      = submit_tag 'Search', class: 'button button-no-margin', id: 'search-button'
+
+- if FeatureSet.dummy_filter.enabled?
+  .grid-row
+    .column-full.button-holder
+      = form_tag dummy_filter_cases_path, method: :post
+        = hidden_field_tag 'filter', 'type'
+        = hidden_field_tag 'query', 'internal_review'
+        = submit_tag 'Filter: Internal Review', class: 'button button-no-margin'
+
+  .grid-row
+    .column-full.button-holder
+      = form_tag dummy_filter_cases_path, method: :post
+      = hidden_field_tag 'filter', 'type'
+      = hidden_field_tag 'query', 'compliance'
+      = submit_tag 'Filter: Compliance', class: 'button button-no-margin'
+
+  .grid-row
+    .column-full.button-holder
+      = form_tag dummy_filter_cases_path, method: :post
+      = hidden_field_tag 'filter', 'type:'
+      = hidden_field_tag 'query', 'timeliness'
+      = submit_tag 'Filter: Timeliness', class: 'button button-no-margin'
 
 
 - if @cases.any?

--- a/app/views/cases/shared/_case_list.html.slim
+++ b/app/views/cases/shared/_case_list.html.slim
@@ -39,7 +39,7 @@
             td aria-label="#{t('common.case_list.number')}"
               span.visually-hidden
                 = t('common.case_list.view_case')
-              = case_link_with_hash(kase, :number, @query_hash, @page, position)
+              = case_link_with_hash(kase, :number, @page, position)
             td aria-label="#{t('common.case_list.type')}"
               = "#{kase.pretty_type} "
               = kase.trigger_case_marker

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,6 +213,7 @@ Rails.application.routes.draw do
     get :request_amends, on: :member
     patch :execute_request_amends, on: :member
     post  :filter, on: :collection
+    post  :dummy_filter, on: :collection
     get 'remove_clearance' => 'cases#remove_clearance', on: :member
     # get 'upload_response_approve' => 'cases#upload_response_approve', on: :member
     get :extend_for_pit, on: :member

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -184,3 +184,9 @@ enabled_features:
     Host-demo: true
     Host-staging: false
     Host-production: false
+  dummy_filter:
+    Local: true
+    Host-dev: true
+    Host-demo: false
+    Host-staging: false
+    Host-production: false

--- a/db/migrate/20180410143714_create_search_queries.rb
+++ b/db/migrate/20180410143714_create_search_queries.rb
@@ -4,15 +4,12 @@ class CreateSearchQueries < ActiveRecord::Migration[5.0]
     create_enum :search_query_type, 'search', 'filter'
 
     create_table :search_queries do |t|
-      t.integer           :user_id, null: false
-      t.integer           :parent_id
-      t.column            :query_type, :search_query_type, null: false, default: :search
-      t.string            :filter_type
-      t.string            :query, null: false
-      t.string            :query_hash, null: false
-      t.integer           :num_results, null: false
-      t.integer           :num_clicks, null: false, default: 0
-      t.integer           :highest_position, null: true
+      t.string :query_hash, null: false
+      t.integer :user_id, null: false
+      t.string :query, null: false
+      t.integer :num_results, null: false
+      t.integer :num_clicks, null: false, default: 0
+      t.integer :highest_position, null: true
 
       t.timestamps
     end

--- a/db/migrate/20180410143714_create_search_queries.rb
+++ b/db/migrate/20180410143714_create_search_queries.rb
@@ -1,12 +1,18 @@
 class CreateSearchQueries < ActiveRecord::Migration[5.0]
   def change
+
+    create_enum :search_query_type, 'search', 'filter'
+
     create_table :search_queries do |t|
-      t.string :query_hash, null: false
-      t.integer :user_id, null: false
-      t.string :query, null: false
-      t.integer :num_results, null: false
-      t.integer :num_clicks, null: false, default: 0
-      t.integer :highest_position, null: true
+      t.integer           :user_id, null: false
+      t.integer           :parent_id
+      t.column            :query_type, :search_query_type, null: false, default: :search
+      t.string            :filter_type
+      t.string            :query, null: false
+      t.string            :query_hash, null: false
+      t.integer           :num_results, null: false
+      t.integer           :num_clicks, null: false, default: 0
+      t.integer           :highest_position, null: true
 
       t.timestamps
     end

--- a/db/migrate/20180410143714_create_search_queries.rb
+++ b/db/migrate/20180410143714_create_search_queries.rb
@@ -1,8 +1,6 @@
 class CreateSearchQueries < ActiveRecord::Migration[5.0]
   def change
 
-    create_enum :search_query_type, 'search', 'filter'
-
     create_table :search_queries do |t|
       t.string :query_hash, null: false
       t.integer :user_id, null: false

--- a/db/migrate/20180419130340_add_parent_id_to_search_queries.rb
+++ b/db/migrate/20180419130340_add_parent_id_to_search_queries.rb
@@ -1,0 +1,8 @@
+class AddParentIdToSearchQueries < ActiveRecord::Migration[5.0]
+  def change
+    add_column :search_queries, :parent_id, :integer
+    add_column :search_queries, :query_type, :search_query_type, null: false, default: :search
+    add_column :search_queries, :filter_type, :string
+  end
+end
+

--- a/db/migrate/20180419130340_add_parent_id_to_search_queries.rb
+++ b/db/migrate/20180419130340_add_parent_id_to_search_queries.rb
@@ -1,4 +1,7 @@
 class AddParentIdToSearchQueries < ActiveRecord::Migration[5.0]
+
+  create_enum :search_query_type, 'search', 'filter'
+
   def change
     add_column :search_queries, :parent_id, :integer
     add_column :search_queries, :query_type, :search_query_type, null: false, default: :search

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.10
--- Dumped by pg_dump version 9.5.10
+-- Dumped from database version 9.5.6
+-- Dumped by pg_dump version 9.5.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -608,22 +608,52 @@ CREATE TABLE schema_migrations (
 
 
 --
+-- Name: search_index; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE search_index (
+    id integer NOT NULL,
+    case_id integer NOT NULL,
+    document tsvector NOT NULL
+);
+
+
+--
+-- Name: search_index_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE search_index_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: search_index_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE search_index_id_seq OWNED BY search_index.id;
+
+
+--
 -- Name: search_queries; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE search_queries (
     id integer NOT NULL,
-    user_id integer NOT NULL,
-    parent_id integer,
-    query_type search_query_type DEFAULT 'search'::search_query_type NOT NULL,
-    filter_type character varying,
-    query character varying NOT NULL,
     query_hash character varying NOT NULL,
+    user_id integer NOT NULL,
+    query character varying NOT NULL,
     num_results integer NOT NULL,
     num_clicks integer DEFAULT 0 NOT NULL,
     highest_position integer,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    parent_id integer,
+    query_type search_query_type DEFAULT 'search'::search_query_type NOT NULL,
+    filter_type character varying
 );
 
 
@@ -989,6 +1019,13 @@ ALTER TABLE ONLY reports ALTER COLUMN id SET DEFAULT nextval('reports_id_seq'::r
 -- Name: id; Type: DEFAULT; Schema: public; Owner: -
 --
 
+ALTER TABLE ONLY search_index ALTER COLUMN id SET DEFAULT nextval('search_index_id_seq'::regclass);
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY search_queries ALTER COLUMN id SET DEFAULT nextval('search_queries_id_seq'::regclass);
 
 
@@ -1159,6 +1196,14 @@ ALTER TABLE ONLY reports
 
 ALTER TABLE ONLY schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: search_index_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY search_index
+    ADD CONSTRAINT search_index_pkey PRIMARY KEY (id);
 
 
 --
@@ -1506,6 +1551,13 @@ CREATE INDEX index_versions_on_item_type_and_item_id ON versions USING btree (it
 
 
 --
+-- Name: search_index_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX search_index_idx ON search_index USING gin (document);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -1608,6 +1660,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180322183946'),
 ('20180406145035'),
 ('20180410142138'),
-('20180410143714');
+('20180410143714'),
+('20180419130340');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -79,6 +79,16 @@ CREATE TYPE requester_type AS ENUM (
 
 
 --
+-- Name: search_query_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE search_query_type AS ENUM (
+    'search',
+    'filter'
+);
+
+
+--
 -- Name: state; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -603,9 +613,12 @@ CREATE TABLE schema_migrations (
 
 CREATE TABLE search_queries (
     id integer NOT NULL,
-    query_hash character varying NOT NULL,
     user_id integer NOT NULL,
+    parent_id integer,
+    query_type search_query_type DEFAULT 'search'::search_query_type NOT NULL,
+    filter_type character varying,
     query character varying NOT NULL,
+    query_hash character varying NOT NULL,
     num_results integer NOT NULL,
     num_clicks integer DEFAULT 0 NOT NULL,
     highest_position integer,

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -29,7 +29,16 @@ namespace :db do
       conn.drop_table(table, force: :cascade)
     end
 
-    enum_types = %w(assignment_type attachment_type requester_type state user_role team_roles cases_delivery_methods)
+    enum_types = %w(
+      assignment_type
+      attachment_type
+      requester_type
+      state
+      user_role
+      team_roles
+      cases_delivery_methods
+      search_query_type
+    )
     enum_types.each do |type|
       conn.execute("DROP TYPE IF EXISTS #{type}")
     end

--- a/spec/controllers/cases_controller/show_spec.rb
+++ b/spec/controllers/cases_controller/show_spec.rb
@@ -385,17 +385,17 @@ describe CasesController, type: :controller do
       context 'has a hash parameter' do
         it 'records search query to record the click' do
           allow(controller).to receive(:flash).and_return(flash)
-          params = ActionController::Parameters.new(id: kase.id.to_s, hash: "XYZ", controller: "cases", action: "show")
-          expect(SearchQuery).to receive(:update_for_click).with(params, flash)
+          params = ActionController::Parameters.new(id: kase.id.to_s, pos: '4', controller: "cases", action: "show")
+          expect(SearchQuery).to receive(:update_for_click).with('XYZ', 4)
           get :show, params: params.to_unsafe_hash
         end
       end
 
-      context 'does not have a hash parameter' do
+      context 'no flash parameter' do
         it 'does not call search query to record the click' do
-          allow(controller).to receive(:flash).and_return(flash)
+          allow(controller).to receive(:flash).and_return( {} )
           params = ActionController::Parameters.new(id: kase.id.to_s, controller: "cases", action: "show")
-          expect(SearchQuery).not_to receive(:update_for_click).with(params, flash)
+          expect(SearchQuery).not_to receive(:update_for_click)
           get :show, params: params.to_unsafe_hash
         end
 

--- a/spec/factories/search_queries.rb
+++ b/spec/factories/search_queries.rb
@@ -1,12 +1,35 @@
+# == Schema Information
+#
+# Table name: search_queries
+#
+#  id               :integer          not null, primary key
+#  user_id          :integer          not null
+#  parent_id        :integer
+#  query_type       :enum             default("search"), not null
+#  filter_type      :string
+#  query            :string           not null
+#  query_hash       :string           not null
+#  num_results      :integer          not null
+#  num_clicks       :integer          default(0), not null
+#  highest_position :integer
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+
 FactoryGirl.define do
   factory :search_query do
-    query_hash 'XYZ'
+    query_hash { (0..10).map { ('a'..'z').to_a[rand(26)] }.join }
     user_id 3
     query 'Winnie the Pooh'
+    query_type 'search'
+    parent_id nil
     num_results 33
     num_clicks 0
     highest_position nil
+  end
 
+  trait :filter do
+    query_type 'filter'
   end
 
   trait :clicked do

--- a/spec/helpers/cases_helper_spec.rb
+++ b/spec/helpers/cases_helper_spec.rb
@@ -164,25 +164,18 @@ href=\"/cases/#{@case.id}/respond\">Mark response as sent</a>"
   describe '#case_link_with_hash' do
     let(:kase) {double 'case', id: 25, number: '180425001'}
 
-    context 'no query hash instance variable' do
-      it 'shows link without hash and position parameters' do
-        expected_link = "<a href=\"/cases/25\">180425001</a>"
-        expect(case_link_with_hash(kase, :number, nil, 3, 44)).to eq expected_link
-      end
-    end
-
     context 'query hash instance variable exists' do
       context 'page parameters exists' do
         it 'shows link with hash and position parameters' do
-          expected_link = "<a href=\"/cases/25?hash=XYZ&amp;pos=35\">180425001</a>"
-          expect(case_link_with_hash(kase, :number, 'XYZ', 2, 14)).to eq expected_link
+          expected_link = "<a href=\"/cases/25?pos=35\">180425001</a>"
+          expect(case_link_with_hash(kase, :number, 2, 14)).to eq expected_link
         end
       end
 
       context 'page number does not exist' do
         it 'shows link with hash and position parameters based on page 1' do
-          expected_link = "<a href=\"/cases/25?hash=XYZ&amp;pos=15\">180425001</a>"
-          expect(case_link_with_hash(kase, :number, 'XYZ', '', 14)).to eq expected_link
+          expected_link = "<a href=\"/cases/25?pos=15\">180425001</a>"
+          expect(case_link_with_hash(kase, :number, '', 14)).to eq expected_link
         end
       end
     end

--- a/spec/models/search_query_spec.rb
+++ b/spec/models/search_query_spec.rb
@@ -3,9 +3,12 @@
 # Table name: search_queries
 #
 #  id               :integer          not null, primary key
-#  query_hash       :string           not null
 #  user_id          :integer          not null
+#  parent_id        :integer
+#  query_type       :enum             default("search"), not null
+#  filter_type      :string
 #  query            :string           not null
+#  query_hash       :string           not null
 #  num_results      :integer          not null
 #  num_clicks       :integer          default(0), not null
 #  highest_position :integer
@@ -17,16 +20,82 @@ require 'rails_helper'
 
 describe SearchQuery do
 
+  describe 'tree functions' do
+
+    before(:each) do
+      @root             = create :search_query,
+                                 query_hash: 'ROOTX'
+      @child            = create :search_query, :filter,
+                                 query_hash: 'CHILD',
+                                 parent_id: @root.id,
+                                 query: 'type:foi-std'
+      @child_2          = create :search_query, :filter,
+                                 parent_id: @root.id,
+                                 query_hash: 'CHILD-2',
+                                 query: 'type:foi-irc'
+      @grandchild       = create :search_query, :filter,
+                                 parent_id: @child.id,
+                                 query_hash: 'GRAND-CHILD',
+                                 query: 'status:closed'
+      @greatgrandchild  = create :search_query, :filter,
+                                 parent_id: @grandchild.id,
+                                 query_hash: 'GREAT-GRAND-CHILD',
+                                 query: 'date:20180101-20180331'
+    end
+
+    describe 'root' do
+      it 'find the top-most ancestor' do
+        expect(@greatgrandchild.root).to eq @root
+      end
+    end
+
+    describe 'ancestors' do
+      context 'a child node' do
+        it 'returns an array of ancestors, root last' do
+          expect(@greatgrandchild.ancestors).to eq( [ @grandchild, @child, @root ] )
+        end
+      end
+
+      context 'the root node' do
+        it 'returns and empty array' do
+          expect(@root.ancestors).to be_empty
+        end
+      end
+    end
+
+    describe '.descendents' do
+      it 'returns and array of descendents, oldest child first' do
+        expect(@root.descendants).to eq( [ @child, @child_2, @grandchild, @greatgrandchild ] )
+      end
+    end
+
+    describe '.by_query_hash!' do
+      it 'finds the record with the specified query_hash' do
+        expect(SearchQuery.by_query_hash!('CHILD-2')).to eq @child_2
+      end
+    end
+
+    describe '.by_query_hash_with_ancestors!' do
+      it 'returns a collection of all ancestors including the specified record starting at the root' do
+        expected = [ @root, @child, @grandchild, @greatgrandchild ]
+        expect(SearchQuery.by_query_hash_with_ancestors!('GREAT-GRAND-CHILD')).to eq expected
+      end
+    end
+  end
+
+
+
   describe '.create_from_search_service' do
 
     let(:params)      { { query: 'cats and dogs', page: 2  } }
-    let(:user)        { double User, id: 1234 }
+    let(:user)        { create :manager }
     let(:service)     { CaseSearchService.new(user, params) }
-    let(:query_hash)  { Digest::SHA256.hexdigest "1234:2018-04-11:cats and dogs" }
+    let(:time)        { Time.new(2018, 4, 11, 12, 33, 22) }
+    let(:query_hash)  { CaseSearchService.generate_query_hash(user, 'search', nil, 'cats and dogs', time) }
 
     context 'no record with same query hash exists' do
       it 'writes a search_query_record' do
-        Timecop.freeze(Time.new(2018, 4, 11, 12, 33, 22)) do
+        Timecop.freeze(time) do
           allow(service).to receive(:unpaginated_result_set).and_return(double "result_set", size: 22)
           expect {
             SearchQuery.create_from_search_service(service)
@@ -47,10 +116,12 @@ describe SearchQuery do
                          query_hash:        query_hash,
                          user_id:           user.id,
                          query:             'cats and dogs',
+                         query_type:        'search',
                          num_results:       22,
                          num_clicks:        5,
                          highest_position:  3)
           allow(service).to receive(:unpaginated_result_set).and_return(double "result_set", size: 22)
+          allow(service).to receive(:query_hash).and_return(query_hash)
           expect {
             SearchQuery.create_from_search_service(service)
           }.not_to change { SearchQuery.count }
@@ -60,73 +131,66 @@ describe SearchQuery do
   end
 
   describe '.update_for_click' do
-    let(:position) { 3 }
-    let(:hash)             { 'XYZ' }
-    let(:params)           { { hash: hash, pos: position } }
+    let(:position)          { 3 }
+    let(:query_hash)        { 'XYZ' }
+    let(:params)            { { hash: query_hash, pos: position } }
 
     context 'the query hash is in the flash' do
 
       let(:flash)          { { query_hash: 'XYZ' } }
 
       context 'user clicks for the first time' do
-        let!(:record)      { create :search_query }
+        let!(:record)      { create :search_query, query_hash: query_hash }
 
         it 'records the click' do
-          SearchQuery.update_for_click(params, flash)
+          SearchQuery.update_for_click(query_hash, position)
           record.reload
           expect(record.num_clicks).to eq 1
         end
 
         it 'updates the highest position' do
-          SearchQuery.update_for_click(params, flash)
+          new_highest_position = 2
+          SearchQuery.update_for_click(query_hash, new_highest_position)
           record.reload
-          expect(record.highest_position).to eq position
+          expect(record.highest_position).to eq new_highest_position
         end
       end
 
       context 'user clicks on higher option' do
-        let!(:record)          { create :search_query, :clicked }
+        let!(:record)          { create :search_query, :clicked, query_hash: query_hash }
         let(:position) { 1 }
 
         it 'records the click' do
-          SearchQuery.update_for_click(params, flash)
+          SearchQuery.update_for_click(query_hash, position)
           record.reload
           expect(record.num_clicks).to eq 2
         end
 
         it 'updates the highest position' do
-          SearchQuery.update_for_click(params, flash)
+          SearchQuery.update_for_click(query_hash, position)
           record.reload
           expect(record.highest_position).to eq position
         end
       end
 
       context 'user clicks on a lower position' do
-        let!(:record)          { create :search_query, :clicked }
-        let(:position)         { 33 }
+        let(:query_hash)        { 'xxxx' }
+        let!(:record)           { create :search_query, :clicked, query_hash: query_hash }
+        let(:position)          { 33 }
 
         it 'records the click' do
-          SearchQuery.update_for_click(params, flash)
+          SearchQuery.update_for_click(query_hash, position)
           record.reload
           expect(record.num_clicks).to eq 2
         end
 
         it 'does not update the highest position' do
-          SearchQuery.update_for_click(params, flash)
+          SearchQuery.update_for_click(query_hash, position)
           record.reload
           expect(record.highest_position).to eq 3
         end
       end
     end
 
-    context 'the query hash is not in the hash' do
-      let(:flash)   { {} }
-      it 'does not update a search_query record' do
-        record = create :search_query
-        SearchQuery.update_for_click(params, flash)
-        record.reload
-        expect(record.num_clicks).to eq 0
-      end
-    end
   end
 end

--- a/spec/services/case_search_service_spec.rb
+++ b/spec/services/case_search_service_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 describe CaseSearchService do
 
+  let(:user)                      { create :manager }
+
   describe '#call' do
 
-    let(:user)                      { create :manager }
+
     let(:decorated_result_set)      { double 'Decorated result set'}
     let(:paginated_result_set)      { double 'Paginated Result Set', decorate: decorated_result_set }
     let(:unpaginated_result_set)    { double 'Unpaginated Result Set', page: paginated_result_set }
@@ -12,119 +14,233 @@ describe CaseSearchService do
     let(:service)                   { CaseSearchService.new(user, params) }
     let(:params)                    { ActionController::Parameters.new({query: specific_query, controller: 'cases', action: 'search'}) }
 
+    context 'no parent hash specified' do
 
-    context 'blank query' do
-      let(:specific_query)      { '  ' }
-      it 'errors' do
-        service.call
-        expect(service.error?).to be true
+      context 'blank query' do
+        let(:specific_query)      { '  ' }
+        it 'errors' do
+          service.call
+          expect(service.error?).to be true
+        end
+
+        it 'populates the error message' do
+          service.call
+          expect(service.error_message).to eq 'Specify what you want to search for'
+        end
+
+        it 'does not record a search_query record' do
+          expect(SearchQuery.count).to eq 0
+        end
       end
 
-      it 'populates the error message' do
-        service.call
-        expect(service.error_message).to eq 'Specify what you want to search for'
+      context 'no results' do
+        let(:specific_query)  { 'query resulting in no hits'}
+
+        it 'records a search_query record' do
+          service.call
+          expect(SearchQuery.count).to eq 1
+          sq = SearchQuery.first
+          expect(sq.query_hash).to eq service.query_hash
+          expect(sq.query).to eq specific_query
+          expect(sq.num_results).to eq 0
+        end
       end
 
-      it 'does not record a search_query record' do
-        expect(SearchQuery.count).to eq 0
+      context 'with results' do
+        before(:all) do
+          @assigned_case = create :assigned_case
+          @unassigned_case = create :case
+          Case::Base.update_all_indexes
+        end
+
+        after(:all)   { DbHousekeeping.clean }
+
+        context 'search by number' do
+          let(:specific_query)       { @assigned_case.number }
+
+          it 'finds a case by number' do
+            service.call
+            expect(service.result_set).to eq [ @assigned_case ]
+          end
+
+        end
+
+        context 'search by text' do
+          context 'no leading or trailing whitespace' do
+            let(:specific_query)   { 'assigned' }
+            it 'finds a case by text' do
+              service.call
+              expect(service.result_set).to eq [ @assigned_case ]
+            end
+
+            it 'records a search_query record' do
+              service.call
+              expect(SearchQuery.count).to eq 1
+              sq = SearchQuery.first
+              expect(sq.query_hash).to eq service.query_hash
+              expect(sq.query).to eq specific_query
+              expect(sq.num_results).to eq 1
+            end
+          end
+
+          context 'leading and trailing whitespace' do
+            let(:specific_query)      { '   assigned  ' }
+            it 'ignores leading and trailing whitespace' do
+              service.call
+              expect(service.result_set).to eq [ @assigned_case ]
+            end
+
+            it 'records a search_query record' do
+              service.call
+              expect(SearchQuery.count).to eq 1
+              sq = SearchQuery.first
+              expect(sq.query_hash).to eq service.query_hash
+              expect(sq.query).to eq specific_query.strip
+              expect(sq.num_results).to eq 1
+            end
+          end
+        end
+
+        context 'pagination' do
+          it 'passes the page param to the paginator' do
+            paged_cases = double('Paged Cases', decorate: [])
+            cases = double('Cases', page: paged_cases, empty?: true, size: 0)
+            allow(Case::Base).to receive(:search).and_return(cases)
+            params = ActionController::Parameters.new({query: 'xx', page: '3', controller: 'cases', action: 'search'})
+            service = CaseSearchService.new(user, params)
+            service.call
+            expect(cases).to have_received(:page).with('3')
+          end
+        end
       end
+
+      context 'use of the policy scope' do
+        let(:specific_query)    { 'my scoped query' }
+        it 'uses the policy scope' do
+          decorated_result_set = double 'Decorated result set', empty?: true, size: 0
+          paginated_result_set = double 'Paginated result set', decorate: decorated_result_set
+          unpaginated_result_set = double 'Unpaginated result set', page: paginated_result_set, size: 0
+          policy_scope = double 'Pundit Policy Scope'
+
+          allow(Pundit).to receive(:policy_scope!).and_return(policy_scope)
+          allow(policy_scope).to receive(:search).with('my scoped query').and_return(unpaginated_result_set)
+          service.call
+          expect(Pundit).to have_received(:policy_scope!).with(user, Case::Base)
+        end
+      end
+
     end
 
-    context 'no results' do
-      let(:specific_query)  { 'query resulting in no hits'}
+    context 'parent hash specified' do
 
-      it 'records a search_query record' do
-        service.call
-        expect(SearchQuery.count).to eq 1
-        sq = SearchQuery.first
-        expect(sq.query_hash).to eq service.query_hash
-        expect(sq.query).to eq specific_query
-        expect(sq.num_results).to eq 0
-      end
-    end
-
-    context 'with results' do
       before(:all) do
-        @assigned_case = create :assigned_case
-        @unassigned_case = create :case
+        @foi_1 = create :case, subject: 'dogs in prison'
+        @foi_2 = create :case, subject: 'dogs in jail'
+        @foi_3 = create :case, subject: 'dog eat dog mentality'
+        @irc_1 = create :compliance_review, subject: 'dogs in prison compliance review'
+        @irc_2 = create :compliance_review, subject: 'jail dog compliance review'
+        @irt_1 = create :timeliness_review, subject: 'dogs in prison timeliness review'
+        @irt_2 = create :timeliness_review, subject: 'jail dog timeliness review'
         Case::Base.update_all_indexes
       end
 
       after(:all)   { DbHousekeeping.clean }
 
-      context 'search by number' do
-        let(:specific_query)       { @assigned_case.number }
+      context 'parent search query is the root' do
+        let(:params)            { ActionController::Parameters.new({filter: 'type', query: 'internal_review'}) }
 
-        it 'finds a case by number' do
-          service.call
-          expect(service.result_set).to eq [ @assigned_case ]
+        before(:each) do
+          @sq = create :search_query,
+                      user_id: user.id,
+                      query_hash: 'ROOT SEARCH QUERY',
+                      query: 'dogs',
+                      parent_id: nil,
+                      num_results: 7
+          @service = CaseSearchService.new(user, params, 'ROOT SEARCH QUERY')
         end
 
-      end
-
-      context 'search by text' do
-        context 'no leading or trailing whitespace' do
-          let(:specific_query)   { 'assigned' }
-          it 'finds a case by text' do
-            service.call
-            expect(service.result_set).to eq [ @assigned_case ]
-          end
-
-          it 'records a search_query record' do
-            service.call
-            expect(SearchQuery.count).to eq 1
-            sq = SearchQuery.first
-            expect(sq.query_hash).to eq service.query_hash
-            expect(sq.query).to eq specific_query
-            expect(sq.num_results).to eq 1
-          end
+        it 'performs the parent_search first and then the CaseFilterService' do
+          expect_any_instance_of(Case::Base::ActiveRecord_Relation).to receive(:search).with('dogs').and_call_original
+          expect(CaseFilterService).to receive(:new).with(instance_of(Case::Base::ActiveRecord_Relation), instance_of(SearchQuery)).and_call_original
+          @service.call
         end
 
-        context 'leading and trailing whitespace' do
-          let(:specific_query)      { '   assigned  ' }
-          it 'ignores leading and trailing whitespace' do
-            service.call
-            expect(service.result_set).to eq [ @assigned_case ]
-          end
+        it 'returns just the internal review cases' do
+          @service.call
+          expect(@service.unpaginated_result_set.map(&:id)).to eq( [ @irc_1.id, @irc_2.id, @irt_1.id, @irt_2.id ] )
+        end
 
-          it 'records a search_query record' do
-            service.call
-            expect(SearchQuery.count).to eq 1
-            sq = SearchQuery.first
-            expect(sq.query_hash).to eq service.query_hash
-            expect(sq.query).to eq specific_query
-            expect(sq.num_results).to eq 1
-          end
+        it 'writes a child search query record' do
+          @service.call
+          expect(SearchQuery.count).to eq 2
+          sq = SearchQuery.last
+          expect(sq.user_id).to eq user.id
+          expect(sq.parent_id).to eq @sq.id
+          expect(sq.filter_type).to eq 'type'
+          expect(sq.query).to eq 'internal_review'
+          expect(sq.num_results).to eq 4
         end
       end
 
-      context 'pagination' do
-        it 'passes the page param to the paginator' do
-          paged_cases = double('Paged Cases', decorate: [])
-          cases = double('Cases', page: paged_cases, empty?: true, size: 0)
-          allow(Case::Base).to receive(:search).and_return(cases)
-          params = ActionController::Parameters.new({query: 'xx', page: '3', controller: 'cases', action: 'search'})
-          service = CaseSearchService.new(user, params)
-          service.call
-          expect(cases).to have_received(:page).with('3')
+      context 'parent search query is a child' do
+        let(:params)            { ActionController::Parameters.new({filter: 'type', query: 'compliance'}) }
+
+        before(:each) do
+          @sq_root = create :search_query,
+                            user_id: user.id,
+                            query_hash: 'ROOT SEARCH QUERY',
+                            query: 'dogs',
+                            parent_id: nil,
+                            num_results: 7
+          @sq_parent = create :search_query, :filter,
+                              user_id: user.id,
+                              query_hash: 'PARENT FILTER QUERY',
+                              filter_type: 'filter',
+                              query: 'internal_review',
+                              parent_id: @sq_root.id,
+                              num_results: 4
+
+          @service = CaseSearchService.new(user, params, 'PARENT FILTER QUERY')
+        end
+
+        it 'performs the parent searches and filters first and then the CaseFilterService' do
+          expect_any_instance_of(Case::Base::ActiveRecord_Relation).to receive(:search).with('dogs').and_call_original
+          expect(CaseFilterService).to receive(:new).with(instance_of(Case::Base::ActiveRecord_Relation), instance_of(SearchQuery)).exactly(2).and_call_original
+          @service.call
+        end
+
+        it 'returns just the internal review for compliance cases' do
+          @service.call
+          expect(@service.unpaginated_result_set.map(&:id)).to eq( [ @irc_1.id, @irc_2.id ] )
+        end
+
+        it 'writes a grandchild search query record' do
+          @service.call
+          expect(SearchQuery.count).to eq 3
+          sq = SearchQuery.last
+          expect(sq.user_id).to eq user.id
+          expect(sq.parent_id).to eq @sq_parent.id
+          expect(sq.filter_type).to eq 'type'
+          expect(sq.query).to eq 'compliance'
+          expect(sq.num_results).to eq 2
         end
       end
-    end
 
-    context 'use of the policy scope' do
-      let(:specific_query)    { 'my scoped query' }
-      it 'uses the policy scope' do
-        decorated_result_set = double 'Decorated result set', empty?: true, size: 0
-        paginated_result_set = double 'Paginated result set', decorate: decorated_result_set
-        unpaginated_result_set = double 'Unpaginated result set', page: paginated_result_set, size: 0
-        policy_scope = double 'Pundit Policy Scope'
 
-        allow(Pundit).to receive(:policy_scope!).and_return(policy_scope)
-        allow(policy_scope).to receive(:search).with('my scoped query').and_return(unpaginated_result_set)
-        service.call
-        expect(Pundit).to have_received(:policy_scope!).with(user, Case::Base)
+      context 'parent hash does not exist in database' do
+
+        let(:params)    { ActionController::Parameters.new({filter: 'type', query: 'internal_review'}) }
+
+        it 'raises' do
+          @service = CaseSearchService.new(user, params, 'NON-EXISTENT HASH')
+          expect {
+            @service .call
+          }.to raise_error ActiveRecord::RecordNotFound, "Couldn't find SearchQuery"
+        end
       end
+
     end
 
   end
 end
+

--- a/spec/site_prism/page_objects/pages/cases/search_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/search_page.rb
@@ -9,7 +9,7 @@ module PageObjects
         end
 
         element :search_query, 'input[type="search"]'
-        element :search_button, 'input.button'
+        element :search_button, 'input.button#search-button'
 
         element :search_results_count, '.search-results-summary'
 

--- a/spec/support/db_housekeeping.rb
+++ b/spec/support/db_housekeeping.rb
@@ -14,7 +14,11 @@ module DbHousekeeping
       teams
       teams_users_roles
       users
-      correspondence_types)
+      correspondence_types
+      cases_users_transitions_trackers
+      linked_cases
+      search_queries
+    )
     tables.each do |table|
       ActiveRecord::Base.connection.execute("TRUNCATE #{table}")
     end


### PR DESCRIPTION
…etrics

Filtering is usually carried out on a result set obtained as a result of a
search.  We don't want the search to be recorded as zero clicks, but rather
indicate that a filter was carried out on the search results (and maybe a
subsequent filter performed on that result set), and then record the number
of clicks against that.

This is acheived by writing a search query record which has a parent_id
relating it to the preceeding search or filter.

All of this is controlled by the CaseSearchService, which works out whether
or not this is child filter, and writes the appropriate record, performing t
the original search and then passing the arel thus obtained to
the CaseFilterService for filtering, before finally passing the filtered
result set back to the controller for display.

This PR implements a dummy filter action on the cases controller, which will
be replaced with the real filter when filtering is implemented.