### PR TITLE
CT-1729 display clearance info immediately for SAR cases

### DIFF
--- a/app/models/case/sar.rb
+++ b/app/models/case/sar.rb
@@ -56,9 +56,13 @@ class Case::SAR < Case::Base
   # The method below is overiding the close method in the case_states.rb file.
   # This is so that the case is closed with the responder's team instead of the manager's team
 
-   def close(current_user)
-     state_machine.close!(acting_user: current_user, acting_team: self.responding_team)
-   end
+  def close(current_user)
+    state_machine.close!(acting_user: current_user, acting_team: self.responding_team)
+  end
+
+  def within_escalation_deadline?
+    false
+  end
 
   private
 

--- a/spec/features/cases/sar/case_creating/creating_spec.rb
+++ b/spec/features/cases/sar/case_creating/creating_spec.rb
@@ -17,8 +17,12 @@ feature 'SAR Case creation by a manager' do
   scenario 'creating a case that does not need clearance', js: true do
     create_sar_case_step
 
-    assign_case_step business_unit: responder.responding_teams.first
+    responding_team = responder.responding_teams.first
+    assign_case_step business_unit: responding_team
 
+    # Clearance level should display deputy director
+    expect(cases_show_page.clearance_levels.basic_details.deputy_director.text)
+      .to include responding_team.team_lead
   end
 
   # scenario 'creating a case with request attachments', js: true  do

--- a/spec/models/case/sar_spec.rb
+++ b/spec/models/case/sar_spec.rb
@@ -87,6 +87,13 @@ describe Case::SAR do
     end
   end
 
+  describe '#within_escalation_deadline?' do
+    it 'returns false' do
+      sar = build(:sar_case)
+      expect(sar.within_escalation_deadline?).to be_falsey
+    end
+  end
+
   describe '#uploaded_request_files' do
     it 'validates presence if message is missing' do
       kase = build :sar_case, uploaded_request_files: [], message: ''


### PR DESCRIPTION
As with FOIs, the clearance info was not being displayed until the escalation
deadline had been met. This change ensures that it's displayed by always
returning false for the "within_esclation_deadline?" predicate.