### PR TITLE
CT-1564 Implement Business Unit performance report for SARs

### DIFF
--- a/app/models/case/foi/standard.rb
+++ b/app/models/case/foi/standard.rb
@@ -74,34 +74,4 @@ class Case::FOI::Standard < Case::Base
 
     internal_deadline >= disclosure_approval_date
   end
-
-
-  # determines whether or not an individual BU responded to a case in time, measured
-  # from the date the case was assigned to the business unit to the time the case was marked as responded.
-  # Note that the time limit is different for trigger cases (the internal time limit) than for non trigger
-  # (the external time limit)
-  #
-  def business_unit_responded_in_time?
-    responding_transitions = transitions.where(event: 'respond')
-    if responding_transitions.any?
-      responding_team_assignment_date = transitions.where(event: 'assign_responder').last.created_at.to_date
-      responding_transition = responding_transitions.last
-      responding_date = responding_transition.created_at.to_date
-      internal_deadline = deadline_calculator
-            .internal_deadline_for_date(correspondence_type, responding_team_assignment_date)
-      internal_deadline >= responding_date
-    else
-      raise ArgumentError.new("Cannot call ##{__method__} on a case without a response (Case #{number})")
-    end
-  end
-
-  def business_unit_already_late?
-    if transitions.where(event: 'respond').any?
-      raise ArgumentError.new("Cannot call ##{__method__} on a case for which the response has been sent")
-    else
-      responding_team_assignment_date = transitions.where(event: 'assign_responder').last.created_at.to_date
-      internal_deadline = deadline_calculator.business_unit_deadline_for_date(responding_team_assignment_date)
-      internal_deadline < Date.today
-    end
-  end
 end

--- a/app/services/deadline_calculator/calendar_days.rb
+++ b/app/services/deadline_calculator/calendar_days.rb
@@ -8,24 +8,23 @@ module DeadlineCalculator
     end
 
     def escalation_deadline
-      calculate_days_from kase.correspondence_type.escalation_time_limit.days,
-                          kase.created_at.to_date
+      kase.created_at.to_date + kase.correspondence_type.escalation_time_limit.days
     end
 
     def internal_deadline     # aka draft deadline
-      calculate_days_from kase.correspondence_type.internal_time_limit.days,
-                          kase.received_date
+      kase.received_date + kase.correspondence_type.internal_time_limit.days
     end
 
     def external_deadline
-      calculate_days_from kase.correspondence_type.external_time_limit.days,
-                          kase.received_date
+      kase.received_date + kase.correspondence_type.external_time_limit.days
     end
 
-    private
-
-    def calculate_days_from(days, start_date)
-      days.since start_date
+    def business_unit_deadline_for_date(date)
+      deadline_method  = @kase.flagged? ? :internal_time_limit : :external_time_limit
+      num_days = @kase.correspondence_type.__send__(deadline_method)
+      date + num_days.days
     end
+
+
   end
 end

