### PR TITLE
CT-1741 press and private officers are now in CorrespondenceType

### DIFF
--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -503,6 +503,17 @@ class Case::Base < ApplicationRecord
     self.class.type_abbreviation
   end
 
+  # Return the CorrespondenceType object for this case.
+  #
+  # The CorrespondenceType is determined by the class of this case, which must
+  # define the method <tt>type_abbreviation</tt> as a class method. This must
+  # match an abbreviation of an existing CorrespondenceType object.
+  #
+  # As this isn't expressed with Rails relationships, the CorrespondenceType
+  # object is cached inside the case object. For environments where the
+  # CorrespondenceType object can change you may need to reload this object to
+  # ensure you have the latest. For example in tests, when expecting a
+  # default_press_officer to be defined on the CorrespondenceType for this case.
   def correspondence_type
     @correspondence_type ||=
       CorrespondenceType.find_by!(abbreviation: type_abbreviation)

--- a/app/models/correspondence_type.rb
+++ b/app/models/correspondence_type.rb
@@ -16,7 +16,9 @@ class CorrespondenceType < ApplicationRecord
                  internal_time_limit: :integer,
                  external_time_limit: :integer,
                  escalation_time_limit: :integer,
-                 deadline_calculator_class: :string
+                 deadline_calculator_class: :string,
+                 default_press_officer: :string,
+                 default_private_officer: :string
 
   enum deadline_calculator_class: {
          'BusinessDays' => 'BusinessDays',

--- a/app/services/default_team_service.rb
+++ b/app/services/default_team_service.rb
@@ -21,7 +21,7 @@ class DefaultTeamService
        },
        {
          team: BusinessUnit.press_office,
-         user: User.find_by!(full_name: default_press_officer)
+         user: User.find_by!(email: default_press_officer)
        }]
     when BusinessUnit.press_office
       [{
@@ -30,7 +30,7 @@ class DefaultTeamService
        },
        {
          team: BusinessUnit.private_office,
-         user: User.find_by!(full_name: default_private_officer)
+         user: User.find_by!(email: default_private_officer)
        }]
     else
       []

--- a/app/services/default_team_service.rb
+++ b/app/services/default_team_service.rb
@@ -2,7 +2,6 @@ class DefaultTeamService
 
   def initialize(kase)
     @case = kase
-    @config = config_for_case
   end
 
   def managing_team
@@ -22,7 +21,7 @@ class DefaultTeamService
        },
        {
          team: BusinessUnit.press_office,
-         user: User.find_by!(full_name: Settings.press_office_default_user)
+         user: User.find_by!(full_name: default_press_officer)
        }]
     when BusinessUnit.press_office
       [{
@@ -31,7 +30,7 @@ class DefaultTeamService
        },
        {
          team: BusinessUnit.private_office,
-         user: User.find_by!(full_name: Settings.private_office_default_user)
+         user: User.find_by!(full_name: default_private_officer)
        }]
     else
       []
@@ -40,8 +39,11 @@ class DefaultTeamService
 
   private
 
-  def config_for_case
-    cat = @case.type_abbreviation.downcase
-    Settings["#{cat}_cases"]
+  def default_press_officer
+    @case.correspondence_type.default_press_officer
+  end
+
+  def default_private_officer
+    @case.correspondence_type.default_private_officer
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,8 +49,6 @@ default_time_format: '%d %b %Y %H:%M'
 
 press_office_team_name: Press Office
 private_office_team_name: Private Office
-press_office_default_user: Preston Offman
-private_office_default_user: Primrose Offord
 
 press_office_team_code: PRESS-OFFICE
 private_office_team_code: PRIVATE-OFFICE

--- a/db/seeders/case_closure_metadata_seeder.rb
+++ b/db/seeders/case_closure_metadata_seeder.rb
@@ -60,9 +60,22 @@ module CaseClosure
         abbreviation: 'notmet',
         sequence_id: 130)
 
+      # Old refusal reason, replaced by the one below.
+      #
+      # Necessary to run 'db:setup' because it looks like these refusal reasons
+      # are already created at that point, and we get the error:
+      #
+      #   ActiveRecord::RecordInvalid: Validation failed: Abbreviation has already been taken
+      #
+      # RefusalReason.find_or_create_by!(
+      #   subtype: nil,
+      #   name: '(s12) - Exceeded cost',
+      #   abbreviation: 'cost',
+      #   sequence_id: 140)
+
       RefusalReason.find_or_create_by!(
         subtype: nil,
-        name: '(s12) - Exceeded cost',
+        name: '(s12(2)) - Exceeded cost to investigate',
         abbreviation: 'cost',
         sequence_id: 140)
 

