### PR TITLE
CT-1842 Add tests for OverturnedSARPolicy

### DIFF
--- a/app/validators/case_link_type_validator.rb
+++ b/app/validators/case_link_type_validator.rb
@@ -21,6 +21,8 @@ class CaseLinkTypeValidator < ActiveModel::Validator
                                         'Case::ICO::SAR'],
       'Case::ICO::SAR'              => ['Case::SAR',
                                         'Case::ICO::SAR'],
+      'Case::OverturnedICO::SAR'    => ['Case::SAR'],
+
     },
     original: {
       'Case::ICO::FOI'            => ['Case::FOI::Standard'],

--- a/spec/policies/cases/overturned_ico/sar_policy_spec.rb
+++ b/spec/policies/cases/overturned_ico/sar_policy_spec.rb
@@ -2,15 +2,29 @@ require 'rails_helper'
 
 RSpec.describe Case::OverturnedICO::SARPolicy do
   subject { described_class }
-  let(:manager)     { create :manager }
-  let(:approver)    { create :disclosure_specialist }
-  let(:responder)   { create :responder}
+
+  let(:managing_team)         { find_or_create :team_dacu }
+  let(:other_managing_team)   { create :managing_team }
+  let(:manager)               { managing_team.managers.first }
+  let(:responding_team)       { create :responding_team }
+  let(:responder)             { responding_team.responders.first }
+  let(:dacu_disclosure)       { find_or_create :team_dacu_disclosure }
+  let(:disclosure_specialist) { dacu_disclosure.approvers.first }
+
+  let(:unassigned_case)       { create :overturned_ico_sar }
+
+  let(:manager)               { managing_team.managers.first }
+  let(:other_manager)         { other_managing_team.managers.first }
+  let(:responder)             { responding_team.responders.first }
+  let(:press_officer)         { find_or_create :press_officer }
+  let(:private_officer)       { find_or_create :private_officer }
+  let(:disclosure_approver)   { dacu_disclosure.approvers.first }
 
 
   permissions :can_add_case? do
-    it { should     permit(manager,     Case::OverturnedICO::SAR) }
-    it { should_not permit(approver,    Case::OverturnedICO::SAR) }
-    it { should_not permit(responder,   Case::OverturnedICO::SAR) }
+    it { should     permit(manager,                 Case::OverturnedICO::SAR) }
+    it { should_not permit(disclosure_specialist,   Case::OverturnedICO::SAR) }
+    it { should_not permit(responder,               Case::OverturnedICO::SAR) }
   end
 
   permissions :new_overturned_ico? do
@@ -28,7 +42,7 @@ RSpec.describe Case::OverturnedICO::SARPolicy do
       end
 
       context 'approver' do
-        it { should_not permit(approver, Case::OverturnedICO::Base) }
+        it { should_not permit(disclosure_specialist, Case::OverturnedICO::Base) }
       end
 
       context 'feature set not enabled' do
@@ -61,9 +75,38 @@ RSpec.describe Case::OverturnedICO::SARPolicy do
         end
 
         context 'approver' do
-          it { should_not permit(approver, Case::OverturnedICO::Base) }
+          it { should_not permit(disclosure_specialist, Case::OverturnedICO::Base) }
         end
       end
     end
+  end
+
+
+  permissions :show? do
+    context 'unassigned case' do
+      it { should     permit(manager,               unassigned_case) }
+      it { should_not permit(responder,             unassigned_case) }
+      it { should_not permit(disclosure_specialist, unassigned_case) }
+    end
+
+    context 'linked case' do
+      let!(:linked_case) do
+        create(:closed_sar, responding_team: responding_team).tap do |kase|
+          unassigned_case.related_cases << kase
+        end
+      end
+
+      it { should_not permit(responder,             unassigned_case) }
+      it { should_not permit(disclosure_specialist, unassigned_case) }
+    end
+  end
+
+  permissions :new_case_link? do
+    it { should     permit(manager,             unassigned_case) }
+    it { should_not permit(other_manager,       unassigned_case) }
+    it { should_not permit(responder,           unassigned_case) }
+    it { should_not permit(press_officer,       unassigned_case) }
+    it { should_not permit(private_officer,     unassigned_case) }
+    it { should_not permit(disclosure_approver, unassigned_case) }
   end
 end

--- a/spec/policies/cases/sar_policy_spec.rb
+++ b/spec/policies/cases/sar_policy_spec.rb
@@ -12,10 +12,10 @@ describe Case::SARPolicy do
   let(:team_disclosure)       { find_or_create :team_dacu_disclosure }
   let(:disclosure_specialist) { team_disclosure.approvers.first }
 
-  let(:unassigned_case) { create :sar_case }
+  let(:unassigned_case)       { create :sar_case }
   let(:other_managing_team)   { create :managing_team }
   let(:responding_team)       { create :responding_team }
-  let(:dacu_disclosure)      { find_or_create :team_dacu_disclosure }
+  let(:dacu_disclosure)       { find_or_create :team_dacu_disclosure }
 
   # Users
   let(:manager)               { managing_team.managers.first }


### PR DESCRIPTION
the `OverturnedSARPolicy` is a subclass of` SARPolicy` with just one addition,
in fact looks a bit thin on the ground to me).  This PR introduces the same tests that we have for
`SARPolicy` to `OverturnedSARPolicy`.