--- a/app/services/stats/base_business_unit_performance_report.rb
+++ b/app/services/stats/base_business_unit_performance_report.rb
@@ -1,0 +1,167 @@
+module Stats
+  class BaseBusinessUnitPerformanceReport < BaseReport
+
+    R003_SPECIFIC_COLUMNS = {
+      business_group:                  'Business group',
+      directorate:                     'Directorate',
+      business_unit:                   'Business unit',
+      responsible:                     'Responsible'
+    }
+    
+    R003_BU_PERFORMANCE_COLUMNS = {
+      bu_performance:             'Performance %',
+      bu_total:                   'Total received',
+      bu_responded_in_time:       'Responded - in time',
+      bu_responded_late:          'Responded - late',
+      bu_open_in_time:            'Open - in time',
+      bu_open_late:               'Open - late',
+    }
+
+    R003_SPECIFIC_SUPERHEADINGS = {
+      business_group:                  '',
+      directorate:                     '',
+      business_unit:                   '',
+      responsible:                     ''
+    }
+    
+    R003_BU_PERFORMANCE_SUPERHEADINGS = {
+      bu_performance:             'Business unit',
+      bu_total:                   'Business unit',
+      bu_responded_in_time:       'Business unit',
+      bu_responded_late:          'Business unit',
+      bu_open_in_time:            'Business unit',
+      bu_open_late:               'Business unit',
+    } 
+    
+
+    def initialize(period_start= Time.now.beginning_of_year, period_end=Time.now, generate_bu_columns=false)
+      super(period_start, period_end)
+      @period_start = period_start
+      @period_end = period_end
+      @generate_bu_columns = generate_bu_columns
+      column_headings = if @generate_bu_columns
+                          R003_SPECIFIC_COLUMNS.merge(CaseAnalyser::COMMON_COLUMNS).merge(R003_BU_PERFORMANCE_COLUMNS)
+                        else
+                          R003_SPECIFIC_COLUMNS.merge(CaseAnalyser::COMMON_COLUMNS)
+                        end
+
+      @stats = StatsCollector.new(Team.hierarchy.map(&:id) + [:total], column_headings)
+      @superheadings = superheadings
+      @stats.add_callback(:before_finalise, -> { roll_up_stats_callback })
+      @stats.add_callback(:before_finalise, -> { populate_team_details_callback })
+      @stats.add_callback(:before_finalise, -> { Calculations::Callbacks.calculate_overall_columns(@stats) })
+      @stats.add_callback(:before_finalise, -> { Calculations::Callbacks.calculate_total_columns(@stats) })
+      @stats.add_callback(:before_finalise, -> { Calculations::Callbacks.calculate_percentages(@stats) })
+    end
+
+    def superheadings
+      headings = if @generate_bu_columns
+                   (R003_SPECIFIC_SUPERHEADINGS.merge(CaseAnalyser::COMMON_SUPERHEADINGS).merge(R003_BU_PERFORMANCE_SUPERHEADINGS)).values
+                 else
+                   (R003_SPECIFIC_SUPERHEADINGS.merge(CaseAnalyser::COMMON_SUPERHEADINGS)).values
+                 end
+
+      [
+        ["#{self.class.title} - #{reporting_period}"], headings
+      ]
+    end
+
+    def case_scope
+      raise RuntimeError.new('#case_scope method must be defined in derived class')
+    end
+
+    def self.title
+      raise RuntimeError.new('title() class  method must be defined in derived class')
+    end
+
+    def self.description
+      raise RuntimeError.new('description() class method must be defined in derived class')
+    end
+
+    def run
+      case_ids = CaseSelector.new(case_scope).ids_for_period(@period_start, @period_end)
+      case_ids.each do |case_id|
+        kase = Case::Base.find(case_id)
+        next if kase.unassigned?
+        analyse_case(kase)
+      end
+      @stats.finalise
+    end
+
+    def to_csv
+      @stats.to_csv(row_names_as_first_column: false, superheadings: superheadings)
+    end
+
+    private
+
+    # this method is passed into the stats collector as a before_finalize callback and accesses the
+    # @stats variable  inside the stats collector to sum totals for directorates and business groups
+    def roll_up_stats_callback
+      overall_total_results = @stats.stats[:total]
+      BusinessUnit.all.each do |bu|
+        bu_results = @stats.stats[bu.id]
+        directorate_results = @stats.stats[bu.directorate.id]
+        business_group_results = @stats.stats[bu.business_group.id]
+        bu_results.each do |key, value|
+          directorate_results[key] += value
+          business_group_results[key] += value
+          overall_total_results[key] += value
+        end
+      end
+    end
+
+    # another callback method to populate the team names from the team id column
+    def populate_team_details_callback
+      @stats.stats.except(:total).each do | team_id, result_set|
+        team = Team.find(team_id)
+        case team.class.to_s
+        when 'BusinessUnit'
+          result_set[:business_unit] = team.name
+          result_set[:directorate] = team.parent.name
+          result_set[:business_group] = team.parent.parent.name
+        when 'Directorate'
+          result_set[:business_unit] = ''
+          result_set[:directorate] = team.name
+          result_set[:business_group] = team.parent.name
+        when 'BusinessGroup'
+          result_set[:business_unit] = ''
+          result_set[:directorate] = ''
+          result_set[:business_group] = team.name
+        else
+          raise "Invalid team type"
+        end
+        result_set[:responsible] = team.team_lead
+      end
+
+      @stats.stats[:total][:business_group] = 'Total'
+      @stats.stats[:total][:directorate] = ''
+      @stats.stats[:total][:business_unit] = ''
+      @stats.stats[:total][:responsible] = ''
+    end
+
+    def analyse_case(kase)
+      analyser = CaseAnalyser.new(kase)
+      analyser.run
+      column_key = analyser.result
+      @stats.record_stats(kase.responding_team.id, column_key)
+
+      if @generate_bu_columns
+        business_unit_column_key = "bu_#{analyser.bu_result}".to_sym
+        @stats.record_stats(kase.responding_team.id, business_unit_column_key)
+      end
+    end
+
+    def add_trigger_state(kase, timeliness)
+      status = kase.flagged? ? 'trigger_' + timeliness : 'non_trigger_' + timeliness
+      status.to_sym
+    end
+
+    def analyse_closed_case(kase)
+      kase.responded_in_time? ? 'responded_in_time' : 'responded_late'
+    end
+
+    def analyse_open_case(kase)
+      kase.already_late? ? 'open_late' : 'open_in_time'
+    end
+  end
+end

