### PR TITLE
CT-1495 Limit scope for SAR cases

### DIFF
--- a/app/models/search_query.rb
+++ b/app/models/search_query.rb
@@ -136,9 +136,8 @@ class SearchQuery < ApplicationRecord
 
   def results(cases_list = nil)
     if root.query_type == 'search'
-      cases_list ||= Case::BasePolicy::Scope
-                       .new(User.find(user_id), Case::Base.all)
-                       .for_view_only
+
+      cases_list ||= Pundit.policy_scope(user, Case::Base.all)
       cases_list = cases_list.search(search_text)
     elsif cases_list.nil?
       raise ArgumentError.new("cannot perform filters without list of cases")

--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -443,11 +443,10 @@ class Case::BasePolicy < ApplicationPolicy
   end
 
   def show?
+    # this is just a catch-all in case we introduce a new type without a corresponding policy for the new type.
+    # For safety sake, we do not allow viewing
     clear_failed_checks
-
-    check(:user_is_a_manager_for_case) ||
-      check(:user_is_a_responder_for_case) ||
-      check(:user_is_an_approver_for_case)
+    false
   end
 
   private

--- a/app/policies/case/foi/standard_policy.rb
+++ b/app/policies/case/foi/standard_policy.rb
@@ -1,4 +1,42 @@
 class Case::FOI::StandardPolicy < Case::BasePolicy
+
+  class Scope
+    attr_reader :user, :scope
+
+
+    def initialize(user, scope)
+      @user  = user
+      @scope = scope
+    end
+
+    def resolve
+      scopes = []
+      if user.manager?
+        scopes << ->(inner_scope) { inner_scope.all }
+      end
+
+      if user.responder?
+        case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
+        scopes << -> (inner_scope) { inner_scope.where(id: case_ids) }
+      end
+
+      if user.approver?
+        scopes << ->(inner_scope) { inner_scope.all }
+      end
+
+      if scopes.present?
+        final_scope = scopes.shift.call(scope)
+        scopes.each do |scope_func|
+          final_scope.or(scope_func.call(scope))
+        end
+        final_scope
+      else
+        Case::FOI::Standard.none
+      end
+    end
+  end
+
+
   def can_request_further_clearance?
     clear_failed_checks
 

--- a/app/policies/case/foi/standard_policy.rb
+++ b/app/policies/case/foi/standard_policy.rb
@@ -16,8 +16,7 @@ class Case::FOI::StandardPolicy < Case::BasePolicy
       end
 
       if user.responder?
-        case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
-        scopes << -> (inner_scope) { inner_scope.where(id: case_ids) }
+        scopes << -> (inner_scope) { inner_scope.all }
       end
 
       if user.approver?

--- a/app/policies/case/sar_policy.rb
+++ b/app/policies/case/sar_policy.rb
@@ -42,8 +42,7 @@ class Case::SARPolicy < Case::BasePolicy
     clear_failed_checks
 
     check(:user_is_a_manager_for_case) ||
-      check(:user_is_a_responder_for_case) ||
-      check(:responding_team_is_linked_to_case)
+      check(:user_is_a_responder_for_case)
   end
 
   def new_case_link?

--- a/app/policies/case/sar_policy.rb
+++ b/app/policies/case/sar_policy.rb
@@ -1,5 +1,43 @@
 class Case::SARPolicy < Case::BasePolicy
 
+  class Scope
+
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user  = user
+      @scope = scope
+    end
+
+    def resolve
+      scopes = []
+
+      if user.manager?
+        scopes << ->(inner_scope) { inner_scope.all }
+      end
+
+      if user.responder?
+        case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
+        scopes << -> (inner_scope) { inner_scope.where(id: case_ids) }
+      end
+
+      if user.approver?
+        Case::SAR.none
+      end
+
+      if scopes.present?
+        final_scope = scopes.shift.call(scope)
+        scopes.each do |scope_func|
+          final_scope.or(scope_func.call(scope))
+        end
+        final_scope
+      else
+        Case::SAR.none
+      end
+    end
+
+  end
+
   def show?
     clear_failed_checks
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.9
--- Dumped by pg_dump version 9.5.9
+-- Dumped from database version 9.5.6
+-- Dumped by pg_dump version 9.5.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -190,8 +190,7 @@ CREATE TABLE case_attachments (
     key character varying,
     preview_key character varying,
     upload_group character varying,
-    user_id integer,
-    state character varying DEFAULT 'unprocessed'::character varying NOT NULL
+    user_id integer
 );
 
 
