### PR TITLE
CT-1325 move add message out of policy to predicates

### DIFF
--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -234,7 +234,7 @@ class Case::BasePolicy < ApplicationPolicy
 
   def can_add_message_to_case?
     clear_failed_checks
-    check_case_is_not_closed && (check_user_is_a_manager || check_user_is_an_approver_for_case || check_user_is_a_responder_for_case)
+    check_can_trigger_event(:add_message_to_case)
   end
 
   def execute_response_approval?

--- a/app/state_machines/workflows/predicates.rb
+++ b/app/state_machines/workflows/predicates.rb
@@ -16,6 +16,10 @@ class Workflows::Predicates
     @user.in?(@kase.approvers)
   end
 
+  def user_is_in_approving_team_for_case?
+    @user.in?(@kase.approving_team_users)
+  end
+
   def case_can_be_unflagged_for_clearance?
     case_can_be_unflagged_for_clearance_by_disclosure_specialist? ||
       case_can_be_unflagged_for_clearance_by_press_officer? ||

--- a/config/state_machine/moj.yml
+++ b/config/state_machine/moj.yml
@@ -189,7 +189,7 @@ case_types:
 
               responded:
                 add_message_to_case:
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#user_is_in_approving_team_for_case?
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 extend_for_pit:
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
@@ -354,6 +354,7 @@ case_types:
                 accept_approver_assignment:
                   if: Case::BasePolicy#can_accept_or_reject_approver_assignment?
                 add_message_to_case:
+                  if: Workflows::Predicates#user_is_in_approving_team_for_case?
                 flag_for_clearance:
                 link_a_case:
                 reassign_user:
@@ -471,7 +472,7 @@ case_types:
             states:
               unassigned:
                 add_message_to_case:
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 link_a_case:
                 remove_linked_case:
 
@@ -490,7 +491,7 @@ case_types:
               drafting:
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_response_to_flagged_case:
                   if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
                   transition_to: pending_dacu_clearance
@@ -503,7 +504,7 @@ case_types:
               pending_dacu_clearance:
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 link_a_case:
                 reassign_user:
                   if: Case::BasePolicy#assignments_reassign_user?
@@ -654,7 +655,7 @@ case_types:
                 accept_approver_assignment:
                   if: Case::BasePolicy#can_accept_or_reject_approver_assignment?
                 add_message_to_case:
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#user_is_in_approving_team_for_case?
                 flag_for_clearance:
                 link_a_case:
                 reassign_user:
@@ -670,7 +671,7 @@ case_types:
                 accept_approver_assignment:
                   if: Case::BasePolicy#can_accept_or_reject_approver_assignment?
                 add_message_to_case:
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#user_is_in_approving_team_for_case?
                 flag_for_clearance:
                 link_a_case:
                 reassign_user:
@@ -686,7 +687,7 @@ case_types:
                   if: Case::BasePolicy#can_accept_or_reject_approver_assignment?
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#user_is_in_approving_team_for_case?
                 extend_for_pit:
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
                 flag_for_clearance:
@@ -704,7 +705,7 @@ case_types:
                   if: Case::BasePolicy#can_accept_or_reject_approver_assignment?
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#user_is_in_approving_team_for_case?
                 approve:
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
                   transition_to: pending_press_office_clearance
@@ -734,7 +735,7 @@ case_types:
                 #   if: Case::BasePolicy#can_accept_or_reject_approver_assignment?
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#user_is_in_approving_team_for_case?
                 approve:
                   if: Workflows::Predicates#user_is_assigned_press_officer?
                   transition_to: pending_private_office_clearance
@@ -758,7 +759,7 @@ case_types:
                 #   if: Case::BasePolicy#can_accept_or_reject_approver_assignment?
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#user_is_in_approving_team_for_case?
                 approve:
                   if: Workflows::Predicates#user_is_assigned_private_officer?
                   transition_to: awaiting_dispatch
@@ -802,7 +803,7 @@ case_types:
 
               responded:
                 add_message_to_case:
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#user_is_in_approving_team_for_case?
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 extend_for_pit:
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
@@ -820,7 +821,7 @@ case_types:
             states:
               unassigned:
                 add_message_to_case:
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 link_a_case:
                 remove_linked_case:
 
@@ -839,7 +840,7 @@ case_types:
               drafting:
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_response_to_flagged_case:
                   if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
                   transition_to: pending_dacu_clearance
@@ -852,7 +853,7 @@ case_types:
               pending_dacu_clearance:
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 link_a_case:
                 reassign_user:
                   if: Case::BasePolicy#assignments_reassign_user?
@@ -861,7 +862,7 @@ case_types:
               pending_press_office_clearance:
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 link_a_case:
                 reassign_user:
                   if: Case::BasePolicy#assignments_reassign_user?
@@ -870,7 +871,7 @@ case_types:
               pending_private_office_clearance:
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                  if: Case::BasePolicy#can_add_message_to_case?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 link_a_case:
                 reassign_user:
                   if: Case::BasePolicy#assignments_reassign_user?

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1617,5 +1617,3 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180621094208'),
 ('20180622153909'),
 ('20180620135756');
