### PR TITLE
CT-1671 fix "Take on" action on the case details page

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -330,6 +330,14 @@ class CasesController < ApplicationController
                                       kase: @case,
                                       team: BusinessUnit.dacu_disclosure,
                                       message: params[:message]).call
+
+    respond_to do |format|
+      format.js { render 'cases/unflag_for_clearance.js.erb' }
+      format.html do
+        flash[:notice] = "Case has been de-escalated. #{ get_de_escalated_undo_link }".html_safe
+        redirect_to case_path(@case)
+      end
+    end
   end
 
   def flag_for_clearance
@@ -337,6 +345,12 @@ class CasesController < ApplicationController
     CaseFlagForClearanceService.new(user: current_user,
                                     kase: @case,
                                     team: BusinessUnit.dacu_disclosure).call
+    respond_to do |format|
+      format.js { render 'cases/flag_for_clearance.js.erb' }
+      format.html do
+        redirect_to case_path(@case)
+      end
+    end
   end
 
   def approve_response_interstitial
@@ -724,5 +738,12 @@ class CasesController < ApplicationController
     @permitted_correspondence_types
   end
 
+
+  def get_de_escalated_undo_link
+    unlink_path = flag_for_clearance_case_path(id: @case.id)
+    view_context.link_to "Undo",
+                         unlink_path,
+                         { method: :patch, class: 'undo-de-escalate-link'}
+  end
 end
 #rubocop:enable Metrics/ClassLength

--- a/app/views/cases/_take_case_on_or_de_escalate.html.slim
+++ b/app/views/cases/_take_case_on_or_de_escalate.html.slim
@@ -3,12 +3,12 @@
             accept_case_assignment_path(case_details, case_details.approver_assignments.with_teams(current_user.teams).first),
             id: "take_case_on_#{case_details.id}",
             class: 'button take-case-on-link',
-            remote: true,
+            remote: !current_page?(case_path(case_details.id)),
             method: :patch
   - unless case_details.flagged_for_press_office_clearance? || case_details.flagged_for_private_office_clearance?
     = link_to 'De-escalate',
               unflag_for_clearance_case_path(id: case_details.id),
-              remote: true,
+              remote: !current_page?(case_path(case_details.id)),
               class: 'js-de-escalate-link secondard-action-link',
               method: :patch
 

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -204,86 +204,173 @@ RSpec.describe AssignmentsController, type: :controller do
           sign_in approver
         end
 
-        it 'uses the service' do
-          patch :accept, params: params, xhr: true
-          expect(CaseAcceptApproverAssignmentService)
-            .to have_received(:new)
-                  .with(user: approver, assignment: assignment)
+        context 'calling the action from an AJAX request' do
+          it 'uses the service' do
+            patch :accept, params: params, xhr: true
+            expect(CaseAcceptApproverAssignmentService)
+              .to have_received(:new)
+                    .with(user: approver, assignment: assignment)
+          end
+
+          context 'service succeeds' do
+            before do
+              allow(service).to receive(:call).and_return(true)
+            end
+
+            it 'records success' do
+              patch :accept, params: params, xhr: true
+              expect(assigns(:success)).to be true
+            end
+
+            it 'sets the message to success' do
+              patch :accept, params: params, xhr: true
+              expect(assigns(:message)).to eq 'Case taken on'
+            end
+
+            it 'renders the view' do
+              patch :accept, params: params, xhr: true
+              expect(response).to have_rendered('assignments/accept.js.erb')
+            end
+          end
+
+          context 'assignment is already accepted by user' do
+            before do
+              allow(service).to receive(:call).and_return(false)
+              allow(service).to receive(:result).and_return(:not_pending)
+              assignment.user = approver
+              assignment.accepted!
+              assignment.save!
+            end
+
+            it 'records success' do
+              patch :accept, params: params, xhr: true
+              expect(assigns(:success)).to be true
+            end
+
+            it 'sets the message to success' do
+              patch :accept, params: params, xhr: true
+              expect(assigns(:message)).to eq 'Case taken on'
+            end
+
+            it 'renders the view' do
+              patch :accept, params: params, xhr: true
+              expect(response).to have_rendered('assignments/accept.js.erb')
+            end
+          end
+
+
+          context 'assignment is already accepted by another user' do
+            let(:another_approver) { create :approver,
+                                            approving_team: approving_team }
+
+            before do
+              allow(service).to receive(:call).and_return(false)
+              allow(service).to receive(:result).and_return(:not_pending)
+              assignment.user = another_approver
+              assignment.accepted!
+              assignment.save!
+            end
+
+            it 'records failure' do
+              patch :accept, params: params, xhr: true
+              expect(assigns(:success)).to be false
+            end
+
+            it 'sets the message to already_accepted' do
+              patch :accept, params: params, xhr: true
+              expect(assigns(:message))
+                .to eq "Case already accepted by #{another_approver.full_name}"
+            end
+
+            it 'renders the view' do
+              patch :accept, params: params, xhr: true
+              expect(response).to have_rendered('assignments/accept.js.erb')
+            end
+          end
         end
 