@@ -352,8 +351,8 @@ CREATE TABLE cases (
     info_held_status_id integer,
     type character varying,
     appeal_outcome_id integer,
-    document_tsvector tsvector,
-    dirty boolean DEFAULT false
+    dirty boolean DEFAULT false,
+    document_tsvector tsvector
 );
 
 
@@ -815,15 +814,6 @@ CREATE SEQUENCE teams_users_roles_id_seq
 --
 
 ALTER SEQUENCE teams_users_roles_id_seq OWNED BY teams_users_roles.id;
-
-
---
--- Name: test_json; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE test_json (
-    data text
-);
 
 
 --
@@ -1607,7 +1597,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180214163355'),
 ('20180222125345'),
 ('20180228174550'),
-('20180319202822'),
 ('20180321094200'),
 ('20180322183946'),
 ('20180406145035'),

--- a/spec/features/cases/foi/case_listing/open_cases_spec.rb
+++ b/spec/features/cases/foi/case_listing/open_cases_spec.rb
@@ -68,10 +68,14 @@ feature 'listing open cases on the system' do
     visit '/cases/open'
 
     cases = cases_page.case_list
-    expect(cases.count).to eq 3
-    expect(cases[0].number).to have_text @assigned_case_team_a.number
-    expect(cases[1].number).to have_text @assigned_case_coresponder_team_a.number
-    expect(cases[2].number).to have_text @assigned_case_dd_flagged.number
+    expect(cases.count).to eq 7
+    expect(cases[0].number).to have_text @assigned_case_late.number
+    expect(cases[1].number).to have_text @assigned_case_team_a.number
+    expect(cases[2].number).to have_text @assigned_case_coresponder_team_a.number
+    expect(cases[3].number).to have_text @assigned_case_dd_flagged.number
+    expect(cases[4].number).to have_text @assigned_case_team_b.number
+    expect(cases[5].number).to have_text @assigned_case_flagged_for_press_office_accepted.number
+    expect(cases[6].number).to have_text @unassigned_case.number
   end
 
   context 'press officer' do

--- a/spec/policies/base_policy_scope_spec.rb
+++ b/spec/policies/base_policy_scope_spec.rb
@@ -36,10 +36,11 @@ describe Case::BasePolicy::Scope do
       @unassigned_sar_case          = create :sar_case, name: 'unassigned SAR'
       @awaiting_responder_sar_case  = create :awaiting_responder_sar, name: 'SAR awaiting responder'
       @drafting_sar_case            = create :sar_being_drafted, responder: @responder, name: 'SAR being drafted'
+      @drafting_sar_case_other_team = create :sar_being_drafted, responder: @responder_2, name: 'SAR being drafted'
 
       @all_cases                    = Case::Base.all
       @existing_foi_cases           = Case::FOI::Standard.all
-      @responder_cases              = Case::Base.all - [@unassigned_case, @accepted_case_r2, @rejected_case, @unassigned_sar_case, @awaiting_responder_sar_case]
+      @responder_cases              = Case::Base.all - [@unassigned_sar_case, @awaiting_responder_sar_case, @drafting_sar_case_other_team]
 
     end
 
@@ -55,7 +56,7 @@ describe Case::BasePolicy::Scope do
       end
 
       context 'responders' do
-        it 'returns only cases assigned to their team' do
+        it 'returns all FOI cases plus SAR cases assigned to their team' do
           responder_scope = Pundit.policy_scope(@responder, Case::Base)
           expect(responder_scope).to match_array(@responder_cases)
         end

--- a/spec/policies/base_policy_scope_spec.rb
+++ b/spec/policies/base_policy_scope_spec.rb
@@ -6,86 +6,76 @@ describe Case::BasePolicy::Scope do
   describe 'case scope policy' do
 
     before(:all) do
-      @responding_team        = create :responding_team
-      @responding_team_2      = create :responding_team
-      @managing_team          = find_or_create :team_dacu
-      @dacu_disclosure        = find_or_create :team_dacu_disclosure
+      @responding_team              = create :responding_team
+      @responding_team_2            = create :responding_team
+      @managing_team                = find_or_create :team_dacu
+      @dacu_disclosure              = find_or_create :team_dacu_disclosure
 
