### PR TITLE
Use pluck not map to prevent memory spikes

### DIFF
--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -49,7 +49,7 @@ class Case::BasePolicy < ApplicationPolicy
     def resolve
       ids = []
       CASE_TYPES.each do |case_type|
-        ids << Pundit.policy_scope(user, case_type).map(&:id)
+        ids << Pundit.policy_scope(user, case_type).pluck(:id)
       end
       Case::Base.where(id: ids.flatten)
     end


### PR DESCRIPTION
This PR is attempting to fix the slowness and server hanging issues we were having, caused by doing a #map(&:id) on every case returned by the scopes, which would cause hundreds if not thousands of cases to be instantiated, rather than a simple pluck(:id).

It has been deployed as a patch to the live servers, and has been rebased on the latest master so can  be merged into the master branch
