### PR TITLE
CT-1848 update Accept/reject page to support ICO Appeals

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -76,6 +76,7 @@ class AssignmentsController < ApplicationController
         redirect_to case_path @case, accepted_now: false
       else
         authorize @case, :can_accept_or_reject_responder_assignment?
+        @correspondence_type_key = @case.type_abbreviation.downcase
         render :edit
       end
     else

--- a/app/views/assignments/edit.html.slim
+++ b/app/views/assignments/edit.html.slim
@@ -4,15 +4,7 @@
 = GovukElementsErrorsHelper.error_summary @assignment,
   "#{pluralize(@assignment.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""
 
-- content_for :heading
-  = @case.subject
-
-- content_for :sub_heading
-  span.visually-hidden
-    = t('common.case.header_case_number')
-  = @case.number
-
-= render partial: 'layouts/header'
+= render partial: 'shared/components/case_page_heading', locals: {kase: @case}
 
 section.case-info
   = render partial: 'cases/case_status', locals: { case_details: @case }

--- a/app/views/assignments/edit.html.slim
+++ b/app/views/assignments/edit.html.slim
@@ -6,37 +6,37 @@
 
 = render partial: 'shared/components/case_page_heading', locals: {kase: @case}
 
-section.case-info
-  = render partial: 'cases/case_status', locals: { case_details: @case }
+div id="case-#{@correspondence_type_key}" class="case"
+  section.case-info
+    = render partial: 'cases/case_status', locals: { case_details: @case }
 
-section.case-info
-  = render partial: 'cases/linked_cases', locals: { case_details: @case }
+  = render partial: 'shared/components/case_linked_cases'
 
-section.case-info
-  = render partial: 'cases/case_request', locals: { case_details: @case }
+  section.case-info
+    = render partial: 'cases/case_request', locals: { case_details: @case }
 
-section.case-info
-  = render partial: "cases/#{@case.type_abbreviation.downcase}/case_details",
-           locals: { case_details: @case, link_type: nil }
+  section.case-info
+    = render partial: "cases/#{@case.type_abbreviation.downcase}/case_details",
+             locals: { case_details: @case, link_type: nil }
 
-section.case-info
-  = render partial: 'cases/clearance_levels', locals: {case_details: @case }
+  section.case-info
+    = render partial: 'cases/clearance_levels', locals: {case_details: @case }
 
-section#messages-section.case-info
-  = render partial: 'cases/case_messages', locals: { case_details: @case }
+  section#messages-section.case-info
+    = render partial: 'cases/case_messages', locals: { case_details: @case }
 
-- if @case_transitions.any?
-  section.case-info.has-page-break
-    = render partial: 'cases/case_history', locals: { case_transitions: @case_transitions }
+  - if @case_transitions.any?
+    section.case-info.has-page-break
+      = render partial: 'cases/case_history', locals: { case_transitions: @case_transitions }
 
-= render partial: 'shared/components/case_page_original_case_details'
+  = render partial: 'shared/components/case_page_original_case_details'
 
-.grid-row
-  section.case-main
-    = form_for [@case, @assignment], url: accept_or_reject_case_assignment_path(@case, @assignment) do |f|
-      #js-assigment-actions
-        = f.radio_button_fieldset :state, choices: [:accepted, :rejected], inline: true
+  .grid-row
+    section.case-main
+      = form_for [@case, @assignment], url: accept_or_reject_case_assignment_path(@case, @assignment) do |f|
+        #js-assigment-actions
+          = f.radio_button_fieldset :state, choices: [:accepted, :rejected], inline: true
 
-      #js-rejected-reasons.panel.panel-border-narrow
-        = f.text_area :reasons_for_rejection
-      = f.submit t('button.confirm'), class: 'button'
+        #js-rejected-reasons.panel.panel-border-narrow
+          = f.text_area :reasons_for_rejection
+        = f.submit t('button.confirm'), class: 'button'

--- a/app/views/assignments/edit.html.slim
+++ b/app/views/assignments/edit.html.slim
@@ -29,6 +29,8 @@ section#messages-section.case-info
   section.case-info.has-page-break
     = render partial: 'cases/case_history', locals: { case_transitions: @case_transitions }
 
+= render partial: 'shared/components/case_page_original_case_details'
+
 .grid-row
   section.case-main
     = form_for [@case, @assignment], url: accept_or_reject_case_assignment_path(@case, @assignment) do |f|