--- a/app/services/stats/r003_business_unit_performance_report.rb
+++ b/app/services/stats/r003_business_unit_performance_report.rb
@@ -1,163 +1,18 @@
 module Stats
-  class R003BusinessUnitPerformanceReport < BaseReport
-
-    R003_SPECIFIC_COLUMNS = {
-      business_group:                  'Business group',
-      directorate:                     'Directorate',
-      business_unit:                   'Business unit',
-      responsible:                     'Responsible'
-    }
-    
-    R003_BU_PERFORMANCE_COLUMNS = {
-      bu_performance:             'Performance %',
-      bu_total:                   'Total received',
-      bu_responded_in_time:       'Responded - in time',
-      bu_responded_late:          'Responded - late',
-      bu_open_in_time:            'Open - in time',
-      bu_open_late:               'Open - late',
-    }
-
-    R003_SPECIFIC_SUPERHEADINGS = {
-      business_group:                  '',
-      directorate:                     '',
-      business_unit:                   '',
-      responsible:                     ''
-    }
-    
-    R003_BU_PERFORMANCE_SUPERHEADINGS = {
-      bu_performance:             'Business unit',
-      bu_total:                   'Business unit',
-      bu_responded_in_time:       'Business unit',
-      bu_responded_late:          'Business unit',
-      bu_open_in_time:            'Business unit',
-      bu_open_late:               'Business unit',
-    } 
-    
-
-    def initialize(period_start= Time.now.beginning_of_year, period_end=Time.now, generate_bu_columns=false)
-      super(period_start, period_end)
-      @period_start = period_start
-      @period_end = period_end
-      @generate_bu_columns = generate_bu_columns
-      column_headings = if @generate_bu_columns
-                          R003_SPECIFIC_COLUMNS.merge(CaseAnalyser::COMMON_COLUMNS).merge(R003_BU_PERFORMANCE_COLUMNS)
-                        else
-                          R003_SPECIFIC_COLUMNS.merge(CaseAnalyser::COMMON_COLUMNS)
-                        end
-
-      @stats = StatsCollector.new(Team.hierarchy.map(&:id) + [:total], column_headings)
-      @superheadings = superheadings
-      @stats.add_callback(:before_finalise, -> { roll_up_stats_callback })
-      @stats.add_callback(:before_finalise, -> { populate_team_details_callback })
-      @stats.add_callback(:before_finalise, -> { Calculations::Callbacks.calculate_overall_columns(@stats) })
-      @stats.add_callback(:before_finalise, -> { Calculations::Callbacks.calculate_total_columns(@stats) })
-      @stats.add_callback(:before_finalise, -> { Calculations::Callbacks.calculate_percentages(@stats) })
-    end
-
-    def superheadings
-      headings = if @generate_bu_columns
-                   (R003_SPECIFIC_SUPERHEADINGS.merge(CaseAnalyser::COMMON_SUPERHEADINGS).merge(R003_BU_PERFORMANCE_SUPERHEADINGS)).values
-                 else
-                   (R003_SPECIFIC_SUPERHEADINGS.merge(CaseAnalyser::COMMON_SUPERHEADINGS)).values
-                 end
-
-      [
-        ["#{self.class.title} - #{reporting_period}"], headings
-      ]
-    end
+  class R003BusinessUnitPerformanceReport < BaseBusinessUnitPerformanceReport
 
     def self.title
