### PR TITLE
CT-1808 Bugfix for users with multiple roles

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -362,7 +362,7 @@ class CasesController < ApplicationController
     close_params = process_closure_params(@case.type_abbreviation)
     if @case.update(close_params)
       @case.state_machine.update_closure!(acting_user: current_user,
-                                          acting_team: @case.team_for_user(current_user))
+                                          acting_team: @case.team_for_unassigned_user(current_user, :manager))
       set_permitted_events
       flash[:notice] = t('notices.closure_details_updated')
       redirect_to case_path(@case)
@@ -597,7 +597,7 @@ class CasesController < ApplicationController
     authorize @case
 
     @case.state_machine.progress_for_clearance!(acting_user: current_user,
-                                                acting_team: @case.team_for_user(current_user),
+                                                acting_team: @case.team_for_assigned_user(current_user, :responder),
                                                 target_team: @case.approver_assignments.first.team)
 
     flash[:notice] = t('notices.progress_for_clearance')
@@ -612,8 +612,7 @@ class CasesController < ApplicationController
       format.js do
         if process_new_linked_cases_for_params
           response = render_to_string(
-            partial: "cases/#{ @correspondence_type_key }/case_linking/" \
-                     "linked_cases",
+            partial: "cases/#{ @correspondence_type_key }/case_linking/linked_cases",
             locals: {
               linked_cases: @linked_cases.map(&:decorate),
               link_type: @link_type,

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -317,11 +317,11 @@ class Case::Base < ApplicationRecord
   end
 
   def upload_response_groups
-    CaseAttachmentUploadGroupCollection.new(self, attachments.response)
+    CaseAttachmentUploadGroupCollection.new(self, attachments.response, :responder)
   end
 
   def upload_request_groups
-    CaseAttachmentUploadGroupCollection.new(self, attachments.request)
+    CaseAttachmentUploadGroupCollection.new(self, attachments.request, :manager)
   end
 
   def info_held_status_abbreviation
@@ -336,9 +336,12 @@ class Case::Base < ApplicationRecord
     @default_team_service ||= DefaultTeamService.new(self)
   end
 
-  def team_for_user(user)
-    assignments.where(user_id: user.id).first&.team ||
-      (teams & user.teams).first
+  def team_for_assigned_user(user, role)
+    TeamFinderService.new(self, user, role).team_for_assigned_user
+  end
+
+  def team_for_unassigned_user(user, role)
+    TeamFinderService.new(self, user, role).team_for_unassigned_user
   end
 
   def allow_event?(user, event)

--- a/app/models/case_attachment_upload_group.rb
+++ b/app/models/case_attachment_upload_group.rb
@@ -4,11 +4,11 @@ class CaseAttachmentUploadGroup
 
   attr_reader :user, :collection, :timestamp, :team_name
 
-  def initialize(array_of_time_and_user_id, kase, collection)
+  def initialize(array_of_time_and_user_id, role, kase, collection)
     @timestamp = get_time(array_of_time_and_user_id.first)
     @user = User.find(array_of_time_and_user_id.last)
     @collection = collection.to_a
-    team = kase.team_for_user(@user)
+    team = kase.team_for_unassigned_user(@user, role)
     @team_name = team.nil? ? '' : team.name
 
   end

--- a/app/models/case_attachment_upload_group_collection.rb
+++ b/app/models/case_attachment_upload_group_collection.rb
@@ -1,11 +1,11 @@
 class CaseAttachmentUploadGroupCollection
 
 
-  def initialize(kase, attachments)
+  def initialize(kase, attachments, role)
     groups_keyed_by_array_of_time_and_user_id = attachments.group_by { |at| [at.upload_group, at.user_id] }
     @grouped_collection = []
     groups_keyed_by_array_of_time_and_user_id.each do | array_of_time_and_user_id, collection|
-      @grouped_collection << CaseAttachmentUploadGroup.new(array_of_time_and_user_id, kase, collection)
+      @grouped_collection << CaseAttachmentUploadGroup.new(array_of_time_and_user_id, role, kase, collection)
     end
     @grouped_collection.sort!
   end
@@ -21,6 +21,4 @@ class CaseAttachmentUploadGroupCollection
     raise ArgumentError.new "No upload group contains a case attachment with id #{case_attachment_id}" unless result
     result
   end
-
-
 end

--- a/app/models/concerns/case_states.rb
+++ b/app/models/concerns/case_states.rb
@@ -44,8 +44,9 @@ module CaseStates
   end
 
   def respond(current_user)
+    team = self.assignments.accepted.where(user_id: current_user.id).first.team
     ActiveRecord::Base.transaction do
-      state_machine.respond!(acting_user: current_user, acting_team: self.team_for_user(current_user))
+      state_machine.respond!(acting_user: current_user, acting_team: team)
     end
   end
 

--- a/app/services/team_finder_service.rb
+++ b/app/services/team_finder_service.rb
@@ -1,0 +1,63 @@
+
+class TeamFinderService
+
+  class UserNotFoundError < RuntimeError
+    def initialize(team_finder_service)
+      user = team_finder_service.user
+      kase = team_finder_service.kase
+      role = team_finder_service.assignment_role
+      super("No accepted assignment with role '#{role}' for user #{user.id} on case #{kase.id}")
+    end
+  end
+
+  class AssignmentNotFound < RuntimeError
+    def initialize(team_finder_service)
+      kase = team_finder_service.kase
+      role = team_finder_service.assignment_role
+      super ("No accepted assignment found for case #{kase} with role '#{role}'")
+    end
+  end
+
+
+  TEAM_ROLES = {
+      manager: :managing,
+      responder: :responding,
+      approver: :approving
+  }.freeze
+
+  attr_reader :kase, :user, :assignment_role
+
+  def initialize(kase, user, team_role)
+    @kase             = kase
+    @user             = user
+    @team_role        = team_role
+    @assignment_role  = translate_role_for_assignment
+  end
+
+  # returns the team for the named user on the case. The user must be an accepted assigned user
+  # on the case, or a TeamFinderService::UserNotFound error is raised
+  #
+  def team_for_assigned_user
+    assignments = @kase.assignments.accepted.where(user_id: @user.id, role: @assignment_role)
+    raise UserNotFoundError.new(self) if assignments.empty?
+    assignments.singular.team
+  end
+
+  # returns the team for the user, where the team is accepted for the specified role in the case assignments
+  #
+  def team_for_unassigned_user
+    assigned_teams = @kase.assignments.where(state: [:accepted, :pending], role: @assignment_role).map(&:team)
+    raise UserNotFoundError.new(self) if assigned_teams.empty?
+    user_teams = @user.team_roles.where(role: @team_role).map(&:team)
+    (assigned_teams & user_teams).first
+  end
+
+
+  private
+
+  def translate_role_for_assignment
+    raise ArgumentError.new('Invalid role') unless @team_role.in?(TEAM_ROLES.keys)
+    TEAM_ROLES[@team_role]
+  end
+end
+

--- a/spec/features/cases/sar/case_viewing_spec.rb
+++ b/spec/features/cases/sar/case_viewing_spec.rb
@@ -66,7 +66,6 @@ feature 'viewing SAR cases' do
       login_as responder
 
       cases_show_page.load id: kase.id
-
       expect(cases_show_page.request).to have_message
       expect(cases_show_page.request.message.text)
         .to eq kase.message

--- a/spec/models/case_attachment_upload_group_collection_spec.rb
+++ b/spec/models/case_attachment_upload_group_collection_spec.rb
@@ -49,7 +49,7 @@ describe CaseAttachmentUploadGroupCollection do
 
     it 'returns a team name for each group' do
       team_names = []
-      expect(@kase).to receive(:team_for_user).exactly(2).and_return(create(:business_unit, name: 'Team 1'), create(:business_unit, name: 'Team 2'))
+      expect(@kase).to receive(:team_for_unassigned_user).exactly(2).and_return(create(:business_unit, name: 'Team 1'), create(:business_unit, name: 'Team 2'))
       @kase.upload_response_groups.each { |ug| team_names << ug.team_name }
       expect(team_names).to match_array [ 'Team 1', 'Team 2']
     end

--- a/spec/models/case_attachment_upload_group_spec.rb
+++ b/spec/models/case_attachment_upload_group_spec.rb
@@ -20,7 +20,7 @@ describe CaseAttachmentUploadGroup do
   after(:all) { DbHousekeeping.clean }
 
 
-  let(:upload_group) { CaseAttachmentUploadGroup.new([@upload_group, @responder.id], @kase, @kase.attachments) }
+  let(:upload_group) { CaseAttachmentUploadGroup.new([@upload_group, @responder.id], :responder, @kase, @kase.attachments) }
 
   describe '#user' do
     it 'returns the user specified by the id' do

--- a/spec/services/team_finder_service_spec.rb
+++ b/spec/services/team_finder_service_spec.rb
@@ -1,0 +1,139 @@
+require 'rails_helper'
+
+
+describe TeamFinderService do
+
+  # teams
+  let(:team_bmt)                    { find_or_create :team_disclosure_bmt }
+  let(:team_disclosure)             { find_or_create :team_disclosure }
+  let(:team_candi)                  { create :responding_team, name: 'Candi' }
+  let(:other_team)                  { create :responding_team, name: 'Other responding team' }
+
+  # users
+  let(:responder)                   { create :responder, responding_teams: [team_candi] }
+  let(:other_responder)             { create :responder, responding_teams: [team_candi] }
+  let(:multi_role_user) do
+    create :user,
+           managing_teams: [team_bmt],
+           approving_team: team_disclosure,
+           responding_teams: [team_candi]
+  end
+  let(:disclosure_specialist)       { create :disclosure_specialist }
+  let(:other_approver)              { create :user, approving_team: team_disclosure }
+
+  #cases
+  let(:kase) do
+    create :case_with_response, :flagged_accepted,
+           responder: responder,
+           approving_team: team_disclosure,
+           approver: disclosure_specialist
+  end
+
+  let(:multi_role_managed_case) do
+    create :case_with_response, :flagged_accepted,
+           responder: multi_role_user,
+           approving_team: team_disclosure,
+           approver: multi_role_user
+  end
+
+
+  let(:other_responder_case)        { create :case_with_response, responder: other_responder }
+
+
+  describe '#team_for_assigned_user' do
+    context 'no such assignment with specified user' do
+      it 'raises' do
+        expect{
+          TeamFinderService.new(kase, other_responder, :approver).team_for_assigned_user
+        }.to raise_error TeamFinderService::UserNotFoundError,
+                         "No accepted assignment with role 'approving' for user #{other_responder.id} on case #{kase.id}"
+      end
+    end
+
+    context 'assignment with user exists, but not for specified role' do
+      it 'raises' do
+        expect{
+          TeamFinderService.new(kase, disclosure_specialist, :responder).team_for_assigned_user
+        }.to raise_error TeamFinderService::UserNotFoundError,
+                         "No accepted assignment with role 'responding' for user #{disclosure_specialist.id} on case #{kase.id}"
+      end
+    end
+
+    context 'assignment with user exists for specified role, but not accepted' do
+      it 'raises' do
+        assignment = kase.assignments.responding.accepted.first
+        assignment.update!(state: 'pending')
+        expect{
+          TeamFinderService.new(kase, responder, :responder).team_for_assigned_user
+        }.to raise_error TeamFinderService::UserNotFoundError,
+                         "No accepted assignment with role 'responding' for user #{responder.id} on case #{kase.id}"
+      end
+    end
+
+    context 'accepted assignment for user with specified role exists' do
+      it 'returns the team' do
+        team = TeamFinderService.new(kase, responder, :responder).team_for_assigned_user
+        expect(team).to eq team_candi
+      end
+    end
+
+    context 'accepted assignment exist for user with multiple roles' do
+      it 'returns the correct team for the role' do
+        user_assignments = multi_role_managed_case.assignments.accepted.where(user_id: multi_role_user.id)
+        expect(user_assignments.size).to eq 2
+        expect(user_assignments.map(&:team_id)).to match_array( [ team_disclosure.id, team_candi.id ] )
+        team = TeamFinderService.new(multi_role_managed_case, multi_role_user, :approver).team_for_assigned_user
+        expect(team).to eq team_disclosure
+      end
+    end
+  end
+
+
+  describe '#team_for_unassigned_user' do
+    context 'no assignments on case with specified role' do
+      it 'raises' do
+        responder_assignment = kase.assignments.responding.singular
+        responder_assignment.destroy!
+        expect{
+          TeamFinderService.new(kase, responder, :responder).team_for_unassigned_user
+        }.to raise_error TeamFinderService::UserNotFoundError,
+                   "No accepted assignment with role 'responding' for user #{responder.id} on case #{kase.id}"
+      end
+    end
+
+    context 'assignment exists with the specified role, but is not accepted' do
+      it 'raises' do
+        responder_assignment = kase.assignments.responding.singular
+        responder_assignment.update!(state: 'rejected', reasons_for_rejection: 'just because')
+        expect{
+          TeamFinderService.new(kase, responder, :responder).team_for_unassigned_user
+        }.to raise_error TeamFinderService::UserNotFoundError,
+                         "No accepted assignment with role 'responding' for user #{responder.id} on case #{kase.id}"
+      end
+    end
+
+    context 'user is member of team that is assigned to case in specified role' do
+      it 'returns the team' do
+        team =  TeamFinderService.new(kase, other_responder, :responder).team_for_unassigned_user
+        expect(team).to eq team_candi
+      end
+    end
+
+    context 'multi-role user is member of team which is assigned to case in specified role' do
+      it 'returns the team' do
+        team =  TeamFinderService.new(multi_role_managed_case, multi_role_user, :responder).team_for_unassigned_user
+        expect(team).to eq team_candi
+      end
+    end
+  end
+
+  context 'Invalid team role' do
+    it 'raises' do
+      expect {
+        TeamFinderService.new('mock_case', 'mock_user', :assessor)
+      }.to raise_error ArgumentError, 'Invalid role'
+    end
+  end
+
+
+end

--- a/spec/support/features/interactions.rb
+++ b/spec/support/features/interactions.rb
@@ -199,6 +199,7 @@ module Features
     def do_case_reassign_to(user)
       reassign_user_page.choose_assignment_user user
       reassign_user_page.confirm_button.click
+
       expect(cases_show_page).to be_displayed
       expect(cases_show_page.case_history.entries.first)
         .to have_text("re-assigned this case to #{user.full_name}")


### PR DESCRIPTION
A bug was reported where users with multiple roles (manager, responder and approver)
were unable to mark a case as responded.

This is caused by the Case::Base#team_for_user method which was used to determine
which team to pass into the state machine as the acting team.  It just took the
first team that was common to both the case (i.e. on the assignements) and the User#team_roles.
This took no account of the role of the team, therefore we had the clash of StateMachine
events being called with a team which had no rights to perform that event.

This has been replaced by two methods:

 - Case::Base#team_for_assigned_user(user, role)
 - Case::Base#team_for_unassigned_user(user, role)

Note that both methods now take role as a parameter, to ensure that the correct matching team
is returned.

the difference between the two methods are that #team_for_assigned_user looks for an intersect between
the user's teams, and the accepted assignments for that user on the case, whereas #team_for_unassigned_user
looks for an intersect between the user's teams and teams on assignments in  unassigned or pending (not necessarily
for the same user).