### PR TITLE
CT-1942 Remove option to Edit closure details for OVT SAR

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -336,7 +336,11 @@ class CasesController < ApplicationController
       @case.respond_and_close(current_user)
       set_permitted_events
       @close_flash_message = t('notices.case_closed')
-      flash[:notice] = "#{@close_flash_message}. #{ get_edit_close_link }".html_safe
+      if @permitted_events.include?(:update_closure)
+        flash[:notice] = "#{@close_flash_message}. #{ get_edit_close_link }".html_safe
+      else
+        flash[:notice] = @close_flash_message
+      end
       redirect_to case_path(@case)
     else
       set_permitted_events

--- a/app/state_machines/workflows/predicates.rb
+++ b/app/state_machines/workflows/predicates.rb
@@ -13,6 +13,10 @@ class Workflows::Predicates
     end
   end
 
+  def responder_is_member_of_assigned_team_and_not_overturned?
+    responder_is_member_of_assigned_team? && not_overturned?
+  end
+
   def user_is_assigned_responder?
     @kase.responder == @user
   end

--- a/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
@@ -57,6 +57,7 @@
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
                 update_closure:
+                  if: Workflows::Predicates#not_overturned?
                 link_a_case:
                 remove_linked_case:
 
@@ -96,7 +97,7 @@
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 update_closure:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_overturned?
 
 
           ########################### SAR :: STANDARD WORKFLOW :: APPROVER ########################

--- a/spec/state_machines/overturned_sar_event_spec.rb
+++ b/spec/state_machines/overturned_sar_event_spec.rb
@@ -141,12 +141,4 @@ describe 'state machine' do
       )}
   end
 
-  describe :update_closure do
-    it {
-      should permit_event_to_be_triggered_only_by(
-        [:disclosure_bmt, :ot_ico_sar_noff_closed],
-        [:responder, :ot_ico_sar_noff_closed],
-        [:another_responder_in_same_team, :ot_ico_sar_noff_closed],
-      )}
-  end
 end

--- a/spec/state_machines/workflows/overturned_sar_permitted_events.rb/standard_spec.rb
+++ b/spec/state_machines/workflows/overturned_sar_permitted_events.rb/standard_spec.rb
@@ -52,8 +52,7 @@ describe ConfigurableStateMachine::Machine do
                                                                       :assign_to_new_team,
                                                                       :destroy_case,
                                                                       :link_a_case,
-                                                                      :remove_linked_case,
-                                                                      :update_closure]
+                                                                      :remove_linked_case]
         end
       end
     end
@@ -127,8 +126,7 @@ describe ConfigurableStateMachine::Machine do
           k = create :closed_ot_ico_sar
           responder = responder_in_assigned_team(k)
           expect(k.current_state).to eq 'closed'
-          expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                        :update_closure]
+          expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case]
         end
       end
     end

--- a/spec/support/features/interactions.rb
+++ b/spec/support/features/interactions.rb
@@ -156,7 +156,7 @@ module Features
     def close_sar_case(kase:, user:, tmm: false, timeliness:)
       login_step user: user
       go_to_case_details_step kase: kase
-      close_sar_case_step timeliness: timeliness, tmm: tmm
+      close_sar_case_step timeliness: timeliness, tmm: tmm, editable: !kase.overturned_ico?
     end
 
     def close_ico_appeal_case(kase:, user:, timeliness:, decision:)

--- a/spec/support/features/steps/cases/responding_steps.rb
+++ b/spec/support/features/steps/cases/responding_steps.rb
@@ -53,7 +53,7 @@ def close_case_step(responded_date: Date.today)
   expect(cases_show_page.case_status.details.copy.text).to eq "Case closed"
 end
 
-def close_sar_case_step(timeliness: 'in time', tmm: false)
+def close_sar_case_step(timeliness: 'in time', tmm: false, editable: true)
   cases_show_page.actions.close_case.click
 
   cases_close_page.fill_in_date_responded(Date.today)
@@ -67,7 +67,11 @@ def close_sar_case_step(timeliness: 'in time', tmm: false)
   cases_close_page.click_on 'Close case'
 
   show_page = cases_show_page.case_details
-  expect(cases_show_page.notice.text).to eq("You've closed this case. Edit case closure details")
+  if editable
+    expect(cases_show_page.notice.text).to eq("You've closed this case. Edit case closure details")
+  else
+    expect(cases_show_page.notice.text).to eq("You've closed this case")
+  end
 
   expect(show_page.response_details.date_responded.data.text)
     .to eq Date.today.strftime(Settings.default_date_format)


### PR DESCRIPTION
This option was erroneously added in when we merged the
state machine configs for OVT SARs and SARs.  This fixes it.