-      'Business unit report'
+      'Business unit report (FOIs)'
     end
 
     def self.description
-      'Shows all open cases and cases closed this month, in-time or late, by responding team'
+      'Shows all FOI open cases and cases closed this month, in-time or late, by responding team'
     end
 
-    def run
-      case_ids = CaseSelector.new(Case::Base.standard_foi).ids_for_period(@period_start, @period_end)
-      case_ids.each do |case_id|
-        kase = Case::Base.find(case_id)
-        next if kase.unassigned?
-        analyse_case(kase)
-      end
-      @stats.finalise
+    def case_scope
+      Case::Base.standard_foi
     end
 
-    def to_csv
-      @stats.to_csv(row_names_as_first_column: false, superheadings: superheadings)
-    end
 
-    private
-
-    # this method is passed into the stats collector as a before_finalize callback and accesses the
-    # @stats variable  inside the stats collector to sum totals for directorates and business groups
-    def roll_up_stats_callback
-      overall_total_results = @stats.stats[:total]
-      BusinessUnit.all.each do |bu|
-        bu_results = @stats.stats[bu.id]
-        directorate_results = @stats.stats[bu.directorate.id]
-        business_group_results = @stats.stats[bu.business_group.id]
-        bu_results.each do |key, value|
-          directorate_results[key] += value
-          business_group_results[key] += value
-          overall_total_results[key] += value
-        end
-      end
-    end
-
-    # another callback method to populate the team names from the team id column
-    def populate_team_details_callback
-      @stats.stats.except(:total).each do | team_id, result_set|
-        team = Team.find(team_id)
-        case team.class.to_s
-        when 'BusinessUnit'
-          result_set[:business_unit] = team.name
-          result_set[:directorate] = team.parent.name
-          result_set[:business_group] = team.parent.parent.name
-        when 'Directorate'
-          result_set[:business_unit] = ''
-          result_set[:directorate] = team.name
-          result_set[:business_group] = team.parent.name
-        when 'BusinessGroup'
-          result_set[:business_unit] = ''
-          result_set[:directorate] = ''
-          result_set[:business_group] = team.name
-        else
-          raise "Invalid team type"
-        end
-        result_set[:responsible] = team.team_lead
-      end
-
-      @stats.stats[:total][:business_group] = 'Total'
-      @stats.stats[:total][:directorate] = ''
-      @stats.stats[:total][:business_unit] = ''
-      @stats.stats[:total][:responsible] = ''
-    end
-
-    def analyse_case(kase)
-      analyser = CaseAnalyser.new(kase)
-      analyser.run
-      column_key = analyser.result
-      @stats.record_stats(kase.responding_team.id, column_key)
-
-      if @generate_bu_columns
-        business_unit_column_key = "bu_#{analyser.bu_result}".to_sym
-        @stats.record_stats(kase.responding_team.id, business_unit_column_key)
-      end
-    end
-
-    def add_trigger_state(kase, timeliness)
-      status = kase.flagged? ? 'trigger_' + timeliness : 'non_trigger_' + timeliness
-      status.to_sym
-    end
-
-    def analyse_closed_case(kase)
-      kase.responded_in_time? ? 'responded_in_time' : 'responded_late'
-    end
-
-    def analyse_open_case(kase)
-      kase.already_late? ? 'open_late' : 'open_in_time'
-    end
   end
 end

