### PR TITLE
CT-1830 ensure we only retrieve accepted responder assignments

### DIFF
--- a/app/mailers/action_notifications_mailer.rb
+++ b/app/mailers/action_notifications_mailer.rb
@@ -45,7 +45,7 @@ class ActionNotificationsMailer < GovukNotifyRails::Mailer
   def notify_information_officers(kase, type)
     RavenContextProvider.set_context
 
-    recipient = kase.responder_assignment.user
+    recipient = kase.assignments.responding.accepted.first.user
     find_template(type)
 
     set_personalisation(

--- a/spec/mailers/action_notifications_mailer_spec.rb
+++ b/spec/mailers/action_notifications_mailer_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe ActionNotificationsMailer, type: :mailer do
                                    subject: 'The anatomy of man' }
     let(:assignment)      { approved_case.responder_assignment }
     let(:responding_team) { assignment.team }
-    let(:responder)       { responding_team.responders.first }
+    let(:responder)       { approved_case.responder }
     let(:mail)            { described_class.notify_information_officers(approved_case, 'Ready to send')}
 
     it 'personalises the email' do
@@ -140,6 +140,17 @@ RSpec.describe ActionNotificationsMailer, type: :mailer do
 
     it 'sets the To address of the email using the provided user' do
       expect(mail.to).to include assignment.user.email
+    end
+
+    context 'with a case that still has pending assignments' do
+      it 'uses the accepted responder assignment' do
+        other_responding_team = create(:responding_team, responders: [responder])
+        approved_case.assignments << Assignment.new(role: 'responding',
+                                                    team: other_responding_team,
+                                                    state: 'pending')
+        approved_case.reload
+        expect(mail.to).to include responder.email
+      end
     end
 
     context 'ready to send' do


### PR DESCRIPTION
We had a bug where in some situations, when retrieving "responder_assignment" on
a case we would return an assignment that hadn't been accepted, which led to
errors when trying to, for example, trying to send an email to the responding
user assigned to a case.