### PR TITLE
Re-initialise row object in take case on steps.

### DIFF
--- a/spec/support/features/steps/cases/taking_on_and_escalating_case_steps.rb
+++ b/spec/support/features/steps/cases/taking_on_and_escalating_case_steps.rb
@@ -1,7 +1,11 @@
 def take_on_case_step(kase:)
   row = incoming_cases_page.row_for_case_number(kase.number)
   row.actions.take_on_case.click
-  sleep 1
+  # The above click messes about with the DOM, causing intermittent errors with
+  # PhantomJS. Re-initialising the row object and waiting until actions shows
+  # up seems to be helping this.
+  row = incoming_cases_page.row_for_case_number(kase.number)
+  row.wait_until_actions_visible
   row.actions.wait_until_take_on_case_invisible(10)
   expect(row.actions).to have_undo_assign_link
   expect(row.actions.success_message)
@@ -12,7 +16,11 @@ end
 def undo_taking_case_on_step(kase:)
   row = incoming_cases_page.row_for_case_number(kase.number)
   row.actions.undo_assign_link.click
-  sleep 1
+  # The above click messes about with the DOM, causing intermittent errors with
+  # PhantomJS. Re-initialising the row object and waiting until actions shows
+  # up seems to be helping this.
+  row = incoming_cases_page.row_for_case_number(kase.number)
+  row.wait_until_actions_visible
   row.actions.wait_until_undo_assign_link_invisible(10)
   expect(row.actions).to have_take_on_case
   expect(row.actions).to have_no_success_message
@@ -22,7 +30,11 @@ end
 def de_escalate_case_step(kase:)
   row = incoming_cases_page.row_for_case_number(kase.number)
   row.actions.de_escalate_link.click
-  sleep 1
+  # The above click messes about with the DOM, causing intermittent errors with
+  # PhantomJS. Re-initialising the row object and waiting until actions shows
+  # up seems to be helping this.
+  row = incoming_cases_page.row_for_case_number(kase.number)
+  row.wait_until_actions_visible
   row.actions.wait_until_de_escalate_link_invisible(10)
   expect(row.actions).to have_undo_de_escalate_link
   expect(row.actions).to have_no_take_on_case
@@ -33,6 +45,11 @@ end
 def undo_de_escalate_case_step(kase:)
   row = incoming_cases_page.row_for_case_number(kase.number)
   row.actions.undo_de_escalate_link.click
+  # The above click messes about with the DOM, causing intermittent errors with
+  # PhantomJS. Re-initialising the row object and waiting until actions shows
+  # up seems to be helping this.
+  row = incoming_cases_page.row_for_case_number(kase.number)
+  row.wait_until_actions_visible
   row.actions.wait_until_undo_de_escalate_link_invisible(10)
   expect(row.actions).to have_de_escalate_link
   expect(row.actions).to have_take_on_case


### PR DESCRIPTION
In an attempt to solve intermittent CI errors.