### PR TITLE
CT-1869 Fix bug caused by deleting linked cases

### DIFF
--- a/app/models/linked_case.rb
+++ b/app/models/linked_case.rb
@@ -26,7 +26,6 @@ class LinkedCase < ApplicationRecord
   after_create :create_reverse_link
   after_destroy :destroy_reverse_link
 
-  validates :linked_case, presence: true
   validates :linked_case_number,
             presence: true,
             if: -> { linked_case_id.nil? }


### PR DESCRIPTION
If a case had linked cases, and one of the linked cases was subsequently
soft deleted, that case became invalid, and could no longer be updated due
to failing validation errors.

This is fixed by the removal of the  `vaidates :linked_case` on the 'LinkedCase'
model.  This is not required, as there are validations for either linked_case id or
linked case number on creation.