### PR TITLE
fixes assets not minifying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ COPY . .
 
 RUN mkdir log tmp
 
-RUN bundle exec rake assets:precompile assets:non_digested SECRET_KEY_BASE=required_but_does_not_matter_for_assets
+RUN RAILS_ENV=production bundle exec rake assets:clean assets:precompile assets:non_digested SECRET_KEY_BASE=required_but_does_not_matter_for_assets
 
 ENTRYPOINT ["./run.sh"]


### PR DESCRIPTION
When compiling assets you need to specify which rails env those assets
will be used in else it defaults to develop. In develop environment, it
does not minify or concatenate the assets that the service is using.

same as https://github.com/ministryofjustice/correspondence_tool_public/pull/171