### PR TITLE
CT-1916 Fix Erroneous error message

### DIFF
--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -241,4 +241,11 @@ module CasesHelper
       'case-details'
     end
   end
+
+  def manager_updating_close_details_on_old_case?(user, kase)
+    # the only reason a manager can't the closure details of a closed case is because
+    # it is an "old style" closure, i.e. it was closed before we implemented the new
+    # outcomes, info_held statuses, refusal reasons, etc
+    user.manager? && kase.closed? && !kase.allow_event?(user, :update_closure)
+  end
 end

--- a/app/views/cases/foi/_case_details.html.slim
+++ b/app/views/cases/foi/_case_details.html.slim
@@ -34,6 +34,7 @@
       / display links to edit case and/or closure details
       = case_details_links(case_details, current_user).html_safe
 
-      - if case_details.closed? && !case_details.allow_event?(current_user, :update_closure)
+      - if manager_updating_close_details_on_old_case?(current_user, @case)
+
         p
           = t('.cannot_update_closure_html')

--- a/spec/features/cases/foi/editing_case_closure_spec.rb
+++ b/spec/features/cases/foi/editing_case_closure_spec.rb
@@ -45,4 +45,16 @@ feature 'editing case closure information' do
     expect(cases_show_page.case_details)
       .to have_text("This is an old case with closure details that can't be edited. If you need to edit this case let us know.")
   end
+
+  scenario 'responder views case details for FOI with old closure info', js: true do
+    responder = create :responder
+    kase = create :closed_case, responder: responder
+    kase.update_attribute(:info_held_status_id, nil)
+
+    login_as responder
+    cases_show_page.load(id: kase.id)
+    expect(cases_show_page.case_details).not_to have_edit_closure
+    expect(cases_show_page.case_details)
+        .not_to have_text("This is an old case with closure details that can't be edited. If you need to edit this case let us know.")
+  end
 end

--- a/spec/helpers/cases_helper_spec.rb
+++ b/spec/helpers/cases_helper_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe CasesHelper, type: :helper do
         context 'new style closure details' do
           it 'returns false' do
             expect(manager_updating_close_details_on_old_case?(responder, new_style_closed_case)).to be false
+          end
         end
-      end
       end
     end
   end

--- a/spec/helpers/cases_helper_spec.rb
+++ b/spec/helpers/cases_helper_spec.rb
@@ -12,11 +12,72 @@ require 'rails_helper'
 # end
 RSpec.describe CasesHelper, type: :helper do
 
-  let(:manager)   { create :manager }
-  let(:responder) { create :responder }
-  let(:coworker)  { create :responder,
-                           responding_teams: responder.responding_teams }
+  let(:manager)           { create :manager }
+  let(:responder)         { create :responder }
+  let(:coworker)          { create :responder,
+                                    responding_teams: responder.responding_teams }
   let(:another_responder) { create :responder }
+  let(:approver)          { create :approver }
+
+  describe '#manager_updating_close_details_on_old_case?' do
+
+    let(:old_style_closed_case)   { create :closed_case, :old_without_info_held }
+    let(:new_style_closed_case)   { create :closed_case }
+    let(:open_case)               { create :assigned_case }
+
+    context 'manager' do
+      context 'case_closed' do
+        context 'old_style closure details on case' do
+          it 'returns true' do
+            expect(manager_updating_close_details_on_old_case?(manager, old_style_closed_case)).to be true
+          end
+        end
+
+        context 'new style closure details' do
+          it 'returns false' do
+            expect(manager_updating_close_details_on_old_case?(manager, new_style_closed_case)).to be false
+          end
+        end
+      end
+
+      context 'case open' do
+        it 'returns false' do
+          expect(manager_updating_close_details_on_old_case?(manager, open_case)).to be false
+        end
+      end
+    end
+
+    context 'approver' do
+      context 'case closed' do
+        context 'old style closure details' do
+          it 'returns false' do
+            expect(manager_updating_close_details_on_old_case?(approver, old_style_closed_case)).to be false
+          end
+        end
+        context 'new style closure details' do
+          it 'returns false' do
+            expect(manager_updating_close_details_on_old_case?(approver, new_style_closed_case)).to be false
+          end
+        end
+      end
+    end
+
+    context 'responder' do
+      context 'case closed' do
+        context 'old style closure details' do
+          it 'returns false' do
+            expect(manager_updating_close_details_on_old_case?(responder, old_style_closed_case)).to be false
+          end
+        end
+        context 'new style closure details' do
+          it 'returns false' do
+            expect(manager_updating_close_details_on_old_case?(responder, new_style_closed_case)).to be false
+        end
+      end
+      end
+    end
+  end
+
 
   describe '#action_button_for(event)' do
 

--- a/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
+++ b/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
@@ -329,9 +329,6 @@ describe ConfigurableStateMachine::Machine do
         context 'pending_dacu_disclosure_clearance state' do
           it 'shows events' do
             k = create :pending_dacu_clearance_ico_foi_case, :dacu_disclosure
-
-            binding.pry
-
             expect(k.current_state).to eq 'pending_dacu_clearance'
             expect(k.state_machine.permitted_events(approver.id)).to eq [ :add_message_to_case,
                                                                           :link_a_case,

--- a/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
+++ b/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
@@ -328,7 +328,9 @@ describe ConfigurableStateMachine::Machine do
 
         context 'pending_dacu_disclosure_clearance state' do
           it 'shows events' do
-            k = create :pending_dacu_clearance_ico_foi_case, :flagged, :dacu_disclosure
+            k = create :pending_dacu_clearance_ico_foi_case, :dacu_disclosure
+
+            binding.pry
 
             expect(k.current_state).to eq 'pending_dacu_clearance'
             expect(k.state_machine.permitted_events(approver.id)).to eq [ :add_message_to_case,


### PR DESCRIPTION
Responders were getting an error message saying they couldn't update
closure details on old-style closed cases.  This is a bug because
responders can't update closure details on ANY case.