### PR TITLE
add translation for event assign_new_team

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,6 +209,7 @@ en:
     add_responses: Response uploaded
     approve: Response cleared
     assign_responder: Assign responder
+    assign_to_new_team: Assign to new team
     close: Case closed
     edit_case: Case details edited
     extend_for_pit: Extended for Public Interest Test (PIT)


### PR DESCRIPTION
quick fix for assign_to_new_team having a missing translation in the case history. I've created a ticket to investigate it further