--- a/app/views/cases/foi/_case_details.html.slim
+++ b/app/views/cases/foi/_case_details.html.slim
@@ -34,6 +34,6 @@
       / display links to edit case and/or closure details
       = case_details_links(case_details, current_user).html_safe
 
-    - if case_details.closed? && !case_details.allow_event?(current_user, :update_closure)
-      p
-        = t('.cannot_update_closure_html')
+      - if case_details.closed? && !case_details.allow_event?(current_user, :update_closure)
+        p
+          = t('.cannot_update_closure_html')

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -83,11 +83,6 @@ div id="case-#{@correspondence_type_key}" class="case"
     section.case-info.has-page-break
       = render partial: 'cases/case_history', locals: { case_transitions: @case_transitions }
 
-  - if @case.ico?
-    section.case-info
-      = render partial: "cases/#{@case.original_case.type_abbreviation.downcase}/case_details",
-              locals: { case_details: @case.original_case.decorate,
-                        link_type: 'original' }
-
+  = render partial: 'shared/components/case_page_original_case_details'
   section.case-info
     = action_links_for_allowed_events(@case, :extend_for_pit, :destroy_case).join(' | ').html_safe

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -47,15 +47,7 @@ div id="case-#{@correspondence_type_key}" class="case"
   section.case-info
     = render partial: 'cases/case_status', locals: {case_details: @case}
 
-  - if @case.ico?
-    - if case_attachments_visible_for_case?
-      section.case-info
-        = render partial: 'cases/case_attachments', locals: { case_details: @case }
-    section.case-info
-      = render partial: 'cases/ico/show_linked_cases', locals: { case_details: @case }
-  - else
-    section.case-info
-      = render partial: 'cases/linked_cases', locals: { case_details: @case }
+  = render partial: 'shared/components/case_linked_cases'
 
   section.case-info
     = render partial: 'cases/case_request', locals: {case_details: @case}

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -9,17 +9,8 @@
   .alert-orange
     = t('alerts.escalation_warning_html', escalation_deadline: @case.escalation_deadline)
 
-- content_for :heading
-  span.visually-hidden
-    = t('common.case.header_subject')
-  = @case.subject
 
-- content_for :sub_heading
-  span.visually-hidden
-    = t('common.case.header_case_number')
-  = "#{@case.number} - #{@case.pretty_type}"
-
-= render partial: 'layouts/header'
+= render partial: 'shared/components/case_page_heading', locals: {kase: @case}
 
 div id="case-#{@correspondence_type_key}" class="case"
   section.case-info.has-actions

--- a/app/views/shared/components/_case_linked_cases.html.slim
+++ b/app/views/shared/components/_case_linked_cases.html.slim
@@ -1,0 +1,9 @@
+- if @case.ico?
+  - if case_attachments_visible_for_case?
+    section.case-info
+      = render partial: 'cases/case_attachments', locals: { case_details: @case }
+  section.case-info
+    = render partial: 'cases/ico/show_linked_cases', locals: { case_details: @case }
+- else
+  section.case-info
+    = render partial: 'cases/linked_cases', locals: { case_details: @case }

--- a/app/views/shared/components/_case_page_heading.html.slim
+++ b/app/views/shared/components/_case_page_heading.html.slim
@@ -1,0 +1,11 @@
+- content_for :heading
+  span.visually-hidden
+    = t('common.case.header_subject')
+  = kase.subject
+
+- content_for :sub_heading
+  span.visually-hidden
+    = t('common.case.header_case_number')
+  = "#{kase.number} - #{kase.pretty_type}"
+
+= render partial: 'layouts/header'

--- a/app/views/shared/components/_case_page_original_case_details.html.slim
+++ b/app/views/shared/components/_case_page_original_case_details.html.slim
@@ -1,0 +1,5 @@
+- if @case.ico?
+  section.case-info
+    = render partial: "cases/#{@case.original_case.type_abbreviation.downcase}/case_details",
+            locals: { case_details: @case.original_case.decorate,
+                      link_type: 'original' }

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -606,6 +606,15 @@ RSpec.describe AssignmentsController, type: :controller do
       expect(assigns(:case)).to eq assignment.case
     end
 
