### PR TITLE
CT-1944 Fix bug where OVT SAR cases appeared to link to themselves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ node_modules
 
 # Ignore files that may contain production data. If you need to allow specific
 # files include them below using the ! notation.
+**/*.bak
 **/*.sql
 **/*.csv
 **/*.txt

--- a/app/decorators/case/base_decorator.rb
+++ b/app/decorators/case/base_decorator.rb
@@ -4,6 +4,7 @@ class Case::BaseDecorator < Draper::Decorator
   decorates_association :original_case
   decorates_associations :related_cases
   decorates_association :original_ico_appeal
+  decorates_association :original_appeal_and_related_cases
 
 
   # if the case is with a responding team and the current user is a responder

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -290,6 +290,15 @@ class Case::Base < ApplicationRecord
            through: :related_case_links,
            source: :linked_case
 
+  has_many :original_appeal_and_related_case_links,
+           -> { related_and_appeal },
+           class_name: 'LinkedCase',
+           foreign_key: :case_id
+
+  has_many :original_appeal_and_related_cases,
+           through: :original_appeal_and_related_case_links,
+           source: :linked_case
+
 
   after_initialize do
     self.workflow = default_workflow if self.workflow.nil?

--- a/app/models/linked_case.rb
+++ b/app/models/linked_case.rb
@@ -24,6 +24,8 @@ class LinkedCase < ApplicationRecord
          original_appeal: 'original_appeal'
        }
 
+  scope :related_and_appeal, -> {  related.or(original_appeal).order(:type, :id) }
+
   before_validation :find_linked_case_by_number
   after_create :create_reverse_link
   after_destroy :destroy_reverse_link

--- a/app/services/new_overturned_ico_case_service.rb
+++ b/app/services/new_overturned_ico_case_service.rb
@@ -28,7 +28,6 @@ class NewOverturnedIcoCaseService
     if success?
       original_case                                 = @original_ico_appeal.original_case
       @overturned_ico_case                          = overturned_klass.new
-      # @overturned_ic_case.subject                  = original_case.subject
       @overturned_ico_case.original_ico_appeal_id   = @original_ico_appeal.id
       @overturned_ico_case.original_case_id         = original_case.id
       @overturned_ico_case.ico_officer_name         = @original_ico_appeal.ico_officer_name

--- a/app/views/cases/ico/_show_linked_cases.html.slim
+++ b/app/views/cases/ico/_show_linked_cases.html.slim
@@ -25,11 +25,10 @@
             td
               = request_details_html(case_details.original_case)
 
-
 .grid-row.form-group.related-linked-cases
   .column-full
     h2.request--heading
-      = "Related case"
+      = "Other linked cases"
     table
       thead
         tr
@@ -40,8 +39,8 @@
           th style="width:60%"
             = 'Request'
       tbody
-        - if case_details.related_cases.present?
-          - case_details.related_cases.each do |linked_case|
+        - if (case_details.original_appeal_and_related_cases).any?
+          - case_details.original_appeal_and_related_cases.each do |linked_case|
             tr
               td
                 = link_to case_path(linked_case.id) do

--- a/app/views/shared/components/_case_linked_cases.html.slim
+++ b/app/views/shared/components/_case_linked_cases.html.slim
@@ -9,7 +9,7 @@
     section.case-info
       = render partial: 'cases/case_attachments', locals: { case_details: @case.original_ico_appeal.decorate }
   section.case-info
-    = render partial: 'cases/ico/show_linked_cases', locals: { case_details: @case.original_ico_appeal.decorate }
+    = render partial: 'cases/ico/show_linked_cases', locals: { case_details: @case.decorate }
 - else
   section.case-info
     = render partial: 'cases/linked_cases', locals: { case_details: @case }

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -470,6 +470,30 @@ RSpec.describe Case::Base, type: :model do
     end
   end
 
+  describe 'original_appeal_and_related_cases association' do
+
+    let(:sar)               { create :sar_case }
+    let(:linked_sar)        { create :sar_case }
+    let(:manager)           { sar.managing_team.users.first }
+    let(:ico_appeal)        { create :closed_ico_sar_case, :overturned_by_ico, original_case: sar }
+
+    before(:each) do
+      cls = CaseLinkingService.new(manager, sar, linked_sar.number)
+      cls.create
+      @ovt = create :overturned_ico_sar, original_ico_appeal: ico_appeal, original_case: sar
+      @ovt.link_related_cases
+      @ovt.reload
+    end
+
+
+    it 'returns all related cases and the original appeal' do
+      expect(@ovt.original_case).to eq sar
+      expect(@ovt.related_cases).to eq [linked_sar]
+      expect(@ovt.original_appeal_and_related_cases).to eq [ ico_appeal, linked_sar]
+    end
+
+  end
+
   describe 'related_case_links association' do
     it { should have_many(:related_case_links)
                   .class_name('LinkedCase')

--- a/spec/views/cases/overturned_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/overturned_sar/_case_details_html_slim_spec.rb
@@ -89,13 +89,14 @@ describe 'cases/overturned_sar/case_details.html.slim', type: :view do
     end
 
     it 'displays the time taken to send the response' do
-      closed_case.update(
-        date_responded: 1.business_day.after(closed_case.external_deadline)
-      )
+      Timecop.freeze(Time.local(2018, 9, 23, 10, 0, 0)) do
+        closed_case.update(
+          date_responded: 1.business_day.after(closed_case.external_deadline)
+        )
+        partial = render_partial(closed_case)
 
-      partial = render_partial(closed_case)
-
-      expect(partial.time_taken.text).to eq '19 working days'
+        expect(partial.time_taken.text).to eq '21 working days'
+      end
     end
   end
 


### PR DESCRIPTION
This PR fixes a bug caused by passing in the original case to the
linked case partial (rather than the current case).  This then displayed
the current case as a linked case.

In fixing this bug, we also found that the original ICO appeal was not being
displayed in Other Related cases section.  This is also fixed by creating a
new scope to include the original ico appeal as well as related cases.