--- a/app/services/stats/r103_sar_business_unit_performance_report.rb
+++ b/app/services/stats/r103_sar_business_unit_performance_report.rb
@@ -1,0 +1,18 @@
+module Stats
+  class R103SarBusinessUnitPerformanceReport < BaseBusinessUnitPerformanceReport
+
+    def self.title
+      'Business unit report (SARs)'
+    end
+
+    def self.description
+      'Shows all SAR open cases and cases closed this month, in-time or late, by responding team (excluding TMMs)'
+    end
+
+    def case_scope
+      tmm = CaseClosure::RefusalReason.tmm
+      Case::SAR.where('refusal_reason_id IS NULL OR refusal_reason_id != ?', tmm.id)
+    end
+
+  end
+end

--- a/app/views/stats/index.html.slim
+++ b/app/views/stats/index.html.slim
@@ -27,15 +27,18 @@ hr
             = "Action"
       tbody
         - @reports.each do |report|
-          tr
-            th
-              = report.full_name
+          - if FeatureSet.sars.disabled? && report.abbr == 'R103'
+            next
+          - else
+            tr
+              th
+                = report.full_name
 
-            td.action-right-aligned
-              = link_to stats_download_path(id: report.id), target: '_blank' do
-                = 'Download'
-                span.visually-hidden
-                  = " #{ report.full_name }"
+              td.action-right-aligned
+                = link_to stats_download_path(id: report.id), target: '_blank' do
+                  = 'Download'
+                  span.visually-hidden
+                    = " #{ report.full_name }"
 
         - if current_user.admin?
           tr

--- a/db/migrate/20180613141421_add_sar_report_type.rb
+++ b/db/migrate/20180613141421_add_sar_report_type.rb
@@ -1,0 +1,14 @@
+class AddSarReportType < ActiveRecord::Migration[5.0]
+  def up
+    ReportType.create!(
+                  abbr: 'R103',
+                  full_name: 'Business unit report (SARs)',
+                  class_name: 'Stats::R103SarBusinessUnitPerformanceReport',
+                  custom_report: true,
+                  seq_id: 250)
+  end
+
+  def down
+    ReportType.find_by(abbr: 'R103').destroy!
+  end
+end

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -10,7 +10,9 @@ class CorrespondenceTypeSeeder
                 escalation_time_limit: 3,
                 internal_time_limit: 10,
                 external_time_limit: 20,
-                deadline_calculator_class: 'BusinessDays')
+                deadline_calculator_class: 'BusinessDays',
+                default_press_officer: 'correspondence-staff-dev+preston.offman@digital.justice.gov.uk',
+                default_private_officer: 'correspondence-staff-dev+primrose.offord@digital.justice.gov.uk')
 
     rec = CorrespondenceType.find_by(abbreviation: 'SAR')
     rec = CorrespondenceType.new if rec.nil?
@@ -19,6 +21,8 @@ class CorrespondenceTypeSeeder
                 escalation_time_limit: 0,
                 internal_time_limit: 10,
                 external_time_limit: 30,
-                deadline_calculator_class: 'CalendarDays')
+                deadline_calculator_class: 'CalendarDays',
+                default_press_officer: 'correspondence-staff-dev+preston.offman@digital.justice.gov.uk',
+                default_private_officer: 'correspondence-staff-dev+primrose.offord@digital.justice.gov.uk')
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.9
--- Dumped by pg_dump version 9.5.9
+-- Dumped from database version 9.5.10
+-- Dumped by pg_dump version 9.5.10
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1609,6 +1609,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180508131152'),
 ('20180517140929'),
 ('20180522132456'),
-('20180524132031');
+('20180524132031'),
+('20180613141421');
 
 