-      @responder              = @responding_team.responders.first
-      @responder_2            = @responding_team_2.responders.first
-      @manager                = @managing_team.managers.first
-      @approver               = @dacu_disclosure.approvers.first
+      @responder                    = @responding_team.responders.first
+      @responder_2                  = @responding_team_2.responders.first
+      @manager                      = @managing_team.managers.first
+      @approver                     = @dacu_disclosure.approvers.first
 
-      @unassigned_case        = create :case, name: 'unassigned'
-      @assigned_case          = create :assigned_case,
-                                       responding_team: @responding_team, name: 'assigned R'
-      @accepted_case          = create :accepted_case,
-                                       responder: @responder,
-                                       manager: @manager, name: 'accepted R'
-      @accepted_case_r2       = create :accepted_case,
-                                       responder: @responder_2,
-                                       name: 'acceptd R2'
-      @rejected_case          = create :rejected_case,
-                                       responding_team: @responding_team,  name: 'rejected R'
-      @case_with_response     = create :case_with_response,
-                                       responder: @responder, name: 'with response R'
-      @responded_case         = create :responded_case,
-                                       responder: @responder, name: 'responded R'
-      @closed_case            = create :closed_case,
-                                       responder: @responder, name: 'closed R'
-      @existing_cases         = Case::Base.all
-      @responder_cases        = Case::Base.all - [@unassigned_case, @accepted_case_r2, @rejected_case]
+      @unassigned_case              = create :case, name: 'unassigned'
+      @assigned_case                = create :assigned_case,
+                                             responding_team: @responding_team, name: 'assigned R'
+      @accepted_case                = create :accepted_case,
+                                             responder: @responder,
+                                             manager: @manager, name: 'accepted R'
+      @accepted_case_r2             = create :accepted_case,
+                                             responder: @responder_2,
+                                             name: 'accepted R2'
+      @rejected_case                = create :rejected_case,
+                                             responding_team: @responding_team,  name: 'rejected R'
+      @case_with_response           = create :case_with_response,
+                                             responder: @responder, name: 'with response R'
+      @responded_case               = create :responded_case,
+                                             responder: @responder, name: 'responded R'
+      @closed_case                  = create :closed_case,
+                                             responder: @responder, name: 'closed R'
+      @unassigned_sar_case          = create :sar_case, name: 'unassigned SAR'
+      @awaiting_responder_sar_case  = create :awaiting_responder_sar, name: 'SAR awaiting responder'
+      @drafting_sar_case            = create :sar_being_drafted, responder: @responder, name: 'SAR being drafted'
+
+      @all_cases                    = Case::Base.all
+      @existing_foi_cases           = Case::FOI::Standard.all
+      @responder_cases              = Case::Base.all - [@unassigned_case, @accepted_case_r2, @rejected_case, @unassigned_sar_case, @awaiting_responder_sar_case]
+
     end
 
     after(:all)  { DbHousekeeping.clean }
 
-    context 'scope with no restrictions' do
-      it 'for managers - returns all cases' do
-        manager_scope = described_class.new(@manager, Case::Base.all).resolve
-        expect(manager_scope).to match_array(@existing_cases)
+
+    describe '#resolve'do
+      context 'managers' do
+        it 'returns all cases' do
+          manager_scope = Pundit.policy_scope(@manager, Case::Base.all)
+          expect(manager_scope).to match_array(@all_cases)
+        end
       end
 
-      it 'for responders - returns only cases assigned to their team' do
-        responder_scope = described_class.new(@responder, Case::Base.all).resolve
-        expect(responder_scope).to match_array(@responder_cases)
+      context 'responders' do
+        it 'returns only cases assigned to their team' do
+          responder_scope = Pundit.policy_scope(@responder, Case::Base)
+          expect(responder_scope).to match_array(@responder_cases)
+        end
       end
 
-      it 'for approvers - returns all cases' do
-        approver_scope = described_class.new(@approver, Case::Base.all).resolve
-        expect(approver_scope).to match_array(@existing_cases)
+      context 'approvers' do
+        it 'returns all FOI cases and no SAR cases' do
+          approver_scope = described_class.new(@approver, Case::Base.all).resolve
+          expect(approver_scope).to match_array(@existing_foi_cases)
+        end
       end
 
