### PR TITLE
CT-1912 Allow SAR and ICO Overturned SAR cases to be reassigned

### DIFF
--- a/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
@@ -35,6 +35,7 @@
               drafting:
                 add_message_to_case:
                 assign_to_new_team:
+                  transition_to: awaiting_responder
                 destroy_case:
                 edit_case:
                 flag_for_clearance:

--- a/config/state_machine/configs/00_moj/20_sar/30_sar_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/20_sar/30_sar_trigger_workflow.yml
@@ -30,6 +30,7 @@
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
+                  transition_to: awaiting_responder
                 destroy_case:
                 edit_case:
                 flag_for_clearance:
@@ -39,7 +40,6 @@
               pending_dacu_clearance:
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                assign_to_new_team:
                 destroy_case:
                 edit_case:
                 link_a_case:
@@ -48,7 +48,6 @@
               awaiting_dispatch:
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                assign_to_new_team:
                 destroy_case:
                 edit_case:
                 link_a_case:

--- a/config/state_machine/configs/00_moj/40_overturned_sar/20_overturned_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_overturned_sar/20_overturned_sar_standard_workflow.yml
@@ -19,6 +19,7 @@
               awaiting_responder:
                 add_message_to_case:
                 assign_to_new_team:
+                  transition_to: awaiting_responder
                 destroy_case:
                 edit_case:
                 flag_for_clearance:
@@ -29,6 +30,7 @@
               drafting:
                 add_message_to_case:
                 assign_to_new_team:
+                  transition_to: awaiting_responder
                 destroy_case:
                 edit_case:
                 flag_for_clearance:

--- a/config/state_machine/configs/00_moj/40_overturned_sar/30_overturned_sar_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_overturned_sar/30_overturned_sar_trigger_workflow.yml
@@ -28,6 +28,7 @@
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
+                  transition_to: awaiting_responder
                 destroy_case:
                 edit_case:
                 link_a_case:
@@ -37,6 +38,7 @@
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
+                  transition_to: awaiting_responder
                 destroy_case:
                 edit_case:
                 link_a_case:

--- a/spec/factories/case/overturned_icos.rb
+++ b/spec/factories/case/overturned_icos.rb
@@ -1,11 +1,12 @@
 FactoryBot.define do
 
-  factory :overturned_ico_sar, class: Case::OverturnedICO::SAR do
-
+  factory :overturned_ico_sar,
+          aliases: [:ot_ico_sar_noff_unassigned],
+          class: Case::OverturnedICO::SAR do
     transient do
-      creation_time   { 4.business_days.ago }
-      identifier      { 'new overturned ico sar case' }
-      managing_team   { find_or_create :team_dacu }
+      creation_time   { Time.now }
+      # creation_time   { 4.business_days.ago }
+      identifier      { "unassigned overturned ico sar" }
     end
 
     message                         { identifier }
@@ -21,10 +22,14 @@ FactoryBot.define do
     email                           { 'dave@moj.com' }
   end
 
-  factory :awaiting_responder_overturned_ico_sar, parent: :overturned_ico_sar do
+  factory :awaiting_responder_ot_ico_sar,
+          aliases: [:ot_ico_sar_noff_awresp],
+          parent: :overturned_ico_sar do
+
     transient do
-      identifier      { "assigned overturned ico sar case" }
+      identifier      { "awaiting responder overturned ico sar case" }
       manager         { managing_team.managers.first }
+      managing_team   { find_or_create :team_dacu }
       responding_team { create :responding_team }
     end
 
@@ -48,12 +53,14 @@ FactoryBot.define do
     end
   end
 
+  factory :accepted_ot_ico_sar,
+          aliases: [:ot_ico_sar_noff_draft],
+          parent: :awaiting_responder_ot_ico_sar do
 
-  factory :accepted_overturned_ico_sar, parent: :awaiting_responder_overturned_ico_sar do
     transient do
-      identifier          { "accepted overturned ico sar case" }
-      responder           { create :responder }
-      responding_team     { responder.responding_teams.first }
+      identifier      { "responder accepted overturned ico sar case" }
+      responder       { create :responder }
+      responding_team { responder.responding_teams.first }
     end
 
     after(:create) do |kase, evaluator|
@@ -68,6 +75,28 @@ FactoryBot.define do
     end
   end
 
+  factory :pending_dacu_clearance_to_ico_sar,
+          aliases: [:ot_ico_sar_noff_pdacu],
+          parent: :accepted_ot_ico_sar do
+    transient do
+      approving_team { find_or_create :team_dacu_disclosure }
+      approver       { create :disclosure_specialist }
+    end
+    workflow { 'trigger' }
+
+    after(:create) do |kase, evaluator|
+      create :approver_assignment,
+             case: kase,
+             team: evaluator.approving_team,
+             state: 'accepted',
+             user_id: evaluator.approver.id
+
+      create :case_transition_pending_dacu_clearance,
+             case_id: kase.id,
+             acting_user_id: evaluator.responder.id
+      kase.reload
+    end
+  end
 
   factory :overturned_ico_foi, class: Case::OverturnedICO::FOI do
     current_state                   { 'unassigned' }

