### PR TITLE
CT-1405 Allow users to see closed SAR cases

### DIFF
--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -85,10 +85,16 @@ class CaseFinderService
   end
 
   def open_cases_scope
-    scope.opened
+    open_scope = scope.opened
       .joins(:assignments)
       .where(assignments: { state: ['pending', 'accepted']})
       .distinct('case.id')
+    if user.responder?
+      case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
+      open_scope.where(id: case_ids)
+    else
+      open_scope
+    end
   end
 
   def open_flagged_for_approval_scope

--- a/app/views/cases/closed_cases.html.slim
+++ b/app/views/cases/closed_cases.html.slim
@@ -9,9 +9,12 @@
       colgroup
         col
         col
+        col
       thead
         th scope='col'
           = t('.number_html')
+        th scope='col'
+          = t('common.case_list.type')
         th.closed-case-heading scope='col'
           = t('.name-subject')
       tbody
@@ -22,6 +25,9 @@
                 = t('.view_case')
               = " "
               = link_to kase.number, case_path(kase.id)
+            td aria-label="#{t('common.case_list.type')}"
+              = "#{kase.pretty_type} "
+              = kase.trigger_case_marker
             td aria-label="#{t('.name-subject')}"
               strong
                 = kase.name

--- a/spec/features/cases/foi/case_listing/open_cases_spec.rb
+++ b/spec/features/cases/foi/case_listing/open_cases_spec.rb
@@ -68,14 +68,10 @@ feature 'listing open cases on the system' do
     visit '/cases/open'
 
     cases = cases_page.case_list
-    expect(cases.count).to eq 7
-    expect(cases[0].number).to have_text @assigned_case_late.number
-    expect(cases[1].number).to have_text @assigned_case_team_a.number
-    expect(cases[2].number).to have_text @assigned_case_coresponder_team_a.number
-    expect(cases[3].number).to have_text @assigned_case_dd_flagged.number
-    expect(cases[4].number).to have_text @assigned_case_team_b.number
-    expect(cases[5].number).to have_text @assigned_case_flagged_for_press_office_accepted.number
-    expect(cases[6].number).to have_text @unassigned_case.number
+    expect(cases.count).to eq 3
+    expect(cases[0].number).to have_text @assigned_case_team_a.number
+    expect(cases[1].number).to have_text @assigned_case_coresponder_team_a.number
+    expect(cases[2].number).to have_text @assigned_case_dd_flagged.number
   end
 
   context 'press officer' do

--- a/spec/services/case_finder_service_spec.rb
+++ b/spec/services/case_finder_service_spec.rb
@@ -248,6 +248,40 @@ describe CaseFinderService do
       end
     end
 
+    describe '#open_cases_scope' do
+      context 'responder' do
+        it 'only includes cases assigned to user teams' do
+          finder = CaseFinderService.new(@responder)
+          expect(finder.__send__ :open_cases_scope).to match_array [
+                                                                       @accepted_case,
+                                                                       @assigned_newer_case,
+                                                                       @assigned_older_case
+                                                                   ]
+        end
+      end
+      context 'non-responder' do
+        it 'includes all assigned cases' do
+          finder = CaseFinderService.new(@manager)
+          expect(finder.__send__ :open_cases_scope).to match_array [
+              @older_case_1,
+              @older_case_2,
+              @assigned_older_case,
+              @older_dacu_flagged_case,
+              @older_dacu_flagged_accept,
+              @case_1,
+              @case_2,
+              @newer_case_1,
+              @newer_case_2,
+              @assigned_newer_case,
+              @assigned_other_team,
+              @newer_dacu_flagged_case,
+              @newer_dacu_flagged_accept,
+              @accepted_case
+          ]
+        end
+      end
+    end
+
   end
 
   context 'mix of FOI cases including compliance review cases' do

--- a/spec/site_prism/page_objects/pages/cases/closed_cases_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/closed_cases_page.rb
@@ -15,7 +15,8 @@ module PageObjects
           section :table_body, 'tbody' do
             sections :closed_case_rows, 'tr' do
               element :case_number, 'td:nth-child(1)'
-              section :subject_name, 'td:nth-child(2)' do
+              element :case_type, 'td:nth-child(2)'
+              section :subject_name, 'td:nth-child(3)' do
                 element :name, 'strong'
                 element :subject, 'span'
               end


### PR DESCRIPTION
In fact, all users that need to see closed SAR cases (BMT and responders)
can see them, but cannot distinguish between SAR cases and FOI cases.  This PR
adds the Type column on the closed case list to show the type (FOI or SAR) as well
as the trigger badge.

This PR also fixes an issue with the scope for responders showing cases assigned to 
all business units, not just those which the current user is a member of.