-
-

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe MessagesController, type: :controller do
   let!(:responder)         { create :responder }
   let!(:another_responder) { create :responder }
   let!(:accepted_case)     { create :accepted_case, responder: responder }
+  let!(:closed_case)       { create :closed_case,
+                                    :flagged_accepted,
+                                    responder: responder,
+                                    approver: approver}
   let!(:flagged_case)      { create :accepted_case,
                                     :flagged_accepted,
                                     approver: approver }
@@ -37,6 +41,13 @@ RSpec.describe MessagesController, type: :controller do
         expect(response).to redirect_to(case_path(accepted_case, anchor: 'messages-section'))
       end
 
+      it 'allows them to post on a closed case' do
+
+        params[:case_id] = closed_case.id
+        post :create , params: params
+        expect(response).to redirect_to(case_path(closed_case, anchor: 'messages-section'))
+      end
+
       it "does not allow them to post to a case they are not responsible for" do
         sign_in another_responder
         post :create , params: params
@@ -52,6 +63,11 @@ RSpec.describe MessagesController, type: :controller do
         post :create , params: params
         expect(response).to redirect_to(case_path(accepted_case, anchor: 'messages-section'))
       end
+      it 'allows them to post on a closed case' do
+        params[:case_id] = closed_case.id
+        post :create , params: params
+        expect(response).to redirect_to(case_path(closed_case, anchor: 'messages-section'))
+      end
     end
 
     context "as a approver" do
@@ -60,6 +76,12 @@ RSpec.describe MessagesController, type: :controller do
       it "doesn't allow them to post messages to non-trigger cases" do
         post :create , params: params
         expect(response).to redirect_to(approver_root_path)
+      end
+
+      it 'allows them to post on a closed case' do
+        params[:case_id] = closed_case.id
+        post :create , params: params
+        expect(response).to redirect_to(case_path(closed_case, anchor: 'messages-section'))
       end
 
       it "redirects to case detail page and contains a anchor" do

--- a/spec/policies/cases/base_policy_spec.rb
+++ b/spec/policies/cases/base_policy_spec.rb
@@ -423,9 +423,9 @@ describe Case::BasePolicy do
     # let(:other_responder) { create :responder }
 
     context 'closed case' do
-      it { should_not permit(manager,     closed_case) }
-      it { should_not permit(approver,    closed_case) }
-      it { should_not permit(responder,   closed_case) }
+      it { should     permit(manager,     closed_case) }
+      it { should     permit(approver,    closed_case) }
+      it { should     permit(responder,   closed_case) }
     end
 
     context 'open case' do

--- a/spec/state_machines/foi_event_spec.rb
+++ b/spec/state_machines/foi_event_spec.rb
@@ -253,12 +253,10 @@ describe 'state machine' do
                  [:disclosure_specialist_coworker, :full_closed_foi],
 
                  [:another_disclosure_specialist, :std_closed_foi],
-                 [:another_disclosure_specialist, :trig_unassigned_foi],
                  [:another_disclosure_specialist, :trig_awresp_foi],
                  [:another_disclosure_specialist, :trig_draft_foi],
                  [:another_disclosure_specialist, :trig_pdacu_foi],
                  [:another_disclosure_specialist, :trig_closed_foi],
-                 [:another_disclosure_specialist, :trig_unassigned_foi_accepted],
                  [:another_disclosure_specialist, :trig_awresp_foi_accepted],
                  [:another_disclosure_specialist, :trig_draft_foi_accepted],
                  [:another_disclosure_specialist, :trig_pdacu_foi_accepted],
@@ -326,11 +324,9 @@ describe 'state machine' do
 
 
                  [:press_officer, :std_closed_foi],
-                 [:press_officer, :trig_unassigned_foi],
                  [:press_officer, :trig_awresp_foi],
                  [:press_officer, :trig_draft_foi],
                  [:press_officer, :trig_pdacu_foi],
-                 [:press_officer, :trig_unassigned_foi_accepted],
                  [:press_officer, :trig_awresp_foi_accepted],
                  [:press_officer, :trig_draft_foi_accepted],
                  [:press_officer, :trig_pdacu_foi_accepted],
@@ -350,11 +346,9 @@ describe 'state machine' do
 
 
                  [:private_officer, :std_closed_foi],
-                 [:private_officer, :trig_unassigned_foi],
                  [:private_officer, :trig_awresp_foi],
                  [:private_officer, :trig_draft_foi],
                  [:private_officer, :trig_pdacu_foi],
-                 [:private_officer, :trig_unassigned_foi_accepted],
                  [:private_officer, :trig_awresp_foi_accepted],
                  [:private_officer, :trig_draft_foi_accepted],
                  [:private_officer, :trig_pdacu_foi_accepted],


### PR DESCRIPTION
Policy was not changed in the first go at this ticket meaning that users could not add messages to cases even on closed cases even when the state machine allowed it.

This PR moves the can add message to case policy out of the base policy and into the state machine where the policy was being called.