--- a/db/seeders/dev_user_seeder.rb
+++ b/db/seeders/dev_user_seeder.rb
@@ -42,7 +42,8 @@ class DevUserSeeder
   # rubocop:enable Metrics/MethodLength
 
 
-  def seed! # rubocop:disable Metrics/MethodLength
+  def seed! # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    foi = CorrespondenceType.foi
     @users.each do |user_name, user_info_list|
       user_info_list.each do |user_info|
         team_abbr = user_info[:team]
@@ -72,6 +73,14 @@ class DevUserSeeder
             user.team_roles.create(role: 'admin')
           end
         end
+
+        if team == 'pressoffice' && foi.default_press_officer.blank?
+          foi.update!(default_press_officer: email)
+        end
+
+        if team == 'privateoffice' && foi.default_private_officer.blank?
+          foi.update!(default_private_officer: email)
+        end
       end
     end
 
@@ -100,11 +109,6 @@ class DevUserSeeder
     TeamsUsersRole.find_or_create_by!(team: BusinessUnit.dacu_bmt, user: smoketest_user, role: 'manager') do
       puts 'Created Team/Role link to user'
     end
-
-    first_press_officer = get_team_users('pressoffice').first
-    first_private_officer = get_team_users('privateoffice').first
-    CorrespondenceType.foi.update!(default_press_officer: first_press_officer,
-                                   default_private_officer: first_private_officer)
   end
 
   private

--- a/db/seeders/dev_user_seeder.rb
+++ b/db/seeders/dev_user_seeder.rb
@@ -42,8 +42,7 @@ class DevUserSeeder
   # rubocop:enable Metrics/MethodLength
 
 
-  #rubocop:disable Metrics/MethodLength
-  def seed!
+  def seed! # rubocop:disable Metrics/MethodLength
     @users.each do |user_name, user_info_list|
       user_info_list.each do |user_info|
         team_abbr = user_info[:team]
@@ -101,13 +100,25 @@ class DevUserSeeder
     TeamsUsersRole.find_or_create_by!(team: BusinessUnit.dacu_bmt, user: smoketest_user, role: 'manager') do
       puts 'Created Team/Role link to user'
     end
+
+    first_press_officer = get_team_users('pressoffice').first
+    first_private_officer = get_team_users('privateoffice').first
+    CorrespondenceType.foi.update!(default_press_officer: first_press_officer,
+                                   default_private_officer: first_private_officer)
   end
-  #rubocop:enable Metrics/MethodLength
 
   private
 
   def email_from_name(name)
     email_name = name.downcase.tr(' ', '.').gsub(/\.{2,}/, '.')
     "correspondence-staff-dev+#{email_name}@digital.justice.gov.uk"
+  end
+
+  def get_team_users(team_name)
+    @users.select do |_name, teams|
+      teams.find do |team|
+        team[:team] == team_name
+      end
+    end.map(&:first)
   end
 end

--- a/db/seeders/report_type_seeder.rb
+++ b/db/seeders/report_type_seeder.rb
@@ -7,7 +7,7 @@ class ReportTypeSeeder
     ReportType.find_or_create_by!(abbr:'R003', full_name: 'Business unit report', class_name: 'Stats::R003BusinessUnitPerformanceReport' , custom_report: true, seq_id: 200)
     ReportType.find_or_create_by!(abbr:'R004', full_name: 'Cabinet Office report', class_name: 'Stats::R004CabinetOfficeReport', custom_report: false, seq_id: 400)
     ReportType.find_or_create_by!(abbr:'R005', full_name: 'Monthly report', class_name: 'Stats::R005MonthlyPerformanceReport',custom_report: true, seq_id: 300)
-    ReportType.find_or_create_by!(abbr:'R006', full_name: 'Business unit map', class_name: 'Stats::R006KiloMap', custom_report: false, seq_id: 9999)
+    ReportType.find_or_create_by!(abbr:'R006', full_name: 'Business Unit Map', class_name: 'Stats::R006KiloMap', custom_report: false, seq_id: 9999)
   end
 end
 

--- a/spec/controllers/cases_controller/show_spec.rb
+++ b/spec/controllers/cases_controller/show_spec.rb
@@ -167,8 +167,8 @@ describe CasesController, type: :controller do
         it { should have_nil_permitted_events }
 
         it 'renders the show template for the responder assignment' do
