### PR TITLE
CT-1722 Refactor SAR close to respond_and_close

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -292,7 +292,7 @@ class CasesController < ApplicationController
 
 
   def process_respond_and_close
-    authorize @case
+    authorize @case, :respond_and_close?
     @case.prepare_for_close
     close_params = process_closure_params(@case.type_abbreviation)
     if @case.update(close_params)

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -40,12 +40,14 @@ class CasesController < ApplicationController
                   :flag_for_clearance,
                   :new_response_upload,
                   :process_closure,
+                  :process_respond_and_close,
                   :progress_for_clearance,
                   :reassign_approver,
                   :remove_clearance,
                   :request_amends,
                   :request_further_clearance,
                   :respond,
+                  :respond_and_close,
                   :show,
                   :update,
                   :unflag_for_clearance,
@@ -279,6 +281,29 @@ class CasesController < ApplicationController
     authorize @case, :can_close_case?
     @case.date_responded = nil
     set_permitted_events
+  end
+
+  def respond_and_close
+    authorize @case
+    @case.date_responded = nil
+    set_permitted_events
+    render :close
+  end
+
+
+  def process_respond_and_close
+    authorize @case
+    @case.prepare_for_close
+    close_params = process_closure_params(@case.type_abbreviation)
+    if @case.update(close_params)
+      @case.respond_and_close(current_user)
+      set_permitted_events
+      flash[:notice] = t('notices.case_closed')
+      redirect_to case_path(@case)
+    else
+      set_permitted_events
+      render :close
+    end
   end
 
   def process_closure

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -75,6 +75,11 @@ module CasesHelper
               close_case_path(@case),
               id: 'action--close-case',
               class: 'button', method: :get
+    when :respond_and_close
+      link_to I18n.t('common.case.close'),
+              respond_and_close_case_path(@case),
+              id: 'action--close-case',
+              class: 'button', method: :get
     when :progress_for_clearance
       link_to I18n.t('common.case.progress_for_clearance'),
               progress_for_clearance_case_path(@case),

--- a/app/models/case/sar.rb
+++ b/app/models/case/sar.rb
@@ -56,7 +56,8 @@ class Case::SAR < Case::Base
   # The method below is overiding the close method in the case_states.rb file.
   # This is so that the case is closed with the responder's team instead of the manager's team
 
-  def close(current_user)
+  def respond_and_close(current_user)
+    state_machine.respond!(acting_user: current_user, acting_team: self.responding_team)
     state_machine.close!(acting_user: current_user, acting_team: self.responding_team)
   end
 

--- a/app/policies/case/sar_policy.rb
+++ b/app/policies/case/sar_policy.rb
@@ -45,10 +45,6 @@ class Case::SARPolicy < Case::BasePolicy
         user.responding_teams.include?(self.case.responding_team)
   end
 
-  def process_respond_and_close?
-    respond_and_close?
-  end
-
   def show?
     clear_failed_checks
 

--- a/app/policies/case/sar_policy.rb
+++ b/app/policies/case/sar_policy.rb
@@ -39,6 +39,16 @@ class Case::SARPolicy < Case::BasePolicy
 
   end
 
+  def respond_and_close?
+    clear_failed_checks
+    self.case.drafting? &&
+        user.responding_teams.include?(self.case.responding_team)
+  end
+
+  def process_respond_and_close?
+    respond_and_close?
+  end
+
   def show?
     clear_failed_checks
 

--- a/app/views/cases/close.html.slim
+++ b/app/views/cases/close.html.slim
@@ -15,5 +15,4 @@
 
 = render partial: "cases/#{@case.type_abbreviation.downcase}/close_form",
          locals: { kase: @case,
-                   form_url: process_closure_case_path(id: @case.id),
                    submit_button: t('.submit')}

--- a/app/views/cases/foi/_close_form.html.slim
+++ b/app/views/cases/foi/_close_form.html.slim
@@ -2,7 +2,8 @@
   .column-full
     = render partial: 'cases/case_attachments', locals: { case_details: @case }
 
-= form_for @case, as: :case_foi, url: form_url do |f|
+- url = defined?(form_url) ? form_url : process_closure_case_path(id: @case.id)
+= form_for @case, as: :case_foi, url: url do |f|
   .form-group
     = f.gov_uk_date_field :date_responded, { legend_text: t('.close_date'), form_hint_text: t('.date_example') }
 

