### PR TITLE
CT-1824 Bugfix for responders not able to upload after approval

### DIFF
--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -426,8 +426,7 @@ class Case::BasePolicy < ApplicationPolicy
 
   # check case_is_in_responder_attachable_state
   check :case_is_in_attachable_state do
-    (self.case.drafting? || self.case.awaiting_dispatch?) &&
-        self.case.assignments.approving.approved.none?
+    self.case.drafting? || self.case.awaiting_dispatch?
   end
 
   check :escalation_deadline_has_expired do

--- a/spec/factories/case/fois.rb
+++ b/spec/factories/case/fois.rb
@@ -341,6 +341,18 @@ FactoryBot.define do
     end
   end
 
+  factory :redrafting_case, parent: :pending_private_clearance_case do
+    after(:create) do |kase, _evaluator|
+      team_dacu_disclosure = find_or_create :team_dacu_disclosure
+      disclosure_approval  = kase.assignments.approving.where(team_id: team_dacu_disclosure.id).first
+      disclosure_approval.update(approved: true)
+
+      kase.update(current_state: 'drafting')
+      kase.reload
+    end
+
+  end
+
   factory :approved_case, parent: :pending_dacu_clearance_case do
     transient do
       approving_team { find_or_create :team_dacu_disclosure }

--- a/spec/features/cases/foi/case_responding/upload_response_spec.rb
+++ b/spec/features/cases/foi/case_responding/upload_response_spec.rb
@@ -25,7 +25,7 @@ feature 'Upload response' do
     scenario 'restrict upload more responses to an approved case' do
       cases_show_page.load(id: approved_case.id)
 
-      expect(cases_show_page.actions).to have_no_upload_response
+      expect(cases_show_page.actions).to have_upload_response
     end
 
   end

--- a/spec/policies/cases/base_policy_spec.rb
+++ b/spec/policies/cases/base_policy_spec.rb
@@ -77,6 +77,13 @@ describe Case::BasePolicy do
     @press_flagged_case             = create :assigned_case,
                                              :flagged_accepted,
                                              :press_office
+    @redrafting_case                = create :redrafting_case,
+                                             :flagged_accepted,
+                                             :press_office,
+                                             approving_team: @dacu_disclosure,
+                                             approver: @disclosure_specialist,
+                                             responder: @responder
+
 
     @pending_dacu_clearance_press_case =
       create :pending_dacu_clearance_case_flagged_for_press,
@@ -133,6 +140,7 @@ describe Case::BasePolicy do
 
   let(:drafting_trigger_case) { @drafting_trigger_case }
   let(:press_flagged_case) { @press_flagged_case }
+  let(:redrafting_case)    { @redrafting_case }
 
   let(:pending_dacu_clearance_press_case) { @pending_dacu_clearance_press_case }
   let(:pending_press_private_clearance_case) { @pending_press_private_clearance_case }
@@ -290,6 +298,13 @@ describe Case::BasePolicy do
         it { should_not permit(coworker,          pending_dacu_clearance_case) }
         it { should_not permit(another_responder, pending_dacu_clearance_case) }
         it { should     permit(approver,          pending_dacu_clearance_case) }
+      end
+
+      context 'case being re-drafted after approval' do
+        it { should     permit(responder,         redrafting_case) }
+        it { should     permit(coworker,          redrafting_case) }
+        it { should_not permit(manager,           redrafting_case) }
+        it { should_not permit(another_responder, redrafting_case) }
       end
     end
   end

--- a/spec/services/case_create_service_spec.rb
+++ b/spec/services/case_create_service_spec.rb
@@ -95,7 +95,7 @@ describe CaseCreateService do
   
   context 'ICO case' do
     let(:received)    { Date.today }
-    let(:deadline)    { 1.month.from_now }
+    let(:deadline)    { 1.month.from_now.beginning_of_day + 10.hours }
     let(:params) do
       {
           'type'                    => 'Case::ICO::FOI',


### PR DESCRIPTION
If a responder has uploaded a document to a flagged case, and that case
has been approved by disclosure, but amends requested by Press or Private,
the responder was not able to upload documents again once the case was
back in drafting due to a condition that prohibited it if there was an approved
approver assignemtn on the case.  This fix removes that prohibition, allowing
responders to upload if the case is in drafting regardless of whether or not the
case has previously been approved.