### PR TITLE
Fix Dev seeder

### DIFF
--- a/db/data_migrations/20180808010203_populate_dev_teams_and_users.rb
+++ b/db/data_migrations/20180808010203_populate_dev_teams_and_users.rb
@@ -1,0 +1,8 @@
+class PopulateDevTeamsAndUsers < ActiveRecord::DataMigration
+  def up
+    unless Rails.env.production?
+      Rake::Task['db:seed:dev:teams'].invoke
+      Rake::Task['db:seed:dev:users'].invoke
+    end
+  end
+end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -9,12 +9,8 @@ namespace :db do
 
   desc 'Clear the database, run migrations and basic seeds (not users, teams, roles)'
   task :reseed => :clear do
-    # ENV['RESEEDING_DATABASE'] = '1'
-    # Rake::Task['db:migrate'].invoke
     Rake::Task['db:structure_load'].invoke
     Rake::Task['data:migrate'].invoke
-    Rake::Task['db:seed:dev:teams'].invoke
-    Rake::Task['db:seed:dev:users'].invoke
   end
   
   task :structure_load => :environment do


### PR DESCRIPTION
The rake task `db:reseed` was not working correctly - the business
units were not able to process Overturned SAR correspondence types.

This was because the data migration PopulateTeamsForOverturnedSars
was being run before the teams had been populated, and therefore had
no effect.  This was fixed by adding an additional data migration to
run the DevUserSeeder instead of running it in the rake task itself,
with a check to ensure it doesn't run on production.