-        context 'service succeeds' do
-          before do
-            allow(service).to receive(:call).and_return(true)
+        context 'calling the action from an http request' do
+          it 'uses the service' do
+            patch :accept, params: params
+            expect(CaseAcceptApproverAssignmentService)
+              .to have_received(:new)
+                    .with(user: approver, assignment: assignment)
           end
 
-          it 'records success' do
-            patch :accept, params: params, xhr: true
-            expect(assigns(:success)).to be true
+          context 'service succeeds' do
+            before do
+              allow(service).to receive(:call).and_return(true)
+            end
+
+            it 'records success' do
+              patch :accept, params: params
+              expect(assigns(:success)).to be true
+            end
+
+            it 'sets the message to success' do
+              patch :accept, params: params
+              expect(assigns(:message)).to eq 'Case taken on'
+            end
+
+            it 'renders the view' do
+              patch :accept, params: params
+              expect(response).to redirect_to case_path(assigned_case_flagged)
+            end
           end
 
-          it 'sets the message to success' do
-            patch :accept, params: params, xhr: true
-            expect(assigns(:message)).to eq 'Case taken on'
+          context 'assignment is already accepted by user' do
+            before do
+              allow(service).to receive(:call).and_return(false)
+              allow(service).to receive(:result).and_return(:not_pending)
+              assignment.user = approver
+              assignment.accepted!
+              assignment.save!
+            end
+
+            it 'records success' do
+              patch :accept, params: params
+              expect(assigns(:success)).to be true
+            end
+
+            it 'sets the message to success' do
+              patch :accept, params: params
+              expect(assigns(:message)).to eq 'Case taken on'
+            end
+
+            it 'renders the view' do
+              patch :accept, params: params
+              expect(response).to redirect_to case_path(id: assigned_case_flagged.id)
+            end
           end
 
-          it 'renders the view' do
-            patch :accept, params: params, xhr: true
-            expect(response).to have_rendered('assignments/accept')
-          end
-        end
 
-        context 'assignment is already accepted by user' do
-          before do
-            allow(service).to receive(:call).and_return(false)
-            allow(service).to receive(:result).and_return(:not_pending)
-            assignment.user = approver
-            assignment.accepted!
-            assignment.save!
-          end
+          context 'assignment is already accepted by another user' do
+            let(:another_approver) { create :approver,
+                                            approving_team: approving_team }
 
-          it 'records success' do
-            patch :accept, params: params, xhr: true
-            expect(assigns(:success)).to be true
-          end
+            before do
+              allow(service).to receive(:call).and_return(false)
+              allow(service).to receive(:result).and_return(:not_pending)
+              assignment.user = another_approver
+              assignment.accepted!
+              assignment.save!
+            end
 
-          it 'sets the message to success' do
-            patch :accept, params: params, xhr: true
-            expect(assigns(:message)).to eq 'Case taken on'
-          end
+            it 'records failure' do
+              patch :accept, params: params
+              expect(assigns(:success)).to be false
+            end
 
-          it 'renders the view' do
-            patch :accept, params: params, xhr: true
-            expect(response).to have_rendered('assignments/accept')
-          end
-        end
+            it 'sets the message to already_accepted' do
+              patch :accept, params: params
+              expect(assigns(:message))
+                .to eq "Case already accepted by #{another_approver.full_name}"
+            end
 
-
-        context 'assignment is already accepted by another user' do
-          let(:another_approver) { create :approver,
-                                          approving_team: approving_team }
-
-          before do
-            allow(service).to receive(:call).and_return(false)
-            allow(service).to receive(:result).and_return(:not_pending)
-            assignment.user = another_approver
-            assignment.accepted!
-            assignment.save!
-          end
-
-          it 'records failure' do
-            patch :accept, params: params, xhr: true
-            expect(assigns(:success)).to be false
-          end
-
-          it 'sets the message to already_accepted' do
-            patch :accept, params: params, xhr: true
-            expect(assigns(:message))
-              .to eq "Case already accepted by #{another_approver.full_name}"
-          end
-
-          it 'renders the view' do
-            patch :accept, params: params, xhr: true
-            expect(response).to have_rendered('assignments/accept')
+            it 'renders the view' do
+              patch :accept, params: params
+              expect(response).to redirect_to case_path(id: assigned_case_flagged.id)
+            end
           end
         end
       end
@@ -316,26 +403,54 @@ RSpec.describe AssignmentsController, type: :controller do
         sign_in approver
       end
 
