### PR TITLE
CT-1728 Remove sensitivity notice for SAR cases

### DIFF
--- a/db/migrate/20180530110444_change_escalation_time_limit_for_sars.rb
+++ b/db/migrate/20180530110444_change_escalation_time_limit_for_sars.rb
@@ -1,0 +1,17 @@
+class ChangeEscalationTimeLimitForSars < ActiveRecord::Migration[5.0]
+  def up
+    sar = CorrespondenceType.find_by(abbreviation: 'SAR')
+    if sar.present?
+      sar.escalation_time_limit = -1
+      sar.save!
+    end
+  end
+
+  def down
+    sar = CorrespondenceType.find_by(abbreviation: 'SAR')
+    if sar.present?
+      sar.escalation_time_limit = 0
+      sar.save!
+    end
+  end
+end

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -16,7 +16,7 @@ class CorrespondenceTypeSeeder
     rec = CorrespondenceType.new if rec.nil?
     rec.update!(name: 'Subject Access Request',
                 abbreviation: 'SAR',
-                escalation_time_limit: 0,
+                escalation_time_limit: -1,
                 internal_time_limit: 10,
                 external_time_limit: 30,
                 deadline_calculator_class: 'CalendarDays')

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.9
--- Dumped by pg_dump version 9.5.9
+-- Dumped from database version 9.5.6
+-- Dumped by pg_dump version 9.5.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -190,8 +190,7 @@ CREATE TABLE case_attachments (
     key character varying,
     preview_key character varying,
     upload_group character varying,
-    user_id integer,
-    state character varying DEFAULT 'unprocessed'::character varying NOT NULL
+    user_id integer
 );
 
 
@@ -352,8 +351,8 @@ CREATE TABLE cases (
     info_held_status_id integer,
     type character varying,
     appeal_outcome_id integer,
-    document_tsvector tsvector,
-    dirty boolean DEFAULT false
+    dirty boolean DEFAULT false,
+    document_tsvector tsvector
 );
 
 
@@ -815,15 +814,6 @@ CREATE SEQUENCE teams_users_roles_id_seq
 --
 
 ALTER SEQUENCE teams_users_roles_id_seq OWNED BY teams_users_roles.id;
-
-
---
--- Name: test_json; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE test_json (
-    data text
-);
 
 
 --
@@ -1607,7 +1597,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180214163355'),
 ('20180222125345'),
 ('20180228174550'),
-('20180319202822'),
 ('20180321094200'),
 ('20180322183946'),
 ('20180406145035'),
@@ -1620,6 +1609,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180508131152'),
 ('20180517140929'),
 ('20180522132456'),
-('20180524132031');
+('20180524132031'),
+('20180530110444');
 
 

--- a/spec/factories/correspondence_types.rb
+++ b/spec/factories/correspondence_types.rb
@@ -26,7 +26,7 @@ FactoryGirl.define do
   factory :sar_correspondence_type, parent: :correspondence_type do
     name 'Subject Access Request'
     abbreviation 'SAR'
-    escalation_time_limit 3
+    escalation_time_limit(-1)
     internal_time_limit 10
     external_time_limit 30
     deadline_calculator_class 'CalendarDays'

--- a/spec/services/deadline_calculator/calendar_days_spec.rb
+++ b/spec/services/deadline_calculator/calendar_days_spec.rb
@@ -7,9 +7,9 @@ describe DeadlineCalculator::CalendarDays do
 
   context 'SAR case' do
     describe 'escalation deadline' do
-      it 'is 3 calendar days after the date of creation' do
+      it 'is 1 calendar day before creation' do
         expect(deadline_calculator.escalation_deadline)
-          .to eq 3.days.since(sar_case.created_at.to_date)
+          .to eq sar_case.created_at.to_date - 1.day
       end
     end
 


### PR DESCRIPTION
This is acheived by setting the escalation date to the day before
the creation date.  This prevents the sensitivity banner from ever
being displayed, as the escalation date is always in the past.