--- a/spec/services/deadline_calculator/calendar_days_spec.rb
+++ b/spec/services/deadline_calculator/calendar_days_spec.rb
@@ -4,27 +4,47 @@ describe DeadlineCalculator::CalendarDays do
   let(:sar)                 { find_or_create :sar_correspondence_type }
   let(:sar_case)            { create :sar_case }
   let(:deadline_calculator) { described_class.new sar_case }
+  let(:start_date)          { Date.new(2018, 6, 14) }
+  let(:start_date_plus_10)  { Date.new(2018, 6, 24) }
+  let(:start_date_plus_30)  { Date.new(2018, 7, 14) }
 
   context 'SAR case' do
-    describe 'escalation deadline' do
+    describe '#escalation deadline' do
       it 'is 3 calendar days after the date of creation' do
         expect(deadline_calculator.escalation_deadline)
           .to eq 3.days.since(sar_case.created_at.to_date)
       end
     end
 
-    describe 'internal deadline' do
+    describe '#internal deadline' do
       it 'is 10 calendar days after the date received' do
         expect(deadline_calculator.internal_deadline)
           .to eq 10.days.since(sar_case.received_date)
       end
     end
 
-    describe 'external deadline' do
+    describe '#external deadline' do
       it 'is 30 calendar days after the date received' do
         expect(deadline_calculator.external_deadline)
           .to eq 30.days.since(sar_case.received_date)
       end
+    end
+
+    describe '#buiness_unit_deadline_for_date' do
+      context 'unflagged' do
+        it 'is 30 days from date' do
+          expect(sar_case).not_to be_flagged
+          expect(deadline_calculator.business_unit_deadline_for_date(start_date)).to eq start_date_plus_30
+        end
+      end
+
+      context 'flagged' do
+        it 'is 10 days from date' do
+          allow(sar_case).to receive(:flagged?).and_return(true)
+          expect(deadline_calculator.business_unit_deadline_for_date(start_date)).to eq start_date_plus_10
+        end
+      end
+
     end
   end
 end

--- a/spec/services/stats/r003_business_unit_performance_report_spec.rb
+++ b/spec/services/stats/r003_business_unit_performance_report_spec.rb
@@ -86,13 +86,13 @@ module Stats
 
     describe '#title' do
       it 'returns the report title' do
-        expect(R003BusinessUnitPerformanceReport.title).to eq 'Business unit report'
+        expect(R003BusinessUnitPerformanceReport.title).to eq 'Business unit report (FOIs)'
       end
     end
 
     describe '#description' do
       it 'returns the report description' do
-        expect(R003BusinessUnitPerformanceReport.description).to eq 'Shows all open cases and cases closed this month, in-time or late, by responding team'
+        expect(R003BusinessUnitPerformanceReport.description).to eq 'Shows all FOI open cases and cases closed this month, in-time or late, by responding team'
       end
     end
 
@@ -204,7 +204,7 @@ module Stats
                 %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late,} +
                 %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late}
             expected_text = <<~EOCSV
-            Business unit report - 1 Jan 2017 to 30 Jun 2017
+            Business unit report (FOIs) - 1 Jan 2017 to 30 Jun 2017
             #{super_header}
             #{header}
             BGAB,"","",#{@bizgrp_ab.team_lead},28.6,9,2,2,2,3,33.3,5,1,1,2,1,30.0,14,3,3,4,4
@@ -378,7 +378,7 @@ module Stats
               %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late,} +
               %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late}
             expected_text = <<~EOCSV
-              Business unit report - 1 Jan 2017 to 30 Jun 2017
+              Business unit report (FOIs) - 1 Jan 2017 to 30 Jun 2017
               #{super_header}
               #{header}
               BGAB,"","",#{@bizgrp_ab.team_lead},28.6,9,2,2,2,3,33.3,5,1,1,2,1,30.0,14,3,3,4,4,0.0,14,0,6,0,8

