### PR TITLE
CT-1816 cannot assign SAR without message

### DIFF
--- a/app/views/cases/_case_request.html.slim
+++ b/app/views/cases/_case_request.html.slim
@@ -3,10 +3,10 @@
     = t('common.case.request')
 
   .request--message
-    - if case_details.is_sar? || case_details.sent_by_email?
+    - if case_details.message.present?
       p
         = show_hide_message(case_details)
-    - elsif case_details.is_sar? || case_details.sent_by_post?
+    - if case_details.attachments.request.present?
       - case_details.upload_request_groups.each do |ug|
         .case-attachments-group
           h3.case-attachments--primary

--- a/spec/features/cases/foi/case_creating/creating_spec.rb
+++ b/spec/features/cases/foi/case_creating/creating_spec.rb
@@ -28,7 +28,6 @@ feature 'FOI Case creation by a manager' do
   end
 
   scenario 'creating a case with request attachments', js: true  do
-    stub_s3_uploader_for_all_files!
     request_attachment = Rails.root.join('spec', 'fixtures', 'request-1.pdf')
 
     create_foi_case_step delivery_method: :sent_by_post,

--- a/spec/features/cases/foi/case_viewing/viewing_spec.rb
+++ b/spec/features/cases/foi/case_viewing/viewing_spec.rb
@@ -96,9 +96,33 @@ feature 'viewing details of case in the system' do
       cases_show_page.load id: old_foi.id
       expect(cases_show_page).to have_no_escalation_notice
     end
-
   end
 
+  context 'FOI case with both full case details and attachment' do
+    given(:request_file) { "#{Faker::Internet.slug}.pdf" }
+    given(:foi) do
+      create :accepted_case, :sent_by_post,
+             requester_type: :offender,
+             name: 'Freddie FOI',
+             email: 'freddie.foi@testing.digital.justice.gov.uk',
+             subject: 'this is a foi',
+             message: 'viewing foi details test message',
+             responding_team: responding_team,
+             uploaded_request_files: [request_file]
+    end
+
+    scenario 'displaying case details' do
+      cases_show_page.load id: foi.id
+
+      expect(cases_show_page.request).to have_message
+      expect(cases_show_page.request.message.text)
+        .to eq 'viewing foi details test message'
+      expect(cases_show_page.request).to have_attachments
+      expect(cases_show_page.request.attachments.count).to eq 1
+      expect(cases_show_page.request.attachments[0].collection[0].filename.text)
+        .to eq request_file
+    end
+  end
 
   context 'viewing case request with a long message' do
 

--- a/spec/features/cases/sar/case_creating/creating_spec.rb
+++ b/spec/features/cases/sar/case_creating/creating_spec.rb
@@ -25,6 +25,20 @@ feature 'SAR Case creation by a manager' do
       .to include responding_team.team_lead
   end
 
+  scenario 'creating a non-trigger SAR case with only uploaded files', js: true do
+    request_attachment = Rails.root.join('spec', 'fixtures', 'request-1.pdf')
+
+    create_sar_case_step(message: '',
+                         uploaded_request_files: [request_attachment])
+
+    responding_team = responder.responding_teams.first
+    assign_case_step business_unit: responding_team
+
+    # Clearance level should display deputy director
+    expect(cases_show_page.clearance_levels.basic_details.deputy_director.text)
+      .to include responding_team.team_lead
+  end
+
   scenario 'creating a case that needs clearance' do
     create_sar_case_step flag_for_disclosure: true
 

--- a/spec/features/cases/sar/case_viewing_spec.rb
+++ b/spec/features/cases/sar/case_viewing_spec.rb
@@ -52,4 +52,29 @@ feature 'viewing SAR cases' do
       expect(open_cases_page).to be_displayed
     end
   end
+
+  context 'case with both full case details and attachment' do
+    given(:request_file) { "#{Faker::Internet.slug}.pdf" }
+    given(:kase) do
+      create :accepted_sar,
+             responder: responder,
+             uploading_user: manager,
+             uploaded_request_files: [request_file]
+    end
+
+    scenario 'displaying case details' do
+      login_as responder
+
+      cases_show_page.load id: kase.id
+
+      expect(cases_show_page.request).to have_message
+      expect(cases_show_page.request.message.text)
+        .to eq kase.message
+      expect(cases_show_page.request).to have_attachments
+      expect(cases_show_page.request.attachments.count).to eq 1
+      expect(cases_show_page.request.attachments[0].collection[0].filename.text)
+        .to eq request_file
+    end
+  end
+
 end

--- a/spec/models/case/sar_spec.rb
+++ b/spec/models/case/sar_spec.rb
@@ -91,16 +91,36 @@ describe Case::SAR do
   end
 
   describe '#message' do
-    it 'validates presence if uploaded_request_files is missing' do
+    it 'validates presence if uploaded_request_files is missing on create' do
       kase = build :sar_case, uploaded_request_files: [], message: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:message]).to eq ["can't be blank"]
+      expect(kase.errors[:message])
+        .to eq ["can't be blank if no request files attached"]
     end
 
-    it 'does validates presence if uploaded_request_files is present' do
+    it 'validates presence if attached request files is missing on update' do
+      kase = create :sar_case, uploaded_request_files: [], message: 'foo'
+      expect(kase).to be_valid
+      kase.update_attributes(message: '')
+      expect(kase).not_to be_valid
+      expect(kase.errors[:message])
+        .to eq ["can't be blank if no request files attached"]
+    end
+
+    it 'can be empty on create if uploaded_request_files is present' do
       kase = build :sar_case,
                    uploaded_request_files: ["#{Faker::Internet.slug}.pdf"],
                    message: ''