+          assigned_case.correspondence_type.reload
           responder_assignment = assigned_case.assignments.last
-          create :default_press_officer
           CaseFlagForClearanceService.new(user: press_officer, kase: assigned_case, team: press_office).call
           expect(response)
             .to redirect_to(edit_case_assignment_path(

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -510,8 +510,8 @@ RSpec.describe CasesController, type: :controller do
         it { should have_nil_permitted_events }
 
         it 'renders the show template for the responder assignment' do
+          assigned_case.correspondence_type.reload
           responder_assignment = assigned_case.assignments.last
-          create :default_press_officer
           CaseFlagForClearanceService.new(user: press_officer, kase: assigned_case, team: press_office).call
           expect(response)
               .to redirect_to(edit_case_assignment_path(

--- a/spec/factories/correspondence_types.rb
+++ b/spec/factories/correspondence_types.rb
@@ -12,15 +12,13 @@
 
 FactoryGirl.define do
   factory :correspondence_type, aliases: [:foi_correspondence_type] do
-
     name "Freedom of information request"
     abbreviation "FOI"
     escalation_time_limit 3
     internal_time_limit 10
     external_time_limit 20
     deadline_calculator_class 'BusinessDays'
-    default_press_officer 'Preston Offman'
-    default_private_officer 'Primrose Offord'
+
     initialize_with { CorrespondenceType.find_or_create_by(name: name) }
   end
 

--- a/spec/factories/correspondence_types.rb
+++ b/spec/factories/correspondence_types.rb
@@ -19,7 +19,8 @@ FactoryGirl.define do
     internal_time_limit 10
     external_time_limit 20
     deadline_calculator_class 'BusinessDays'
-
+    default_press_officer 'Preston Offman'
+    default_private_officer 'Primrose Offord'
     initialize_with { CorrespondenceType.find_or_create_by(name: name) }
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -148,16 +148,13 @@ FactoryGirl.define do
 
       full_name      { generate(:press_officer_name) }
       approving_team { find_or_create(:team_press_office) }
+
     end
 
-    factory :default_press_officer do
-      transient do
-        foi { find_or_create :foi_correspondence_type }
-        identifier 'default press-office approving user'
+    factory :default_press_officer, parent: :press_officer do
+      after(:create) do |user|
+        CorrespondenceType.foi.update!(default_press_officer: user.email)
       end
-
-      full_name { foi.default_press_officer }
-      approving_team { find_or_create(:team_press_office) }
     end
 
     factory :private_officer do
@@ -169,14 +166,10 @@ FactoryGirl.define do
       approving_team { find_or_create(:team_private_office) }
     end
 
-    factory :default_private_officer do
-      transient do
-        foi { find_or_create :foi_correspondence_type }
-        identifier 'default private-office approving user'
+    factory :default_private_officer, parent: :private_officer do
+      after(:create) do |user|
+        CorrespondenceType.foi.update!(default_private_officer: user.email)
       end
-
-      full_name { foi.default_private_officer }
-      approving_team { find_or_create(:team_private_office) }
     end
 
     factory :deactivated_user do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -152,10 +152,11 @@ FactoryGirl.define do
 
     factory :default_press_officer do
       transient do
+        foi { find_or_create :foi_correspondence_type }
         identifier 'default press-office approving user'
       end
 
-      full_name { Settings.press_office_default_user }
+      full_name { foi.default_press_officer }
       approving_team { find_or_create(:team_press_office) }
     end
 
@@ -170,10 +171,11 @@ FactoryGirl.define do
 
     factory :default_private_officer do
       transient do
+        foi { find_or_create :foi_correspondence_type }
         identifier 'default private-office approving user'
       end
 
-      full_name { Settings.private_office_default_user }
+      full_name { foi.default_private_officer }
       approving_team { find_or_create(:team_private_office) }
     end
 

--- a/spec/features/cases/foi/case_approvals/press_office_approvals_spec.rb
+++ b/spec/features/cases/foi/case_approvals/press_office_approvals_spec.rb
@@ -4,12 +4,12 @@ feature 'cases requiring clearance by press office' do
   given(:dacu_disclosure)             { find_or_create :team_dacu_disclosure }
   given(:disclosure_specialist)       { create :disclosure_specialist }
   given(:other_disclosure_specialist) { create :disclosure_specialist }
-  given!(:press_officer)              { create :press_officer }
+  given!(:press_officer)              { find_or_create :default_press_officer }
   given(:other_press_officer)         { create :press_officer }
   given!(:press_office)               { find_or_create :team_press_office }
   given!(:private_office)             { find_or_create :team_private_office }
-  given!(:private_officer)            { create :private_officer,
-                                               full_name: 'Primrose Offord' }
+  given!(:private_officer)            { find_or_create :default_private_officer,
+                                                       full_name: 'Primrose Offord' }
   given(:pending_dacu_clearance_case) do
     create :pending_dacu_clearance_case,
            :flagged_accepted,

--- a/spec/features/cases/foi/case_approvals/private_office_approvals_spec.rb
+++ b/spec/features/cases/foi/case_approvals/private_office_approvals_spec.rb
@@ -5,10 +5,10 @@ feature 'cases requiring clearance by press office' do
   given(:disclosure_specialist) {create :disclosure_specialist}
   given(:other_disclosure_specialist) {create :disclosure_specialist}
   given!(:press_office) {find_or_create :team_press_office}
-  given!(:press_officer) {create :press_officer,
-                                 full_name: 'Preston Offman'}
+  given!(:press_officer) {find_or_create :default_press_officer,
+                                         full_name: 'Preston Offman'}
   given!(:private_office) {find_or_create :team_private_office}
-  given!(:private_officer) {create :private_officer}
+  given!(:private_officer) {find_or_create :default_private_officer}
   given(:other_private_officer) {create :private_officer}
   given(:case_available_for_taking_on) {create :case_being_drafted,
                                                created_at: 1.business_day.ago}

--- a/spec/features/user_journeys/foi/compliance_review_trigger_e2e_spec.rb
+++ b/spec/features/user_journeys/foi/compliance_review_trigger_e2e_spec.rb
@@ -26,8 +26,7 @@ feature 'FOI compliance review case that requires clearance' do
   given!(:press_officer)        { create :press_officer }
   given(:press_office)          { press_officer.approving_team }
   given(:foi)                   { create :foi_correspondence_type }
-  given!(:private_officer)      { create :private_officer,
-                                         full_name: foi.default_private_officer }
+  given!(:private_officer)      { create :default_private_officer }
   given(:private_office)        { private_officer.approving_team }
   given!(:team_dacu_disclosure) { find_or_create :team_dacu_disclosure }
 

--- a/spec/features/user_journeys/foi/compliance_review_trigger_e2e_spec.rb
+++ b/spec/features/user_journeys/foi/compliance_review_trigger_e2e_spec.rb
@@ -25,8 +25,9 @@ feature 'FOI compliance review case that requires clearance' do
   given(:disclosure_specialist) { create :disclosure_specialist }
   given!(:press_officer)        { create :press_officer }
   given(:press_office)          { press_officer.approving_team }
+  given(:foi)                   { create :foi_correspondence_type }
   given!(:private_officer)      { create :private_officer,
-                                         full_name: Settings.private_office_default_user }
+                                         full_name: foi.default_private_officer }
   given(:private_office)        { private_officer.approving_team }
   given!(:team_dacu_disclosure) { find_or_create :team_dacu_disclosure }
 

--- a/spec/features/user_journeys/foi/state_machines_and_workflows_spec.rb
+++ b/spec/features/user_journeys/foi/state_machines_and_workflows_spec.rb
@@ -12,8 +12,9 @@ feature 'FOI case that does not require clearance' do
   given(:disclosure_specialist) { create :disclosure_specialist }
   given!(:press_officer)        { create :press_officer }
   given(:press_office)          { press_officer.approving_team }
+  given(:foi)                   { create :foi_correspondence_type }
   given!(:private_officer)      { create :private_officer,
-                                         full_name: Settings.private_office_default_user }
+                                         full_name: foi.default_private_officer }
   given(:private_office)        { private_officer.approving_team }
   given!(:team_dacu_disclosure) { find_or_create :team_dacu_disclosure }
   given(:team_dacu_bmt)         { find_or_create :team_dacu }

--- a/spec/features/user_journeys/foi/state_machines_and_workflows_spec.rb
+++ b/spec/features/user_journeys/foi/state_machines_and_workflows_spec.rb
@@ -13,8 +13,7 @@ feature 'FOI case that does not require clearance' do
   given!(:press_officer)        { create :press_officer }
   given(:press_office)          { press_officer.approving_team }
   given(:foi)                   { create :foi_correspondence_type }
-  given!(:private_officer)      { create :private_officer,
-                                         full_name: foi.default_private_officer }
+  given!(:private_officer)      { create :default_private_officer }
   given(:private_office)        { private_officer.approving_team }
   given!(:team_dacu_disclosure) { find_or_create :team_dacu_disclosure }
   given(:team_dacu_bmt)         { find_or_create :team_dacu }

--- a/spec/features/user_journeys/foi/trigger_e2e_spec.rb
+++ b/spec/features/user_journeys/foi/trigger_e2e_spec.rb
@@ -27,8 +27,7 @@ feature 'FOI case that does not require clearance' do
   given!(:press_officer)        { create :press_officer }
   given(:press_office)          { press_officer.approving_team }
   given(:foi)                   { create :foi_correspondence_type }
-  given!(:private_officer)      { create :private_officer,
-                                         full_name: foi.default_private_officer }
+  given!(:private_officer)      { create :default_private_officer }
   given(:private_office)        { private_officer.approving_team }
   given!(:team_dacu_disclosure) { find_or_create :team_dacu_disclosure }
   given(:team_dacu)             { find_or_create :team_dacu }

--- a/spec/features/user_journeys/foi/trigger_e2e_spec.rb
+++ b/spec/features/user_journeys/foi/trigger_e2e_spec.rb
@@ -26,8 +26,9 @@ feature 'FOI case that does not require clearance' do
   given(:disclosure_specialist) { create :disclosure_specialist }
   given!(:press_officer)        { create :press_officer }
   given(:press_office)          { press_officer.approving_team }
+  given(:foi)                   { create :foi_correspondence_type }
   given!(:private_officer)      { create :private_officer,
-                                         full_name: Settings.private_office_default_user }
+                                         full_name: foi.default_private_officer }
   given(:private_office)        { private_officer.approving_team }
   given!(:team_dacu_disclosure) { find_or_create :team_dacu_disclosure }
   given(:team_dacu)             { find_or_create :team_dacu }

--- a/spec/models/correspondence_type_spec.rb
+++ b/spec/models/correspondence_type_spec.rb
@@ -20,6 +20,9 @@ describe CorrespondenceType, type: :model do
   it { should validate_presence_of(:internal_time_limit) }
   it { should validate_presence_of(:external_time_limit) }
 
+  it { should have_attributes(default_press_officer: nil,
+                              default_private_officer: nil)}
+
   describe 'deadline_calculator_class' do
     it { should validate_presence_of(:deadline_calculator_class) }
     it 'allows the value CalendarDays' do

--- a/spec/services/case_unaccept_approver_assignment_service_spec.rb
+++ b/spec/services/case_unaccept_approver_assignment_service_spec.rb
@@ -7,9 +7,9 @@ describe CaseUnacceptApproverAssignmentService do
   let(:dacu_disclosure)         { find_or_create :team_dacu_disclosure }
   let(:assignment)              { assigned_case.approver_assignments.first }
   let(:unaccepted_assignment)   { create :approver_assignment }
-  let!(:press_officer)          { find_or_create :press_officer, full_name: 'Preston Offman' }
+  let!(:press_officer)          { find_or_create :default_press_officer }
   let!(:press_office)           { press_officer.approving_team }
-  let!(:private_officer)        { find_or_create :private_officer, full_name: 'Primrose Offord' }
+  let!(:private_officer)        { find_or_create :default_private_officer }
   let!(:private_office)         { private_officer.approving_team }
 
   describe 'call' do

--- a/spec/services/default_team_service_spec.rb
+++ b/spec/services/default_team_service_spec.rb
@@ -5,9 +5,9 @@ describe DefaultTeamService do
   let!(:team_dacu)            { find_or_create :team_dacu}
   let!(:team_dacu_disclosure) { find_or_create :team_dacu_disclosure }
   let!(:press_office)         { find_or_create :team_press_office }
-  let!(:press_officer)        { create :press_officer, full_name: 'Preston Offman' }
+  let!(:press_officer)        { find_or_create :default_press_officer }
   let!(:private_office)       { find_or_create :team_private_office }
-  let!(:private_officer)      { create :private_officer, full_name: 'Primrose Offord' }
+  let!(:private_officer)      { find_or_create :default_private_officer }
   let(:kase)                  { create :case }
   let(:service)               { DefaultTeamService.new(kase) }
 


### PR DESCRIPTION
We didn't have CorrespondenceType with jsonb attributes when we first added
press and private default users, so we stuck it in the settings.yml with ENV
overrides in the deployed environment That's too much maintenance so this gives
us a simpler way to do manage this in the db. We haven't exposed this in the GUI
yet, but that would be the next logical step.