--- a/spec/factories/case/overturned_icos.rb
+++ b/spec/factories/case/overturned_icos.rb
@@ -4,8 +4,7 @@ FactoryBot.define do
           aliases: [:ot_ico_sar_noff_unassigned],
           class: Case::OverturnedICO::SAR do
     transient do
-      creation_time   { Time.now }
-      # creation_time   { 4.business_days.ago }
+      creation_time   { 4.business_days.ago }
       identifier      { "unassigned overturned ico sar" }
     end
 

--- a/spec/features/cases/foi/case_reassign_team_spec.rb
+++ b/spec/features/cases/foi/case_reassign_team_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+feature 'Assigning an FOI case to a new team' do
+  given(:disclosure_bmt_user) { create :disclosure_bmt_user }
+  given(:responding_team)     { create :responding_team }
+
+  background do
+    login_as disclosure_bmt_user
+  end
+
+  scenario 're-assigning a closed FOI case' do
+    responding_team
+
+    closed_case = create :closed_case
+
+    cases_show_page.load(id: closed_case.id)
+    cases_show_page.actions.assign_to_new_team.click
+
+    assign_case_step business_unit: responding_team,
+                     assigning_page: assign_to_new_team_page,
+                     expected_status: 'Case closed',
+                     expected_flash_msg: 'Case has been assigned to a new team'
+  end
+end

--- a/spec/features/cases/sar/case_assigning_new_team_spec.rb
+++ b/spec/features/cases/sar/case_assigning_new_team_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature 'Assigning a closed case to a new team' do
+feature 'Assigning a SAR case to a new team' do
   given(:disclosure_bmt_user) { create :disclosure_bmt_user }
   given(:responding_team)     { create :responding_team }
 
@@ -8,7 +8,7 @@ feature 'Assigning a closed case to a new team' do
     login_as disclosure_bmt_user
   end
 
-  scenario 're-assigning a SAR case' do
+  scenario 're-assigning a closed SAR case' do
     responding_team
 
     closed_case = create :closed_sar
@@ -21,18 +21,32 @@ feature 'Assigning a closed case to a new team' do
                      expected_status: 'Case closed',
                      expected_flash_msg: 'Case has been assigned to a new team'
   end
-  
-  scenario 're-assigning a closed FOI case' do
+
+  scenario 're-assigning a SAR case that is being drafted' do
     responding_team
 
-    closed_case = create :closed_case
+    accepted_case = create :accepted_sar
 
-    cases_show_page.load(id: closed_case.id)
+    cases_show_page.load(id: accepted_case.id)
     cases_show_page.actions.assign_to_new_team.click
 
     assign_case_step business_unit: responding_team,
                      assigning_page: assign_to_new_team_page,
-                     expected_status: 'Case closed',
+                     expected_status: 'To be accepted',
+                     expected_flash_msg: 'Case has been assigned to a new team'
+  end
+
+  scenario 're-assigning a trigger SAR case that is being drafted' do
+    responding_team
+
+    accepted_case = create :accepted_sar
+
+    cases_show_page.load(id: accepted_case.id)
+    cases_show_page.actions.assign_to_new_team.click
+
+    assign_case_step business_unit: responding_team,
+                     assigning_page: assign_to_new_team_page,
+                     expected_status: 'To be accepted',
                      expected_flash_msg: 'Case has been assigned to a new team'
   end
 end

--- a/spec/services/case_finder_service_spec.rb
+++ b/spec/services/case_finder_service_spec.rb
@@ -114,7 +114,7 @@ describe CaseFinderService do
                                                            responder: @responder,
                                                            original_case: @awaiting_responder_overturned_ico_sar_original,
                                                            identifier: '19B-original ico appeal for 18-overturned ico sar')
-        @awaiting_responder_overturned_ico_sar    = create :awaiting_responder_overturned_ico_sar,
+        @awaiting_responder_overturned_ico_sar    = create :awaiting_responder_ot_ico_sar,
                                                            responding_team: @responding_team,
                                                            original_case: @awaiting_responder_overturned_ico_sar_original,
                                                            original_ico_appeal: @awaiting_responder_overturned_ico_sar_original_appeal,
@@ -128,7 +128,7 @@ describe CaseFinderService do
                                                            responder: @responder,
                                                            original_case: @accepted_overturned_ico_sar_original,
                                                            identifier: '20B-original ico appeal for 18-overturned ico sar')
-        @accepted_overturned_ico_sar              = create :accepted_overturned_ico_sar,
+        @accepted_overturned_ico_sar              = create :accepted_ot_ico_sar,
                                                            responding_team: @responding_team,
                                                            original_case: @accepted_overturned_ico_sar_original,
                                                            original_ico_appeal: @accepted_overturned_ico_sar_original_appeal,