-      it 'uses the service' do
-        patch :unaccept, params: params, xhr: true
-        expect(CaseUnacceptApproverAssignmentService)
-          .to have_received(:new).with(assignment: assignment)
-      end
-
-      context 'service succeeds' do
-        before do
-          allow(service).to receive(:call).and_return(true)
-        end
-
-        it 'renders the view' do
+      context 'calling the action from an AJAX request' do
+        it 'uses the service' do
           patch :unaccept, params: params, xhr: true
-          expect(response).to have_rendered('assignments/unaccept')
+          expect(CaseUnacceptApproverAssignmentService)
+            .to have_received(:new).with(assignment: assignment)
+        end
+
+        context 'service succeeds' do
+          before do
+            allow(service).to receive(:call).and_return(true)
+          end
+
+          it 'renders the view' do
+            patch :unaccept, params: params, xhr: true
+            expect(response).to have_rendered('assignments/unaccept.js.erb')
+          end
         end
       end
+
+      context 'calling the action from a HTTP request' do
+        it 'uses the service' do
+          patch :unaccept, params: params
+          expect(CaseUnacceptApproverAssignmentService)
+            .to have_received(:new).with(assignment: assignment)
+        end
+
+        context 'service succeeds' do
+          before do
+            allow(service).to receive(:call).and_return(true)
+          end
+
+          it 'redirects to case details page' do
+            patch :unaccept, params: params
+            expect(response).to redirect_to case_path(assigned_case_trigger)
+          end
+        end
+      end
+
     end
   end
 
   describe '#take_case_on' do
+    # let(:assigned_case)     { create :assigned_case }
+    # let(:assignment) { assigned_case_trigger.approver_assignments.first }
+    let(:assigned_case_flagged) { create :assigned_case, :flagged,
+                                       approving_team: approving_team }
+
+
     context 'as an anonymous user' do
       it 'redirects to login page' do
         patch :take_case_on, params: { id: assignment.id, case_id: assigned_case.id }
@@ -354,7 +469,12 @@ RSpec.describe AssignmentsController, type: :controller do
       it 'calls CaseFlagForClearanceService' do
         expect(CaseFlagForClearanceService).to receive(:new).with(user: press_officer, kase: assigned_case, team: press_office ).and_return(service)
         expect(service).to receive(:call).and_return(:ok)
-
+        # Create assignment for the undo link to hook into
+        create :approver_assignment,
+             case: assigned_case,
+             team: press_officer.approving_team,
+             state: 'pending',
+             user_id: nil
         patch :take_case_on, params: { id: assignment.id, case_id: assigned_case.id }
       end
 
@@ -362,6 +482,12 @@ RSpec.describe AssignmentsController, type: :controller do
         it 'it has success message' do
           expect(CaseFlagForClearanceService).to receive(:new).with(user: press_officer, kase: assigned_case, team: press_office ).and_return(service)
           expect(service).to receive(:call).and_return(:ok)
+          # Create assignment for the undo link to hook into
+        create :approver_assignment,
+             case: assigned_case,
+             team: press_officer.approving_team,
+             state: 'pending',
+             user_id: nil
 
           patch :take_case_on, params: { id: assignment.id, case_id: assigned_case.id }
           expect(assigns(:success)).to eq true

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -1206,15 +1206,18 @@ RSpec.describe CasesController, type: :controller do
           .to redirect_to(new_user_session_path)
       end
 
-      it 'does not call the service' do
-        patch :flag_for_clearance, params: params, xhr: true
-        expect(CaseFlagForClearanceService).not_to have_received(:new)
+      context 'calling the action from an AJAX request' do
+        it 'does not call the service' do
+          patch :flag_for_clearance, params: params, xhr: true
+          expect(CaseFlagForClearanceService).not_to have_received(:new)
+        end
+
+        it 'returns an error' do
+          patch :flag_for_clearance, params: params, xhr: true
+          expect(response).to have_http_status 401
+        end
       end
 
-      it 'returns an error' do
-        patch :flag_for_clearance, params: params, xhr: true
-        expect(response).to have_http_status 401
-      end
     end
 
     context 'as an authenticated responder' do
@@ -1240,23 +1243,46 @@ RSpec.describe CasesController, type: :controller do
         sign_in manager
       end
 
