### PR TITLE
CT-1929 Fix ICO SAR update closure details bug

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -366,7 +366,7 @@ class CasesController < ApplicationController
     @case.prepare_for_close
     close_params = process_closure_params(@case.type_abbreviation)
     if @case.update(close_params)
-      if @case.ico?
+      if @case.ico? && params[:case_ico][:uploaded_decision_files].present?
         uploader = S3Uploader.new(@case, current_user)
         uploader.process_files(params[:case_ico][:uploaded_ico_decision_files], :ico_decision)
       end

--- a/spec/controllers/cases_controller/edit_closure_spec.rb
+++ b/spec/controllers/cases_controller/edit_closure_spec.rb
@@ -2,7 +2,30 @@ require "rails_helper"
 
 describe CasesController do
   describe 'GET edit_closure' do
-    let(:kase)    { create :closed_sar }
+    context 'SAR case' do
+      let(:kase)    { create :closed_sar }
+      let(:manager) { create :disclosure_bmt_user }
+
+      before do
+        sign_in manager
+      end
+
+      it 'authorises with update_closure? policy' do
+        expect{
+          get :edit_closure, params: { id: kase.id }
+        }.to require_permission(:update_closure?)
+               .with_args(manager, kase)
+      end
+
+      it 'renders the close page' do
+        get :edit_closure, params: { id: kase.id }
+        expect(response).to render_template :edit_closure
+      end
+    end
+  end
+
+  describe 'ICO appeal for SAR case' do
+    let(:kase)    { create :closed_ico_sar_case }
     let(:manager) { create :disclosure_bmt_user }
 
     before do
@@ -13,7 +36,7 @@ describe CasesController do
       expect{
         get :edit_closure, params: { id: kase.id }
       }.to require_permission(:update_closure?)
-             .with_args(manager, kase)
+               .with_args(manager, kase)
     end
 
     it 'renders the close page' do

--- a/spec/controllers/cases_controller/update_closure_spec.rb
+++ b/spec/controllers/cases_controller/update_closure_spec.rb
@@ -264,6 +264,37 @@ describe CasesController do
           end
         end
 
+        context 'no ico decison files specified' do
+          let(:params)             { {
+              id: kase.id,
+              case_ico: {
+                  date_ico_decision_received_yyyy: new_date_responded.year,
+                  date_ico_decision_received_mm: new_date_responded.month,
+                  date_ico_decision_received_dd: new_date_responded.day,
+                  ico_decision: 'upheld',
+                  ico_decision_comment: 'ayt',
+              }
+          } }
+          before do
+            sign_in manager
+            patch :update_closure, params: params
+          end
+
+          it 'updates the cases date responded field' do
+            kase.reload
+            expect(kase.date_ico_decision_received).to eq new_date_responded
+          end
+
+          it 'updates the cases refusal reason' do
+            kase.reload
+            expect(kase.ico_decision).to eq 'upheld'
+          end
+
+          it 'redirects to the case details page' do
+            expect(response).to redirect_to case_path(id: kase.id)
+          end
+        end
+
         context 'change to overturned' do
           let(:kase)         { create :closed_ico_foi_case }
           let(:params)       { {

--- a/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
+++ b/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
@@ -329,6 +329,7 @@ describe ConfigurableStateMachine::Machine do
         context 'pending_dacu_disclosure_clearance state' do
           it 'shows events' do
             k = create :pending_dacu_clearance_ico_foi_case, :dacu_disclosure
+
             expect(k.current_state).to eq 'pending_dacu_clearance'
             expect(k.state_machine.permitted_events(approver.id)).to eq [ :add_message_to_case,
                                                                           :link_a_case,
@@ -338,7 +339,7 @@ describe ConfigurableStateMachine::Machine do
         end
         context 'awaiting_dispatch state' do
           it 'shows events' do
-            k = create :approved_ico_foi_case, :flagged, :dacu_disclosure
+            k = create :approved_ico_foi_case, :dacu_disclosure
 
             expect(k.current_state).to eq 'awaiting_dispatch'
             expect(k.state_machine.permitted_events(approver.id)).to eq [ :add_message_to_case,
@@ -350,7 +351,7 @@ describe ConfigurableStateMachine::Machine do
         end
         context 'responded state' do
           it 'shows events' do
-            k = create :responded_ico_foi_case, :flagged, :dacu_disclosure
+            k = create :responded_ico_foi_case, :dacu_disclosure
 
             expect(k.current_state).to eq 'responded'
             expect(k.state_machine.permitted_events(approver.id)).to eq [:add_message_to_case,
@@ -360,7 +361,7 @@ describe ConfigurableStateMachine::Machine do
         end
         context 'closed state' do
           it 'shows events' do
-            k = create :closed_ico_foi_case, :flagged, :dacu_disclosure
+            k = create :closed_ico_foi_case, :dacu_disclosure
 
             expect(k.current_state).to eq 'closed'
             expect(k.state_machine.permitted_events(approver.id)).to eq [ :add_message_to_case,

--- a/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
+++ b/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
@@ -315,7 +315,7 @@ describe ConfigurableStateMachine::Machine do
 
         context 'drafting state' do
           it 'shows events' do
-            k = create :accepted_ico_foi_case, :flagged, :dacu_disclosure
+            k = create :accepted_ico_foi_case, :dacu_disclosure
 
             expect(k.current_state).to eq 'drafting'
             expect(k.state_machine.permitted_events(approver.id)).to eq [ :accept_approver_assignment,


### PR DESCRIPTION
Updating the closure reasons of a closed ICO appeal for SAR
cases crashed if no ICO decision files were uploaded.  This bug
has been fixed.