+    it 'sets @@correspondence_type_key' do
+      get :edit, params: {
+        id: assignment.id,
+        case_id: assignment.case.id
+      }
+      expect(assigns(:correspondence_type_key)).to eq 'foi'
+    end
+
+
     it 'syncs case transitions tracker for user' do
       stub_find_case(assignment.case.id) do |kase|
         expect(kase).to receive(:sync_transition_tracker_for_user)

--- a/spec/site_prism/page_objects/pages/assignments/edit_page.rb
+++ b/spec/site_prism/page_objects/pages/assignments/edit_page.rb
@@ -9,6 +9,10 @@ module PageObjects
         section :page_heading,
                 PageObjects::Sections::PageHeadingSection, '.page-heading'
 
+        section :ico,
+                PageObjects::Sections::Cases::ICO::ShowSection,
+                '#case-ico'
+
         section :case_status,
                 PageObjects::Sections::Cases::CaseStatusSection, '.case-status'
 

--- a/spec/site_prism/page_objects/pages/assignments/edit_page.rb
+++ b/spec/site_prism/page_objects/pages/assignments/edit_page.rb
@@ -16,7 +16,7 @@ module PageObjects
                 PageObjects::Sections::Cases::CaseDetailsSection, '.case-details'
 
         element :message_label, '.request--heading'
-        element :message, '.request--message'
+        element :message, '.request--message p'
 
         section :request,
                 PageObjects::Sections::Cases::CaseRequestSection, '.request'
@@ -33,6 +33,10 @@ module PageObjects
 
         section :case_history,
                 PageObjects::Sections::Cases::CaseHistorySection, '#case-history'
+
+        section :original_case_details, '.original-case-details' do
+          element :link_to_case, 'a'
+        end
 
         element :accept_radio, 'label[for="assignment_state_accepted"]'
 

--- a/spec/views/assignments/edit_page_spec.rb
+++ b/spec/views/assignments/edit_page_spec.rb
@@ -45,9 +45,10 @@ describe 'assignments/edit.html.slim', type: :view do
 
     page = assignments_edit_page
 
-    expect(page.page_heading.heading.text).to eq awaiting_responder_case.subject
+    expect(page.page_heading.heading.text)
+        .to eq "Case subject, #{awaiting_responder_case.subject}"
     expect(page.page_heading.sub_heading.text)
-        .to eq "You are viewing case number #{awaiting_responder_case.number} "
+        .to eq "You are viewing case number #{awaiting_responder_case.number} - #{awaiting_responder_case.pretty_type} "
 
     expect(page).to have_case_status
 

--- a/spec/views/assignments/edit_page_spec.rb
+++ b/spec/views/assignments/edit_page_spec.rb
@@ -33,6 +33,7 @@ describe 'assignments/edit.html.slim', type: :view do
 
     assign(:case, awaiting_responder_case)
     assign(:case_transitions, awaiting_responder_case.transitions.decorate)
+    assign(:correspondence_type_key, awaiting_responder_case.type_abbreviation.downcase)
     assign(:assignment, assignment)
 
     login_as responder
@@ -51,6 +52,8 @@ describe 'assignments/edit.html.slim', type: :view do
         .to eq "You are viewing case number #{awaiting_responder_case.number} - #{awaiting_responder_case.pretty_type} "
 
     expect(page).to have_case_status
+
+    expect(page).to have_no_ico
 
     expect(page).to have_case_details
 
@@ -81,6 +84,7 @@ describe 'assignments/edit.html.slim', type: :view do
     it 'should display page and sections for ICO cases' do
       assign(:case, awaiting_responder_case)
       assign(:case_transitions, awaiting_responder_case.transitions.decorate)
+      assign(:correspondence_type_key, awaiting_responder_case.type_abbreviation.downcase)
       assign(:assignment, assignment_for_ico)
 
       login_as responder
@@ -99,6 +103,10 @@ describe 'assignments/edit.html.slim', type: :view do
           .to eq "You are viewing case number #{awaiting_responder_case.number} - #{awaiting_responder_case.pretty_type} "
 
       expect(page).to have_case_status
+
+      expect(page).to have_ico
+
+      expect(page.ico).to have_original_cases
 
       expect(page).to have_case_details
 


### PR DESCRIPTION
- [x] add case type to assignments page heading
- [x] Add "Original case's details" section
- [x] Add "Original case/Related case" section