--- a/app/views/cases/sar/_close_form.html.slim
+++ b/app/views/cases/sar/_close_form.html.slim
@@ -1,4 +1,5 @@
-= form_for kase, as: :case_sar, url: form_url do |f|
+- url = defined?(form_url) ? form_url : process_respond_and_close_case_path(id: @case.id)
+= form_for kase, as: :case_sar, url: url do |f|
   .form-group
     = f.gov_uk_date_field :date_responded, { legend_text: t('.close_date'),
             form_hint_text: t('.date_example'),

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -39,7 +39,11 @@ div id="case-#{@case.id}"
         - if policy(@case).can_respond?
           = action_button_for(:respond)
 
-        - (@permitted_events - [:add_responses, :add_response_to_flagged_case, :approve, :respond, :reassign_user, :upload_response_and_approve, :upload_response_and_return_for_redraft]).each do |event|
+        - permitted_events = @permitted_events - [:add_responses, :add_response_to_flagged_case, :approve, :respond, :reassign_user, :upload_response_and_approve, :upload_response_and_return_for_redraft]
+        - if @case.type_abbreviation == 'SAR'
+          - permitted_events.delete(:close)
+
+        - permitted_events.each do |event|
           = action_button_for(event)
 
         - if policy(@case).assignments_execute_reassign_user?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -196,6 +196,7 @@ Rails.application.routes.draw do
         as: '',
         defaults: { correspondence_type: '' }
     get 'close', on: :member
+    get 'respond_and_close', on: :member
     get 'closed' => 'cases#closed_cases', on: :collection
     get 'confirm_destroy' => 'cases#confirm_destroy', on: :member
     get 'edit_closure', on: :member, as: :edit_closure
@@ -206,6 +207,7 @@ Rails.application.routes.draw do
     get 'open/in_time', to: redirect('/cases/open')
     get 'open/late',    to: redirect('/cases/open')
     patch 'process_closure', on: :member
+    patch 'process_respond_and_close', on: :member
     patch 'update_closure', on: :member
     get 'respond', on: :member
     patch 'confirm_respond', on: :member

--- a/config/state_machine/moj.yml
+++ b/config/state_machine/moj.yml
@@ -1085,6 +1085,11 @@ case_types:
               drafting:
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                respond_and_close:
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  transition_to: closed
+                respond:
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 close:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   transition_to: closed
@@ -1210,7 +1215,7 @@ case_types:
               awaiting_dispatch:
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-                close:
+                respond_and_close:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   transition_to: closed
                 reassign_user:

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.9
--- Dumped by pg_dump version 9.5.9
+-- Dumped from database version 9.5.6
+-- Dumped by pg_dump version 9.5.6
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe CasesController, type: :controller do
 
         it "closes a case that has been responded to" do
           sign_in responder
-          patch :process_closure, params: sar_closure_params(sar)
+          patch :process_respond_and_close, params: sar_closure_params(sar)
           expect(Case::SAR.first.current_state).to eq 'closed'
           expect(Case::SAR.first.refusal_reason_id).to eq CaseClosure::RefusalReason.tmm.id
           expect(Case::SAR.first.date_responded).to eq 3.days.ago.to_date

--- a/spec/factories/case/sars.rb
+++ b/spec/factories/case/sars.rb
@@ -136,6 +136,10 @@ FactoryGirl.define do
     date_responded { 4.business_days.ago }
 
     after(:create) do |kase, evaluator|
+      create :case_transition_respond,
+             case: kase,
+             acting_user_id: evaluator.responder.id,
+             acting_team_id: evaluator.responding_team.id
       create :case_transition_close,
              case: kase,
              acting_user_id: evaluator.manager.id,
@@ -157,6 +161,10 @@ FactoryGirl.define do
     date_responded { 4.business_days.ago }
 
     after(:create) do |kase, evaluator|
+      create :case_transition_respond,
+             case: kase,
+             acting_user_id: evaluator.responder.id,
+             acting_team_id: evaluator.responding_team.id
       create :case_transition_close,
              case: kase,
              acting_user_id: evaluator.manager.id,

--- a/spec/state_machines/workflows/sar_permitted_events/sar_standard_spec.rb
+++ b/spec/state_machines/workflows/sar_permitted_events/sar_standard_spec.rb
@@ -119,7 +119,9 @@ describe ConfigurableStateMachine::Machine do
           expect(k.current_state).to eq 'drafting'
           expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
                                                                         :close,
-                                                                        :reassign_user]
+                                                                        :reassign_user,
+                                                                        :respond,
+                                                                        :respond_and_close]
         end
       end
 

--- a/spec/state_machines/workflows/sar_permitted_events/sar_trigger_spec.rb
+++ b/spec/state_machines/workflows/sar_permitted_events/sar_trigger_spec.rb
@@ -178,8 +178,8 @@ describe ConfigurableStateMachine::Machine do
           responder = responder_in_assigned_team(k)
           expect(k.current_state).to eq 'awaiting_dispatch'
           expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                        :close,
-                                                                        :reassign_user]
+                                                                        :reassign_user,
+                                                                        :respond_and_close]
         end
       end
 

--- a/spec/views/cases/close_html_slim_spec.rb
+++ b/spec/views/cases/close_html_slim_spec.rb
@@ -12,7 +12,6 @@ describe 'cases/close.html.slim' do
               partial: 'cases/foi/close_form',
               locals: {
                 kase: foi_being_drafted,
-                form_url: process_closure_case_path(id: foi_being_drafted.id),
                 submit_button: 'Close case'
               }
             )
@@ -30,7 +29,6 @@ describe 'cases/close.html.slim' do
               partial: 'cases/sar/close_form',
               locals: {
                 kase: sar_being_drafted,
-                form_url: process_closure_case_path(id: sar_being_drafted.id),
                 submit_button: 'Close case'
               }
             )

--- a/spec/views/cases/sar/_close_form_html_slim_spec.rb
+++ b/spec/views/cases/sar/_close_form_html_slim_spec.rb
@@ -4,9 +4,9 @@ describe 'cases/sar/_close_form.html.slim' do
   let(:closed_sar) { create :closed_sar }
 
   it 'renders the close_form partial' do
+    assign(:case, closed_sar)
     render(partial: 'cases/sar/close_form.html.slim',
            locals: { kase: closed_sar.decorate,
-                     form_url: update_closure_case_path(id: closed_sar.id),
                      submit_button: 'Save changes' })
     cases_close_page.load(rendered)
 


### PR DESCRIPTION
SAR cases do not have uploaded responses, and so the first iteration was
that the responder simply closed the case when ready.  However, this meant
that the way of testing the response date of a case differed between FOI and
SAR cases, in that there was no respond event for SAR cases, and the close
event had to be used a a proxy.

This PR changes the close event for SARs to a respond_and_close which in fact
writes two events tothe transitions table: respond immediately followed by a
close