### PR TITLE
CT-1810 change close event to respond and close in cli create

### DIFF
--- a/lib/cts/cases/create.rb
+++ b/lib/cts/cases/create.rb
@@ -253,8 +253,8 @@ module CTS::Cases
         kase.close(CTS::dacu_manager)
       else
         kase.prepare_for_close
-        kase.update(date_responded: Date.today)
-        kase.close(responder)
+        kase.update(date_responded: Date.today, missing_info: false)
+        kase.respond_and_close(responder)
       end
     end
 


### PR DESCRIPTION
The admin pages use this method to create cases.

It was causing an error on dev and not recording in stats locally