+      expect(kase).to be_valid
+    end
+
+    it 'can be empty on update if attached request files is present' do
+      kase = create :sar_case,
+                    uploaded_request_files: ["#{Faker::Internet.slug}.pdf"],
+                    uploading_user: create(:manager),
+                    message: 'foo'
+      expect(kase).to be_valid
+      kase.update_attributes(message: '')
       expect(kase).to be_valid
     end
   end
@@ -116,7 +136,8 @@ describe Case::SAR do
     it 'validates presence if message is missing' do
       kase = build :sar_case, uploaded_request_files: [], message: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:uploaded_request_files]).to eq ["can't be blank"]
+      expect(kase.errors[:uploaded_request_files])
+        .to eq ["can't be blank if no case details entered"]
     end
 
     it 'does validates presence if message is present' do

--- a/spec/site_prism/page_objects/pages/cases/new/sar_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/sar_page.rb
@@ -54,7 +54,6 @@ module PageObjects
             if kase.third_party?
               choose_third_party true
               requester_full_name.set kase.name
-
             else
               choose_third_party false
             end
@@ -78,7 +77,7 @@ module PageObjects
           def drop_in_dropzone(file_path)
             super file_path: file_path,
                   input_name: dropzone_container['data-file-input-name'],
-                  container_selector: '#delivery-method-fields'
+                  container_selector: '.dropzone'
           end
 
           def choose_flag_for_disclosure_specialists(choice = 'yes')

--- a/spec/support/features/steps/cases/create_steps.rb
+++ b/spec/support/features/steps/cases/create_steps.rb
@@ -53,7 +53,9 @@ def create_ico_case_step(original_case_type: nil,
   Case::Base.find(kase_id)
 end
 
-def create_sar_case_step flag_for_disclosure: false
+def create_sar_case_step(params={})
+  flag_for_disclosure = params.delete(:flag_for_disclosure) { false }
+
   # Assume we are on a case listing page
   expect(cases_page).to have_new_case_button
   cases_page.new_case_button.click
@@ -63,7 +65,7 @@ def create_sar_case_step flag_for_disclosure: false
   cases_new_page.create_link_for_correspondence('SAR').click
   expect(cases_new_sar_page).to be_displayed
 
-  cases_new_sar_page.fill_in_case_details
+  cases_new_sar_page.fill_in_case_details(params)
   cases_new_sar_page.choose_flag_for_disclosure_specialists(
     flag_for_disclosure ? 'yes' : 'no'
   )

--- a/spec/views/cases/_case_request_html_slim_spec.rb
+++ b/spec/views/cases/_case_request_html_slim_spec.rb
@@ -35,25 +35,24 @@ describe 'cases/case_request.html.slim', type: :view do
 
 
   describe 'Displaying a short request' do
-    let(:kase) { double Case::BaseDecorator,
-                        message: "This is a request for information",
-                        message_extract: ["This is a request for information"],
-                        delivery_method: "sent_by_email",
-                        sent_by_email?: true,
-                        is_sar?: false,
-                        is_foi?: true
-    }
+    let(:kase) { create(:case_being_drafted,
+                        message: "This is a request for information") }
+    let(:decorated_case) do
+      kase.decorate.tap do |c|
+        allow(c).to receive(:message_extract)
+                      .and_return(["This is a request for information"])
+      end
+    end
 
     let(:partial) do
       render partial: 'cases/case_request.html.slim',
-             locals:{ case_details: kase}
+             locals:{ case_details: decorated_case }
 
       case_request_section(rendered)
     end
 
     it 'displays the full request for a short request ' do
-      expect(partial.message.text)
-          .to eq kase.message
+      expect(partial.message.text).to eq kase.message
     end
 
     it 'does not have a collapsed request' do
@@ -66,19 +65,16 @@ describe 'cases/case_request.html.slim', type: :view do
 
 
   describe 'displaying a long request and collapsing content' do
-    let(:kase) { double Case::BaseDecorator,
-                        message:  long_message,
-                        message_extract: [short_message,last_part],
-                        delivery_method: "sent_by_email",
-                        sent_by_email?: true,
-                        is_sar?: false,
-                        is_foi?: true
-
-    }
+    let(:kase) { create(:case_being_drafted, message: long_message) }
+    let(:decorated_case) do
+      kase.decorate.tap do |c|
+        allow(c).to receive(:message_extract).and_return([short_message,last_part])
+      end
+    end
 
     let(:partial) do
       render partial: 'cases/case_request.html.slim',
-             locals:{ case_details: kase}
+             locals:{ case_details: decorated_case}
 
       case_request_section(rendered)
     end
@@ -96,11 +92,15 @@ describe 'cases/case_request.html.slim', type: :view do
 
   describe 'displays request attachments for postal FOI' do
     let(:sent_by_post) { create :case, :sent_by_post }
+    let(:decorated_case) do
+      sent_by_post.decorate.tap do |c|
+        allow(c).to receive(:message_extract).and_return([sent_by_post.message, ''])
+      end
+    end
 
     let(:partial) do
-      stub_s3_uploader_for_all_files!
       render partial: 'cases/case_request.html.slim',
-             locals:{ case_details: sent_by_post }
+             locals:{ case_details: decorated_case }
 
       case_request_section(rendered)
     end


### PR DESCRIPTION
Fixes issues with being able to create SAR cases without entering case details, and with being able to view uploaded request attachments for a SAR case.