-      it 'for responder & manager - returns all cases' do
-        @responder.team_roles << TeamsUsersRole.new(team: @dacu_disclosure,
-                                                   role: 'manager')
-        resolved_scope = described_class.new(@responder, Case::Base.all).resolve
-        expect(resolved_scope).to match_array(@existing_cases)
-      end
-    end
-
-    context '#for_view_only' do
-      it 'returns all cases for managers' do
-        manager_scope = described_class.new(@manager, Case::Base.all).for_view_only
-        expect(manager_scope).to match_array(@existing_cases)
-      end
-
-      it 'for responders - returns all cases' do
-        responder_scope = described_class.new(@responder, Case::Base.all).for_view_only
-        expect(responder_scope).to match_array(@existing_cases)
-      end
-
-      it 'for approvers - returns all cases' do
-        approver_scope = described_class.new(@approver, Case::Base.all).for_view_only
-        expect(approver_scope).to match_array(@existing_cases)
-      end
-
-      it 'for responder & manager - returns all cases' do
-        @responder.team_roles << TeamsUsersRole.new(team: @dacu_disclosure,
-                                                    role: 'manager')
-        resolved_scope = described_class.new(@responder, Case::Base.all).for_view_only
-        expect(resolved_scope).to match_array(@existing_cases)
+      context 'user who is both manager and responder' do
+        it 'for responder & manager - returns all cases' do
+          @responder.team_roles << TeamsUsersRole.new(team: @dacu_disclosure,
+                                                     role: 'manager')
+          resolved_scope = described_class.new(@responder, Case::Base.all).resolve
+          expect(resolved_scope).to match_array(@all_cases)
+        end
       end
     end
-
   end
 end

--- a/spec/policies/cases/base_policy_spec.rb
+++ b/spec/policies/cases/base_policy_spec.rb
@@ -729,11 +729,11 @@ describe Case::BasePolicy do
   end
 
   permissions :show? do
-    it { should     permit(manager,               unassigned_case) }
+    it { should_not permit(manager,               unassigned_case) }
     it { should_not permit(responder,             unassigned_case) }
     it { should_not permit(disclosure_specialist, unassigned_case) }
-    it { should     permit(responder,             accepted_case) }
-    it { should     permit(disclosure_specialist, assigned_trigger_case) }
+    it { should_not permit(responder,             accepted_case) }
+    it { should_not permit(disclosure_specialist, assigned_trigger_case) }
   end
   
   permissions :remove_clearance? do

--- a/spec/policies/cases/sar_policy_spec.rb
+++ b/spec/policies/cases/sar_policy_spec.rb
@@ -54,7 +54,7 @@ describe Case::SARPolicy do
         end
       end
 
-      it { should     permit(responder,             unassigned_case) }
+      it { should_not permit(responder,             unassigned_case) }
       it { should_not permit(disclosure_specialist, unassigned_case) }
     end
   end

--- a/spec/services/case_finder_service_spec.rb
+++ b/spec/services/case_finder_service_spec.rb
@@ -111,11 +111,7 @@ describe CaseFinderService do
     describe '#for_user' do
       it 'returns a finder that with a finder scoped to the users cases' do
         finder = CaseFinderService.new(@responder)
-        expect(finder.for_user.scope).to match_array [
-                                           @assigned_newer_case,
-                                           @assigned_older_case,
-                                           @accepted_case
-                                         ]
+        expect(finder.for_user.scope).to match_array Case::Base.all
       end
     end
 

--- a/spec/services/case_search_service_spec.rb
+++ b/spec/services/case_search_service_spec.rb
@@ -30,7 +30,7 @@ describe CaseSearchService do
       let(:specific_query)    { 'my scoped query' }
       it 'uses the for_view_only policy scope' do
         expect(Case::BasePolicy::Scope).to receive(:new).with(user, Case::Base.all).and_call_original
-        expect_any_instance_of(Case::BasePolicy::Scope).to receive(:for_view_only).and_call_original
+        expect_any_instance_of(Case::BasePolicy::Scope).to receive(:resolve).and_call_original
         service.call
       end
     end


### PR DESCRIPTION
The scope for SAR cases is limited as follows:

 - Managers can see all SAR cases
 - responders can only see SAR cases assigned to their team
 - approvers can not see any SAR cases (this will change when we
   introduce trigger sars: Disclosure will be able to see trigger SARS
   but not press or private)

This is done by having the #resole method for Case::BasePolicy::Scope call