### PR TITLE
CT-1765 Generate Audit CSV

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -21,6 +21,12 @@ class StatsController < ApplicationController
     send_data report.report_data, filename: report_type.filename
   end
 
+  def download_audit
+    report = Stats::R900AuditReport.new
+    report.run
+    send_data report.report_data, filename: "R900Audit.csv"
+  end
+
   def custom
     @report = Report.new
     @custom_reports = ReportType.custom.all

--- a/app/services/stats/r900_audit_report.rb
+++ b/app/services/stats/r900_audit_report.rb
@@ -1,0 +1,136 @@
+require 'csv'
+
+module Stats
+  class R900AuditReport
+
+    attr_reader :report_data
+
+    COLUMN_HEADINGS = %w{
+      id
+      number
+      type
+      trigger
+      current_state
+      bu_id
+      business_group
+      directorate
+      business_unit
+      created
+      received
+      responded
+      internal_deadline
+      external_deadline
+      responded
+      outcome
+      info_held
+      refusal_reason
+      appeal_outcome
+      deleted
+    }
+
+    def initialize
+      @case_ids = Case::Base.unscoped.pluck(:id)
+      @date_mask = '%Y-%m-%d'
+    end
+
+    def run
+      @report_data = generate_csv
+    end
+
+    private
+
+    def generate_csv
+      CSV.generate(headers: true) do |csv|
+        csv << COLUMN_HEADINGS
+        @case_ids.each do |case_id|
+          csv << generate_line(case_id)
+        end
+      end
+    end
+
+    def generate_line(case_id)
+      line = []
+      kase = Case::Base.unscoped.find(case_id)
+      COLUMN_HEADINGS.each do |col|
+        meth = col.to_sym
+
+        if meth.in?([:id, :number, :type, :current_state, :internal_deadline, :external_deadline])
+          line << kase.__send__(meth)
+        else
+          line << __send__(meth, kase)
+        end
+      end
+      line
+    end
+
+    def bu_id(k)
+      if k.responding_team.nil?
+        ''
+      else
+        k.responding_team.id
+      end
+    end
+
+    def business_group(k)
+      if k.responding_team.nil?
+        ''
+      else
+        k.responding_team.business_group.name
+      end
+    end
+
+    def directorate(k)
+      if k.responding_team.nil?
+        ''
+      else
+        k.responding_team.directorate.name
+      end
+    end
+
+    def business_unit(k)
+      if k.responding_team.nil?
+        ''
+      else
+        k.responding_team.name
+      end
+    end
+
+    def created(k)
+      k.created_at.strftime(@date_mask)
+    end
+
+    def received(k)
+      k.received_date.strftime(@date_mask)
+    end
+
+    def responded(k)
+      k.date_responded.nil? ? '' : k.date_responded.strftime(@date_mask)
+    end
+
+    def trigger(k)
+      k.flagged? ? 'Y' : 'N'
+    end
+
+    def outcome(k)
+      k.outcome_id.nil? ? '' : k.outcome.name
+    end
+
+    def info_held(k)
+      k.info_held_status_id.nil? ? '' : k.info_held_status.name
+    end
+
+    def refusal_reason(k)
+      k.refusal_reason_id.nil? ? '' : k.refusal_reason.name
+    end
+
+    def appeal_outcome(k)
+      k.appeal_outcome_id.nil? ? '' : k.appeal_outcome.name
+    end
+
+    def deleted(k)
+      k.deleted ? 'Yes' : 'No'
+    end
+
+  end
+end
+

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -34,4 +34,12 @@ hr
                 span.visually-hidden
                   = " #{ report.full_name }"
 
-
+        - if current_user.admin?
+          tr
+            th
+              = 'Audit CSV'
+            td.action-right-aligned
+              = link_to stats_download_audit_path, target: '_blank' do
+                = 'Download'
+                span.visually-hidded
+                  = " audit "

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -287,6 +287,7 @@ Rails.application.routes.draw do
 
   get '/stats' => 'stats#index'
   get '/stats/download/:id' => 'stats#download', as: :stats_download
+  get '/stats/download_audit' => 'stats#download_audit', as: :stats_download_audit
   get '/stats/download_custom_report/:id' => 'stats#download_custom_report', as: :stats_download_custom_report
   get '/stats/custom' => 'stats#custom'
   post 'stats/create_custom_report' => 'stats#create_custom_report'

--- a/spec/views/stats/index_html_slim_spec.rb
+++ b/spec/views/stats/index_html_slim_spec.rb
@@ -12,6 +12,7 @@ describe 'stats/index.html.slim', type: :view do
 
   it 'has a heading' do
     assign(:reports, reports)
+    allow(view).to receive(:current_user).and_return(double(User, admin?: false))
     render
     stats_index_page.load(rendered)
 
@@ -23,6 +24,7 @@ describe 'stats/index.html.slim', type: :view do
 
   it 'has a table with a list of reports' do
     assign(:reports, reports)
+    allow(view).to receive(:current_user).and_return(double(User, admin?: false))
     render
     stats_index_page.load(rendered)
 


### PR DESCRIPTION
This PR adds a line to the Stats index page for Admin users to generate an audit CSV,

The audit CSV is a file containing a line for every case in the system with details of dates, responding business units, etc.
this is needed to compare reports generated by this system with those generated by the old.