-      it 'instantiates and calls the service' do
-        patch :flag_for_clearance, params: params, xhr: true
-        expect(CaseFlagForClearanceService)
-          .to have_received(:new).with(user: manager,
-                                       kase: unflagged_case_decorated,
-                                       team: BusinessUnit.dacu_disclosure)
-        expect(service).to have_received(:call)
+      context 'calling the action from an AJAX request' do
+        it 'instantiates and calls the service' do
+          patch :flag_for_clearance, params: params, xhr: true
+          expect(CaseFlagForClearanceService)
+            .to have_received(:new).with(user: manager,
+                                         kase: unflagged_case_decorated,
+                                         team: BusinessUnit.dacu_disclosure)
+          expect(service).to have_received(:call)
+        end
+
+        it 'renders the view' do
+          patch :flag_for_clearance, params: params, xhr: true
+          expect(response).to have_rendered('cases/flag_for_clearance.js.erb')
+        end
+
+        it 'returns a success code' do
+          patch :flag_for_clearance, params: params, xhr: true
+          expect(response).to have_http_status 200
+        end
       end
 
-      it 'renders the view' do
-        patch :flag_for_clearance, params: params, xhr: true
-        expect(response).to have_rendered(:flag_for_clearance)
-      end
+      context 'calling the action from a HTTP request' do
+        it 'instantiates and calls the service' do
+          patch :flag_for_clearance, params: params
+          expect(CaseFlagForClearanceService)
+            .to have_received(:new).with(user: manager,
+                                         kase: unflagged_case_decorated,
+                                         team: BusinessUnit.dacu_disclosure)
+          expect(service).to have_received(:call)
+        end
 
-      it 'returns a success code' do
-        patch :flag_for_clearance, params: params, xhr: true
-        expect(response).to have_http_status 200
+        it 'renders the view' do
+          patch :flag_for_clearance, params: params
+          expect(response).to redirect_to(case_path(unflagged_case_decorated))
+        end
+
+        it 'returns a success code' do
+          patch :flag_for_clearance, params: params
+          expect(response).to have_http_status 302
+        end
       end
     end
 
@@ -1265,23 +1291,46 @@ RSpec.describe CasesController, type: :controller do
         sign_in disclosure_specialist
       end
 
-      it 'instantiates and calls the service' do
-        patch :flag_for_clearance, params: params, xhr: true
-        expect(CaseFlagForClearanceService)
-          .to have_received(:new).with(user: disclosure_specialist,
-                                       kase: unflagged_case_decorated,
-                                       team: BusinessUnit.dacu_disclosure)
-        expect(service).to have_received(:call)
+      context 'calls the action from an AJAX request' do
+        it 'instantiates and calls the service' do
+          patch :flag_for_clearance, params: params, xhr: true
+          expect(CaseFlagForClearanceService)
+            .to have_received(:new).with(user: disclosure_specialist,
+                                         kase: unflagged_case_decorated,
+                                         team: BusinessUnit.dacu_disclosure)
+          expect(service).to have_received(:call)
+        end
+
+        it 'renders the view' do
+          patch :flag_for_clearance, params: params, xhr: true
+          expect(response).to have_rendered('cases/flag_for_clearance.js.erb')
+        end
+
+        it 'returns success' do
+          patch :flag_for_clearance, params: params, xhr: true
+          expect(response).to have_http_status 200
+        end
       end
 
-      it 'renders the view' do
-        patch :flag_for_clearance, params: params, xhr: true
-        expect(response).to have_rendered(:flag_for_clearance)
-      end
+      context 'calls the action from a HTTP request' do
+        it 'instantiates and calls the service' do
+          patch :flag_for_clearance, params: params
+          expect(CaseFlagForClearanceService)
+            .to have_received(:new).with(user: disclosure_specialist,
+                                         kase: unflagged_case_decorated,
+                                         team: BusinessUnit.dacu_disclosure)
+          expect(service).to have_received(:call)
+        end
 
-      it 'returns success' do
-        patch :flag_for_clearance, params: params, xhr: true
-        expect(response).to have_http_status 200
+        it 'renders the view' do
+          patch :flag_for_clearance, params: params
+          expect(response).to redirect_to case_path(unflagged_case_decorated)
+        end
+
+        it 'returns success' do
+          patch :flag_for_clearance, params: params
+          expect(response).to have_http_status 302
+        end
       end
     end
   end


### PR DESCRIPTION
Users reported that that "Take on" button was not working on the case details
page. When I investigated this issue I discovered that it was taking the
case on but it was not displaying any changes to the page until the Users
refreshed the page.

The functionality to take/de-escalate/undo was copied between the "New cases"
case list page and the case details page. It relied purely on an AJAX request
which would work on the case list but was not designed to work on the case
details page. I did not just update the javascript as there was a lot of
other markup and functionality that the user would need to see and use
compared to the case list which is mainly used to take on cases in "Bulk".

As a solution to the problem, I added a `respond_to` to the action to either
render the actions javascript if it was an ajax request or redirect it to
the case details page if it was a normal HTTP request. If it is from the
redirect then we add a flash message confirming the change on long with
a link to the undo action.

While I was investigating, I discovered that Press/Private Office Users
cannot take on cases from the case details page. We should investigate
this as a separate ticket.