--- a/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
+++ b/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
@@ -1,0 +1,152 @@
+require 'rails_helper'
+
+module Stats
+  describe R103SarBusinessUnitPerformanceReport do
+
+    context 'date management, titles, description, etc' do
+      context 'defining the period' do
+        context 'no period parameters passsed in' do
+          it 'defaults from beginning of year to now' do
+            Timecop.freeze(Time.local(2017, 12, 7, 12,33,44)) do
+              report = R103SarBusinessUnitPerformanceReport.new
+              expect(report.__send__(:reporting_period)).to eq '1 Jan 2017 to 7 Dec 2017'
+            end
+          end
+        end
+
+        context 'period params are passed in' do
+          it 'uses the specify period' do
+            d1 = Date.new(2017, 6, 1)
+            d2 = Date.new(2017, 6, 30)
+            report = R103SarBusinessUnitPerformanceReport.new(d1, d2)
+            expect(report.__send__(:reporting_period)).to eq '1 Jun 2017 to 30 Jun 2017'
+          end
+        end
+      end
+
+      describe '#title' do
+        it 'returns the report title' do
+          expect(R103SarBusinessUnitPerformanceReport.title).to eq 'Business unit report (SARs)'
+        end
+      end
+
+      describe '#description' do
+        it 'returns the report description' do
+          expect(R103SarBusinessUnitPerformanceReport.description).to eq 'Shows all SAR open cases and cases closed this month, in-time or late, by responding team (excluding TMMs)'
+        end
+      end
+    end
+
+    context 'data' do
+      before(:all) do
+        @bizgrp_ab = create :business_group, name: 'BGAB'
+        @dir_a     = create :directorate, name: 'DRA', business_group: @bizgrp_ab
+        @dir_b     = create :directorate, name: 'DRB', business_group: @bizgrp_ab
+        @bizgrp_cd = create :business_group, name: 'BGCD'
+        @dir_cd    = create :directorate, name: 'DRCD', business_group: @bizgrp_cd
+
+        @team_a = create :business_unit, name: 'RTA', directorate: @dir_a
+        @team_b = create :business_unit, name: 'RTB', directorate: @dir_b
+        @team_c = create :business_unit, name: 'RTC', directorate: @dir_cd
+        @team_d = create :business_unit, name: 'RTD', directorate: @dir_cd
+        @team_dacu_disclosure = find_or_create :team_dacu_disclosure
+        @responder_a = create :responder, responding_teams: [@team_a]
+        @responder_b = create :responder, responding_teams: [@team_b]
+        @responder_c = create :responder, responding_teams: [@team_c]
+        @responder_d = create :responder, responding_teams: [@team_d]
+
+        @tmm = create :refusal_reason, :tmm
+        @vex = create :refusal_reason, :vex
+
+        # create cases based on today's date of 30/6/2017
+        create_case(received: '20170601', responded: '20170628', deadline: '20170625', team: @team_a, responder: @responder_a, type: :vex, ident: 'case for team a - responded late')
+        create_case(received: '20170604', responded: '20170629', deadline: '20170625', team: @team_a, responder: @responder_a, type: :vex, ident: 'case for team a - responded late')
+        create_case(received: '20170605', responded: nil,        deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'case for team a - open late')
+        create_case(received: '20170605', responded: nil,        deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'case for team a - open late')
+        create_case(received: '20170605', responded: nil,        deadline: '20170702', team: @team_a, responder: @responder_a, ident: 'case for team a - open in time')
+        create_case(received: '20170606', responded: '20170625', deadline: '20170630', team: @team_a, responder: @responder_a, ident: 'case for team a - responded in time')
+        create_case(received: '20170605', responded: nil,        deadline: '20170625', team: @team_b, responder: @responder_b, ident: 'case for team b - open late')
+        create_case(received: '20170605', responded: nil,        deadline: '20170702', team: @team_b, responder: @responder_b, ident: 'case for team b - open in time')
+        create_case(received: '20170607', responded: '20170620', deadline: '20170625', team: @team_b, responder: @responder_b, ident: 'case for team b - responded in time')
+        create_case(received: '20170604', responded: '20170629', deadline: '20170625', team: @team_c, responder: @responder_c, ident: 'case for team c - responded late')
+        create_case(received: '20170606', responded: '20170625', deadline: '20170630', team: @team_c, responder: @responder_c, ident: 'case for team c - responded in time')
+        create_case(received: '20170605', responded: nil,        deadline: '20170702', team: @team_d, responder: @responder_d, ident: 'case for team d - open in time')
+
+        # create some SAR TMM cases which should be ignored
+        create_case(received: '20170601', responded: '20170628', deadline: '20170625', team: @team_a, responder: @responder_a, type: :tmm, ident: 'case for team a - responded late')
+        create_case(received: '20170604', responded: '20170629', deadline: '20170625', team: @team_a, responder: @responder_a, type: :tmm, ident: 'case for team a - responded late')
+        create_case(received: '20170606', responded: '20170625', deadline: '20170630', team: @team_a, responder: @responder_a, type: :tmm, ident: 'case for team a - responded in time')
+
+        # create some FOI cases which should be ignored
+        create :closed_case
+        create :closed_case
+
+        # delete extraneous teams
+        Team.where('id > ?', @team_d.id).destroy_all
+      end
+
+      after(:all)  { DbHousekeeping.clean }
+
+      context 'without business unit columns' do
+
+        # We only test that the correct cases are being selected for analysis.  The
+        # analysis work, rolling up of business group and directorate toatls and calcualtion
+        # of percentages is carried out in BasePerformanceUnitReport, and is fully testing
+        # by the R003PerfomanceReport spec.
+        #
+        describe '#scope' do
+          before do
+            Timecop.freeze Time.new(2017, 6, 30, 12, 0, 0) do
+
+              report = R103SarBusinessUnitPerformanceReport.new
+              @scope = report.case_scope
+            end
+          end
+
+          it 'selects only SAR cases' do
+            expect(@scope.size).to eq 12
+            expect(@scope.map(&:type).uniq).to eq ['Case::SAR']
+          end
+
+          it 'excludes TMM cases' do
+            expect(@scope.map(&:refusal_reason_id)).not_to include(@tmm.id)
+          end
+
+        end
+      end
+
+
+      #rubocop:disable Metrics/ParameterLists
+      def create_case(received:, responded:, deadline:, team:, responder:, ident:, flagged: false, type: nil)
+        received_date = Date.parse(received)
+        responded_date = responded.nil? ? nil : Date.parse(responded)
+        kase = nil
+        Timecop.freeze(received_date + 10.hours) do
+          factory = :accepted_sar
+          kase = create factory, responding_team: team, responder: responder, identifier: ident
+          kase.external_deadline = Date.parse(deadline)
+          if flagged == true
+            CaseFlagForClearanceService.new(user: kase.managing_team.users.first, kase: kase, team: @team_dacu_disclosure).call
+          end
+          unless responded_date.nil?
+            Timecop.freeze responded_date + 14.hours do
+              kase.date_responded = Time.now
+              kase.state_machine.close!(acting_user: responder, acting_team: team)
+            end
+          end
+        end
+
+
+        if type.present?
+          refusal_reason = CaseClosure::RefusalReason.__send__(type)
+          kase.refusal_reason = refusal_reason
+        end
+        kase.save!
+        kase
+      end
+      #rubocop:enable Metrics/ParameterLists
+
+
+    end
+  end
+end


### PR DESCRIPTION
This is implemented by moving the logic from the existing
R003BusinessUnitPeformanceReport into a new class BaseBusinessUnitPerformanceRepoert
and deriving the Business unit performce reports for both FOIs and SARs from that.  The
derived classes just differ in returning different names nad desciptions of the report, and
most importantly the case_scope, which determines which cases will be reported on

The specs for the new R103SarBusinessUnitPerformanceReport only exercise the new methods; the
code in the base class for analysing, totalling, calculating percentages in thoroughly testing in
the spec for the FOI report.