--- a/spec/state_machines/overturned_sar_event_spec.rb
+++ b/spec/state_machines/overturned_sar_event_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe 'state machine' do
+
+  before(:all) do
+    DbHousekeeping.clean
+    @setup = StandardSetup.new(
+      only_cases: [
+        :ot_ico_sar_noff_unassigned,
+        :ot_ico_sar_noff_awresp,
+        :ot_ico_sar_noff_draft,
+        :ot_ico_sar_noff_trig_awresp,
+        :ot_ico_sar_noff_trig_awresp_accepted,
+        :ot_ico_sar_noff_trig_draft,
+        :ot_ico_sar_noff_trig_draft_accepted,
+      ]
+    )
+  end
+
+
+  after(:all) { DbHousekeeping.clean }
+
+  describe :assign_to_new_team do
+    it { should permit_event_to_be_triggered_only_by(
+                  [:disclosure_bmt, :ot_ico_sar_noff_awresp],
+                  [:disclosure_bmt, :ot_ico_sar_noff_draft],
+                  [:disclosure_bmt, :ot_ico_sar_noff_trig_awresp],
+                  [:disclosure_bmt, :ot_ico_sar_noff_trig_awresp_accepted],
+                  [:disclosure_bmt, :ot_ico_sar_noff_trig_draft],
+                  [:disclosure_bmt, :ot_ico_sar_noff_trig_draft_accepted],
+                ).with_transition_to(:awaiting_responder) }
+
+    # We haven't done closed ICO Overturned SAR cases yet. When we do,
+    # re-instate this test.
+    #
+    # it { should permit_event_to_be_triggered_only_by(
+    #               [:disclosure_bmt, :ot_ico_sar_noff_closed],
+    #             ).with_transition_to(:closed) }
+  end
+
+  def all_user_teams
+    @setup.user_teams
+  end
+
+  def all_cases
+    @setup.cases
+  end
+end

--- a/spec/state_machines/sar_event_spec.rb
+++ b/spec/state_machines/sar_event_spec.rb
@@ -10,12 +10,32 @@ describe 'state machine' do
         :sar_noff_awresp,
         :sar_noff_draft,
         :sar_noff_closed,
+        :sar_noff_trig_awdis,
+        :sar_noff_trig_awresp,
+        :sar_noff_trig_awresp_accepted,
+        :sar_noff_trig_draft,
+        :sar_noff_trig_draft_accepted,
       ]
     )
   end
 
 
   after(:all) { DbHousekeeping.clean }
+
+  describe :assign_to_new_team do
+    it { should permit_event_to_be_triggered_only_by(
+                  [:disclosure_bmt, :sar_noff_awresp],
+                  [:disclosure_bmt, :sar_noff_draft],
+                  [:disclosure_bmt, :sar_noff_trig_awresp],
+                  [:disclosure_bmt, :sar_noff_trig_awresp_accepted],
+                  [:disclosure_bmt, :sar_noff_trig_draft],
+                  [:disclosure_bmt, :sar_noff_trig_draft_accepted],
+                ).with_transition_to(:awaiting_responder) }
+
+    it { should permit_event_to_be_triggered_only_by(
+                  [:disclosure_bmt, :sar_noff_closed],
+                ).with_transition_to(:closed) }
+  end
 
   describe :update_closure do
     it { should permit_event_to_be_triggered_only_by(

--- a/spec/state_machines/workflows/sar_permitted_events/sar_trigger_spec.rb
+++ b/spec/state_machines/workflows/sar_permitted_events/sar_trigger_spec.rb
@@ -52,7 +52,6 @@ describe ConfigurableStateMachine::Machine do
           k = create :pending_dacu_clearance_sar, :flagged_accepted
           expect(k.current_state).to eq 'pending_dacu_clearance'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :assign_to_new_team,
                                                                       :destroy_case,
                                                                       :edit_case,
                                                                       :link_a_case,
@@ -65,7 +64,6 @@ describe ConfigurableStateMachine::Machine do
           k = create :approved_sar, :flagged_accepted
           expect(k.current_state).to eq 'awaiting_dispatch'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :assign_to_new_team,
                                                                       :destroy_case,
                                                                       :edit_case,
                                                                       :link_a_case,


### PR DESCRIPTION
SAR and ICO Overturned SAR cases need to be re-assignable to a new team when in
drafting. This change adds that, and removes the same re-assignability from
pending_dacu_disclosure and awaiting_dispatch states, as that wouldn't have
worked anyway and we don't yet know what to do when that happens. Once the case
is accepted by the new team, should it then go back to the state it was in
previously? Probably, but that work is outside the scope of this bug.

Other noteworthy changes in this commit:

- Change permit_trigger_event matcher to allow the 'transition_to' option to be
  specified. When present, the matcher will only match the case state and user
  to the event if the event has a transition_to to the specified state. This
  does mean that events that transition to another/no state will be treated as
  not-present, so another test will need to be added for those.

  See spec/state_machines/sar_event_spec.rb to see how this is used.

- Cases created by standard setup don't need an identifier set, that'll be taken
  from the name of the case as provided in the StandardSetup config.