### PR TITLE
Ct 1906 test notifications

### DIFF
--- a/app/mailers/action_notifications_mailer.rb
+++ b/app/mailers/action_notifications_mailer.rb
@@ -14,7 +14,7 @@ class ActionNotificationsMailer < GovukNotifyRails::Mailer
         case_abbr:          kase.decorate.pretty_type,
         case_received_date: kase.received_date.strftime(Settings.default_date_format),
         case_subject:       kase.subject,
-        case_link: edit_case_assignment_url(@assignment.case_id, @assignment.id)
+        case_link:          edit_case_assignment_url(@assignment.case_id, @assignment.id)
     )
 
     mail(to: recipient)

--- a/app/services/assign_new_team_service.rb
+++ b/app/services/assign_new_team_service.rb
@@ -16,7 +16,7 @@ class AssignNewTeamService
     ActiveRecord::Base.transaction do
       @assignment.update!(state: 'pending', team_id: @team.id, user_id: nil)
       @case.state_machine.assign_to_new_team!(acting_user: @user, acting_team: @managing_team, target_team: @team)
-      NotifyNewAssignmentService.new(team: @team, assignment: @assignment).run unless @case.current_state == 'closed'
+      # NotifyNewAssignmentService.new(team: @team, assignment: @assignment).run unless @case.current_state == 'closed'
       @result = :ok
     end
   end

--- a/app/services/assign_new_team_service.rb
+++ b/app/services/assign_new_team_service.rb
@@ -16,7 +16,6 @@ class AssignNewTeamService
     ActiveRecord::Base.transaction do
       @assignment.update!(state: 'pending', team_id: @team.id, user_id: nil)
       @case.state_machine.assign_to_new_team!(acting_user: @user, acting_team: @managing_team, target_team: @team)
-      # NotifyNewAssignmentService.new(team: @team, assignment: @assignment).run unless @case.current_state == 'closed'
       @result = :ok
     end
   end

--- a/app/services/case_assign_responder_service.rb
+++ b/app/services/case_assign_responder_service.rb
@@ -22,7 +22,6 @@ class CaseAssignResponderService
       end
     end
     if @result == :ok
-      # NotifyNewAssignmentService.new(team: @team, assignment: @assignment).run
       true
     else
       false

--- a/app/services/case_assign_responder_service.rb
+++ b/app/services/case_assign_responder_service.rb
@@ -22,7 +22,7 @@ class CaseAssignResponderService
       end
     end
     if @result == :ok
-      NotifyNewAssignmentService.new(team: @team, assignment: @assignment).run
+      # NotifyNewAssignmentService.new(team: @team, assignment: @assignment).run
       true
     else
       false

--- a/app/services/user_reassignment_service.rb
+++ b/app/services/user_reassignment_service.rb
@@ -28,10 +28,7 @@ class UserReassignmentService
 
       @result = :ok
     end
-
-    # If everything is good email the user
-    notify_target_user
-
+    
     @result
   rescue => err
     Rails.logger.error err.to_s
@@ -62,19 +59,5 @@ class UserReassignmentService
       roles << assignment.role.sub('ing', 'er').to_sym
     end
     roles.delete(:manager)
-  end
-
-  def notify_target_user
-
-    # User is not assigning to themselves and
-    # the assigned user changed
-
-    # if @acting_user != @target_user &&
-    #     @original_assigned_user != @assignment.user_id
-    #
-    #     ActionNotificationsMailer
-    #       .case_assigned_to_another_user(@kase, @target_user)
-    #       .deliver_later
-    # end
   end
 end

--- a/app/services/user_reassignment_service.rb
+++ b/app/services/user_reassignment_service.rb
@@ -69,12 +69,12 @@ class UserReassignmentService
     # User is not assigning to themselves and
     # the assigned user changed
 
-    if @acting_user != @target_user &&
-        @original_assigned_user != @assignment.user_id
-
-        ActionNotificationsMailer
-          .case_assigned_to_another_user(@kase, @target_user)
-          .deliver_later
-    end
+    # if @acting_user != @target_user &&
+    #     @original_assigned_user != @assignment.user_id
+    #
+    #     ActionNotificationsMailer
+    #       .case_assigned_to_another_user(@kase, @target_user)
+    #       .deliver_later
+    # end
   end
 end

--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -48,17 +48,15 @@ module ConfigurableStateMachine
     #
     def can_trigger_event?(event_name:, metadata:, roles: nil)
       result = false
-      roles = [roles] if roles.is_a?(String)
-      roles = extract_roles_from_metadata(metadata) if roles.nil?
-      user = extract_user_from_metadata(metadata)
-      roles.each do |role|
+      set_users_and_roles(metadata: metadata, roles: roles)
+      @roles.each do |role|
         role_config = @config.user_roles[role]
         next if role_config.nil?
         role_state_config =  role_config.states[@kase.current_state]
         if key_present_but_nil?(role_state_config, event_name.to_sym)
           result = true
         else
-          result = event_present_and_triggerable?(role_state_config: role_state_config, event: event_name, user: user)
+          result = event_present_and_triggerable?(role_state_config: role_state_config, event: event_name, user: @user)
         end
         break if result == true
       end
@@ -66,10 +64,8 @@ module ConfigurableStateMachine
     end
 
     def config_for_event(event_name:, metadata:, roles: nil)
-      roles = [roles] if roles.is_a?(String)
-      roles = extract_roles_from_metadata(metadata) if roles.nil?
-      user = extract_user_from_metadata(metadata)
-      roles.each do |role|
+      set_users_and_roles(metadata: metadata, roles: roles)
+      @roles.each do |role|
         role_config = @config.user_roles[role]
         next if role_config.nil?
         role_state_config =  role_config.states[@kase.current_state]
@@ -78,14 +74,21 @@ module ConfigurableStateMachine
         elsif event_present_and_triggerable?(
                 role_state_config: role_state_config,
                 event: event_name,
-                user: user)
+                user: @user)
           return role_state_config[event_name]
         end
       end
       return nil
     end
 
-    # intercept trigger event  methods, whcih all end in a !
+    def set_users_and_roles(metadata:, roles:)
+      @roles = roles
+      @roles = [roles] if roles.is_a?(String)
+      @roles = extract_roles_from_metadata(metadata) if roles.nil?
+      @user = extract_user_from_metadata(metadata)
+    end
+
+    # intercept trigger event  methods, which all end in a !
     #
     def method_missing(method, *args)
       if method.to_s =~ /(.+)!$/

--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -74,7 +74,7 @@ module ConfigurableStateMachine
         next if role_config.nil?
         role_state_config =  role_config.states[@kase.current_state]
         if key_present_but_nil?(role_state_config, event_name.to_sym)
-          return {}
+          return RecursiveOpenStruct.new
         elsif event_present_and_triggerable?(
                 role_state_config: role_state_config,
                 event: event_name,

--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -224,7 +224,7 @@ module ConfigurableStateMachine
           CaseTransition.unset_most_recent(@kase)
           write_transition(event: event, to_state: to_state, to_workflow: to_workflow, params: params)
           @kase.update!(current_state: to_state, workflow: to_workflow)
-          execute_after_transition_method(event_config: event_config, user: user)
+          execute_after_transition_method(event_config: event_config, user: user, metadata: params)
         end
       else
         raise InvalidEventError.new(
@@ -326,11 +326,11 @@ module ConfigurableStateMachine
       end
     end
 
-    def execute_after_transition_method(event_config:, user:)
+    def execute_after_transition_method(event_config:, user:, metadata:)
       if event_config.to_h.key?(:after_transition)
         class_and_method = event_config.after_transition
         klass, method = class_and_method.split('#')
-        after_object = klass.constantize.new(user: user, kase: @kase)
+        after_object = klass.constantize.new(user: user, kase: @kase, metadata: metadata)
         after_object.__send__(method)
       end
     end

--- a/app/state_machines/workflows/hooks.rb
+++ b/app/state_machines/workflows/hooks.rb
@@ -1,8 +1,9 @@
 class Workflows::Hooks
 
-  def initialize(user:, kase:)
+  def initialize(user:, kase:, metadata:)
     @user = user
     @kase = kase
+    @metadata = metadata
   end
 
   def notify_responder_message_received
@@ -21,5 +22,19 @@ class Workflows::Hooks
 
   def notify_managing_team_case_closed
     NotifyTeamService.new(@kase, 'Case closed').call
+  end
+
+  def reassign_user_email
+    if @user !=  @metadata[:target_user]
+        ActionNotificationsMailer
+          .case_assigned_to_another_user(@kase, @metadata[:target_user])
+          .deliver_later
+    end
+  end
+
+  def assign_responder_email
+    NotifyNewAssignmentService.new(team: @metadata[:target_team],
+                                   assignment: @kase.assignments.responding.first
+                                  ).run
   end
 end

--- a/app/state_machines/workflows/hooks.rb
+++ b/app/state_machines/workflows/hooks.rb
@@ -34,7 +34,7 @@ class Workflows::Hooks
 
   def assign_responder_email
     NotifyNewAssignmentService.new(team: @metadata[:target_team],
-                                   assignment: @kase.assignments.responding.first
+                                   assignment: @kase.responder_assignment
                                   ).run
   end
 end

--- a/config/state_machine/configs/00_moj/10_foi_case_type/20_foi_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/20_foi_standard_workflow.yml
@@ -7,6 +7,7 @@
                 add_message_to_case:
                 assign_responder:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -21,6 +22,7 @@
               awaiting_responder:
                 add_message_to_case:
                 assign_to_new_team:
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -37,6 +39,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -99,6 +102,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -119,6 +123,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -138,6 +143,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -152,6 +158,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -164,6 +171,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
 
               closed:
@@ -201,6 +209,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
 
               awaiting_dispatch:
@@ -212,6 +221,7 @@
                  link_a_case:
                  reassign_user:
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                   after_transition: Workflows::Hooks#reassign_user_email
                  remove_linked_case:
                  remove_response:
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?

--- a/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
@@ -8,6 +8,7 @@
                 add_message_to_case:
                 assign_responder:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -21,6 +22,7 @@
                 add_message_to_case:
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -35,6 +37,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -104,6 +107,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -121,6 +125,7 @@
                 flag_for_clearance:
                 link_a_case:
                 reassign_user:
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -139,6 +144,7 @@
                 flag_for_clearance:
                 link_a_case:
                 reassign_user:
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -160,6 +166,7 @@
                   after_transition: Workflows::Hooks#notify_responder_ready_to_send
                 link_a_case:
                 reassign_user:
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 unaccept_approver_assignment:
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
@@ -186,6 +193,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -234,6 +242,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 upload_responses:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
@@ -245,6 +254,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
 
               awaiting_dispatch:
@@ -256,6 +266,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_last_response:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 remove_linked_case:

--- a/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
@@ -8,6 +8,7 @@
                 add_message_to_case:
                 assign_responder:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                 flag_for_clearance:
@@ -20,6 +21,7 @@
                 add_message_to_case:
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                 flag_for_clearance:
@@ -33,6 +35,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                 extend_for_pit:
@@ -118,6 +121,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -133,6 +137,7 @@
                 flag_for_clearance:
                 link_a_case:
                 reassign_user:
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -149,6 +154,7 @@
                 flag_for_clearance:
                 link_a_case:
                 reassign_user:
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 take_on_for_approval:
                   if: Case::BasePolicy#can_take_on_for_approval?
@@ -170,6 +176,7 @@
                   transition_to: awaiting_dispatch
                 link_a_case:
                 reassign_user:
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 unflag_for_clearance:               # needed for press/private office to unaccept
                   if: Workflows::Predicates#case_can_be_unflagged_for_clearance_by_press_or_private?
@@ -197,6 +204,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 request_amends:
                   if: Workflows::Predicates#user_is_assigned_press_officer?
@@ -219,6 +227,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 request_amends:
                   if: Workflows::Predicates#user_is_assigned_private_officer?
@@ -239,6 +248,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 remove_response:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
@@ -293,6 +303,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 upload_responses:
 
@@ -303,6 +314,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
 
               pending_press_office_clearance:
@@ -312,6 +324,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
 
               pending_private_office_clearance:
@@ -321,6 +334,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
 
               awaiting_dispatch:
@@ -332,6 +346,7 @@
                  link_a_case:
                  reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                  remove_linked_case:
                  remove_response:
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?

--- a/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
@@ -178,6 +178,7 @@
                   transition_to: pending_press_office_clearance
                 upload_response_approve_and_bypass:
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
+                  after_transition: Workflows::Hooks#notify_responder_ready_to_send
                   transition_to: awaiting_dispatch
                 upload_response_and_return_for_redraft:
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?

--- a/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
@@ -37,6 +37,7 @@
 
               drafting:
                 add_message_to_case:
+                  after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
                   transition_to: awaiting_responder
                 destroy_case:
@@ -81,6 +82,7 @@
               drafting:
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#notify_responder_message_received
                 respond_and_close:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   transition_to: closed

--- a/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
@@ -9,6 +9,7 @@
                 add_message_to_case:
                 assign_responder:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -24,6 +25,7 @@
                 add_message_to_case:
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -40,6 +42,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -94,6 +97,7 @@
                   transition_to: closed
                 reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#reassign_user_email
 
               closed:
                 add_message_to_case:

--- a/config/state_machine/configs/00_moj/20_sar/30_sar_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/20_sar/30_sar_trigger_workflow.yml
@@ -11,6 +11,7 @@
                 add_message_to_case:
                 assign_responder:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -21,6 +22,7 @@
               awaiting_responder:
                 add_message_to_case:
                 assign_to_new_team:
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -33,6 +35,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -45,6 +48,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                   if: Workflows::Predicates#not_overturned?
@@ -96,6 +100,7 @@
                   transition_to: pending_dacu_clearance
                 reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#reassign_user_email
 
               pending_dacu_clearance:
                 add_message_to_case:
@@ -103,6 +108,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#reassign_user_email
 
               awaiting_dispatch:
                 add_message_to_case:
@@ -119,6 +125,7 @@
                   transition_to: closed
                 reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#reassign_user_email
 
               closed:
                 add_message_to_case:
@@ -136,6 +143,7 @@
                   if: Workflows::Predicates#user_is_approver_on_case?
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 unaccept_approver_assignment:
                   if: Case::BasePolicy#can_unaccept_approval_assignment?
                 unflag_for_clearance:
@@ -149,6 +157,7 @@
                   if: Workflows::Predicates#user_is_approver_on_case?
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 unaccept_approver_assignment:
                   if: Case::BasePolicy#can_unaccept_approval_assignment?
                 unflag_for_clearance:
@@ -163,6 +172,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 unaccept_approver_assignment:
                   if: Case::BasePolicy#can_unaccept_approval_assignment?
                 unflag_for_clearance:
@@ -181,6 +191,7 @@
                   after_transition: Workflows::Hooks#notify_responder_ready_to_send
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
                 request_amends:
                   if: Workflows::Predicates#user_is_approver_on_case?
                   after_transition: Workflows::Hooks#notify_responder_redraft_requested
@@ -198,6 +209,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user
+                  after_transition: Workflows::Hooks#reassign_user_email
 
               closed:
                 add_message_to_case:

--- a/config/state_machine/configs/00_moj/20_sar/30_sar_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/20_sar/30_sar_trigger_workflow.yml
@@ -90,6 +90,7 @@
               drafting:
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#notify_responder_message_received
                 progress_for_clearance:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   transition_to: pending_dacu_clearance
@@ -99,12 +100,14 @@
               pending_dacu_clearance:
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#notify_responder_message_received
                 reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
 
               awaiting_dispatch:
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#notify_responder_message_received
                 respond_and_close:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   transition_to: closed

--- a/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
@@ -132,9 +132,9 @@
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
                   after_transition: Workflows::Hooks#notify_responder_redraft_requested
                   transition_to: drafting
-                upload_response_approve_and_bypass:
-                  if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
-                  transition_to: awaiting_dispatch
+                # upload_response_approve_and_bypass:
+                #   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
+                #   transition_to: awaiting_dispatch
 
               awaiting_dispatch:
                 add_message_to_case:

--- a/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
@@ -8,6 +8,7 @@
                 add_message_to_case:
                 assign_responder:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                 flag_for_clearance:
@@ -17,6 +18,7 @@
               awaiting_responder:
                 add_message_to_case:
                 assign_to_new_team:
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                 link_a_case:
@@ -27,6 +29,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 assign_to_new_team:
                   transition_to: awaiting_responder
+                  after_transition: Workflows::Hooks#assign_responder_email
                 destroy_case:
                 edit_case:
                 link_a_case:
@@ -79,6 +82,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#user_is_in_approving_team_for_case?
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 unaccept_approver_assignment:
                   if: Case::BasePolicy#can_unaccept_approval_assignment?
@@ -91,6 +95,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#user_is_in_approving_team_for_case?
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 unaccept_approver_assignment:
                   if: Case::BasePolicy#can_unaccept_approval_assignment?
@@ -104,6 +109,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#user_is_in_approving_team_for_case?
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 unaccept_approver_assignment:
                   if: Case::BasePolicy#can_unaccept_approval_assignment?
@@ -121,6 +127,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#user_is_in_approving_team_for_case?
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 unaccept_approver_assignment:
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
@@ -132,9 +139,6 @@
                   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
                   after_transition: Workflows::Hooks#notify_responder_redraft_requested
                   transition_to: drafting
-                # upload_response_approve_and_bypass:
-                #   if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
-                #   transition_to: awaiting_dispatch
 
               awaiting_dispatch:
                 add_message_to_case:
@@ -143,6 +147,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#user_is_in_approving_team_for_case?
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
                 respond:
                   if: Workflows::Predicates#user_is_in_approving_team_for_case?
@@ -191,6 +196,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
 
               pending_dacu_clearance:
@@ -200,6 +206,7 @@
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#reassign_user_email
                 remove_linked_case:
 
               awaiting_dispatch:
@@ -211,6 +218,7 @@
                  link_a_case:
                  reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  after_transition: Workflows::Hooks#reassign_user_email
                  remove_linked_case:
                  remove_response:
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe MessagesController, type: :controller do
       }
     end
 
+    before do
+      allow(ActionNotificationsMailer).to receive_message_chain(:notify_information_officers,
+                                                                :deliver_later)
+    end
+
+
     context "as an anonymous user" do
       it "be redirected to signin if trying to start a new case" do
         post :create , params: params
@@ -62,6 +68,10 @@ RSpec.describe MessagesController, type: :controller do
       it "redirects to case detail page and contains a hash" do
         post :create , params: params
         expect(response).to redirect_to(case_path(accepted_case, anchor: 'messages-section'))
+        expect(ActionNotificationsMailer)
+          .to have_received(:notify_information_officers)
+                .with(accepted_case, 'Message received')
+
       end
       it 'allows them to post on a closed case' do
         params[:case_id] = closed_case.id
@@ -88,6 +98,9 @@ RSpec.describe MessagesController, type: :controller do
         params[:case_id] = flagged_case.id
         post :create , params: params
         expect(response).to redirect_to(case_path(flagged_case, anchor: 'messages-section'))
+        expect(ActionNotificationsMailer)
+          .to have_received(:notify_information_officers)
+                .with(flagged_case, 'Message received')
       end
 
     end
@@ -114,8 +127,83 @@ RSpec.describe MessagesController, type: :controller do
       end
     end
 
+    context "ico fois appeal case" do
+      let(:ico_case)     { create :accepted_ico_foi_case }
+      let(:params) do
+        {
+          case: {
+            message_text: 'This is a new message'
+          },
+          case_id: ico_case.id
+        }
+      end
+
+      context "as a manager" do
+        before { sign_in manager }
+
+        it "redirects to case detail page and contains a hash" do
+          post :create , params: params
+          expect(response).to redirect_to(case_path(ico_case, anchor: 'messages-section'))
+          expect(ActionNotificationsMailer)
+            .to have_received(:notify_information_officers)
+                  .with(ico_case, 'Message received')
+
+        end
+      end
+    end
+
+    context "ico sars appeal case" do
+      let(:ico_case)     { create :accepted_ico_sar_case }
+      let(:params) do
+        {
+          case: {
+            message_text: 'This is a new message'
+          },
+          case_id: ico_case.id
+        }
+      end
+
+      context "as a manager" do
+        before { sign_in manager }
+
+        it "redirects to case detail page and contains a hash" do
+          post :create , params: params
+          expect(response).to redirect_to(case_path(ico_case, anchor: 'messages-section'))
+          expect(ActionNotificationsMailer)
+            .to have_received(:notify_information_officers)
+                  .with(ico_case, 'Message received')
+
+        end
+      end
+    end
+
+    context "sar case" do
+      let(:sar)     { create :accepted_sar }
+      let(:params) do
+        {
+          case: {
+            message_text: 'This is a new message'
+          },
+          case_id: sar.id
+        }
+      end
+
+      context "as a manager" do
+        before { sign_in manager }
+
+        it "redirects to case detail page and contains a hash" do
+          post :create , params: params
+          expect(response).to redirect_to(case_path(sar, anchor: 'messages-section'))
+          expect(ActionNotificationsMailer)
+            .to have_received(:notify_information_officers)
+                  .with(sar, 'Message received')
+
+        end
+      end
+    end
+
     context "overturned_sar case" do
-      let(:overturned_sar)     { create :overturned_ico_sar }
+      let(:overturned_sar)     { create :accepted_ot_ico_sar }
       let(:params) do
         {
           case: {
@@ -131,6 +219,35 @@ RSpec.describe MessagesController, type: :controller do
         it "redirects to case detail page and contains a hash" do
           post :create , params: params
           expect(response).to redirect_to(case_path(overturned_sar, anchor: 'messages-section'))
+          expect(ActionNotificationsMailer)
+            .to have_received(:notify_information_officers)
+                  .with(overturned_sar, 'Message received')
+
+        end
+      end
+    end
+
+    context "overturned_foi case" do
+      let(:overturned_foi)     { create :accepted_ot_ico_foi }
+      let(:params) do
+        {
+          case: {
+            message_text: 'This is a new message'
+          },
+          case_id: overturned_foi.id
+        }
+      end
+
+      context "as a manager" do
+        before { sign_in manager }
+
+        it "redirects to case detail page and contains a hash" do
+          post :create , params: params
+          expect(response).to redirect_to(case_path(overturned_foi, anchor: 'messages-section'))
+          expect(ActionNotificationsMailer)
+            .to have_received(:notify_information_officers)
+                  .with(overturned_foi, 'Message received')
+
         end
       end
     end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -26,12 +26,6 @@ RSpec.describe MessagesController, type: :controller do
       }
     end
 
-    before do
-      allow(ActionNotificationsMailer).to receive_message_chain(:notify_information_officers,
-                                                                :deliver_later)
-    end
-
-
     context "as an anonymous user" do
       it "be redirected to signin if trying to start a new case" do
         post :create , params: params
@@ -68,10 +62,6 @@ RSpec.describe MessagesController, type: :controller do
       it "redirects to case detail page and contains a hash" do
         post :create , params: params
         expect(response).to redirect_to(case_path(accepted_case, anchor: 'messages-section'))
-        expect(ActionNotificationsMailer)
-          .to have_received(:notify_information_officers)
-                .with(accepted_case, 'Message received')
-
       end
       it 'allows them to post on a closed case' do
         params[:case_id] = closed_case.id
@@ -98,9 +88,6 @@ RSpec.describe MessagesController, type: :controller do
         params[:case_id] = flagged_case.id
         post :create , params: params
         expect(response).to redirect_to(case_path(flagged_case, anchor: 'messages-section'))
-        expect(ActionNotificationsMailer)
-          .to have_received(:notify_information_officers)
-                .with(flagged_case, 'Message received')
       end
 
     end
@@ -127,83 +114,8 @@ RSpec.describe MessagesController, type: :controller do
       end
     end
 
-    context "ico fois appeal case" do
-      let(:ico_case)     { create :accepted_ico_foi_case }
-      let(:params) do
-        {
-          case: {
-            message_text: 'This is a new message'
-          },
-          case_id: ico_case.id
-        }
-      end
-
-      context "as a manager" do
-        before { sign_in manager }
-
-        it "redirects to case detail page and contains a hash" do
-          post :create , params: params
-          expect(response).to redirect_to(case_path(ico_case, anchor: 'messages-section'))
-          expect(ActionNotificationsMailer)
-            .to have_received(:notify_information_officers)
-                  .with(ico_case, 'Message received')
-
-        end
-      end
-    end
-
-    context "ico sars appeal case" do
-      let(:ico_case)     { create :accepted_ico_sar_case }
-      let(:params) do
-        {
-          case: {
-            message_text: 'This is a new message'
-          },
-          case_id: ico_case.id
-        }
-      end
-
-      context "as a manager" do
-        before { sign_in manager }
-
-        it "redirects to case detail page and contains a hash" do
-          post :create , params: params
-          expect(response).to redirect_to(case_path(ico_case, anchor: 'messages-section'))
-          expect(ActionNotificationsMailer)
-            .to have_received(:notify_information_officers)
-                  .with(ico_case, 'Message received')
-
-        end
-      end
-    end
-
-    context "sar case" do
-      let(:sar)     { create :accepted_sar }
-      let(:params) do
-        {
-          case: {
-            message_text: 'This is a new message'
-          },
-          case_id: sar.id
-        }
-      end
-
-      context "as a manager" do
-        before { sign_in manager }
-
-        it "redirects to case detail page and contains a hash" do
-          post :create , params: params
-          expect(response).to redirect_to(case_path(sar, anchor: 'messages-section'))
-          expect(ActionNotificationsMailer)
-            .to have_received(:notify_information_officers)
-                  .with(sar, 'Message received')
-
-        end
-      end
-    end
-
     context "overturned_sar case" do
-      let(:overturned_sar)     { create :accepted_ot_ico_sar }
+      let(:overturned_sar)     { create :overturned_ico_sar }
       let(:params) do
         {
           case: {
@@ -219,35 +131,6 @@ RSpec.describe MessagesController, type: :controller do
         it "redirects to case detail page and contains a hash" do
           post :create , params: params
           expect(response).to redirect_to(case_path(overturned_sar, anchor: 'messages-section'))
-          expect(ActionNotificationsMailer)
-            .to have_received(:notify_information_officers)
-                  .with(overturned_sar, 'Message received')
-
-        end
-      end
-    end
-
-    context "overturned_foi case" do
-      let(:overturned_foi)     { create :accepted_ot_ico_foi }
-      let(:params) do
-        {
-          case: {
-            message_text: 'This is a new message'
-          },
-          case_id: overturned_foi.id
-        }
-      end
-
-      context "as a manager" do
-        before { sign_in manager }
-
-        it "redirects to case detail page and contains a hash" do
-          post :create , params: params
-          expect(response).to redirect_to(case_path(overturned_foi, anchor: 'messages-section'))
-          expect(ActionNotificationsMailer)
-            .to have_received(:notify_information_officers)
-                  .with(overturned_foi, 'Message received')
-
         end
       end
     end

--- a/spec/services/case_assign_responder_service_spec.rb
+++ b/spec/services/case_assign_responder_service_spec.rb
@@ -52,32 +52,6 @@ describe CaseAssignResponderService, type: :service do
         service.call
         expect(service.assignment).to eq new_assignment
       end
-
-      it 'emails the team' do
-        service.call
-        expect(ActionNotificationsMailer).to have_received(:new_assignment)
-                                      .with new_assignment,
-                                            responding_team.email
-      end
-
-      context 'a team with no email address' do
-        let(:other_responder) { create :responder }
-
-        before do
-          responding_team.responders << other_responder
-          responding_team.update email: nil
-        end
-
-        it 'emails each of the responders on the team' do
-          service.call
-          expect(ActionNotificationsMailer).to have_received(:new_assignment)
-                                        .with new_assignment,
-                                              responder.email
-          expect(ActionNotificationsMailer).to have_received(:new_assignment)
-                                        .with new_assignment,
-                                              other_responder.email
-        end
-      end
     end
 
     context 'created assignment is invalid' do

--- a/spec/services/user_reassignment_service_spec.rb
+++ b/spec/services/user_reassignment_service_spec.rb
@@ -54,12 +54,6 @@ describe UserReassignmentService do
 
     context 'Reassign the assignment' do
 
-      before do
-        allow(ActionNotificationsMailer).to receive_message_chain(
-                                            :case_assigned_to_another_user,
-                                            :deliver_later)
-      end
-
       it 'returns :ok' do
         expect(service.call).to eq :ok
       end
@@ -75,11 +69,6 @@ describe UserReassignmentService do
         assignment = accepted_case.assignments
         service.call
         expect(accepted_case.assignments).to eq assignment
-      end
-
-      it 'sends an email (only if different and user not assigning themselves' do
-        service.call
-        expect(ActionNotificationsMailer).to have_received(:case_assigned_to_another_user)
       end
 
       context 'when an error occurs' do
@@ -104,12 +93,6 @@ describe UserReassignmentService do
           expect(result).to eq :error
           expect(service.result).to eq :error
         end
-
-        it 'does not send an email' do
-          allow(assignment).to receive(:update).and_throw(RuntimeError)
-          service.call
-          expect(ActionNotificationsMailer).to_not have_received(:case_assigned_to_another_user)
-        end
       end
     end
 
@@ -120,16 +103,9 @@ describe UserReassignmentService do
                                     assignment: assignment )
       }
 
-      before do
-        allow(ActionNotificationsMailer).to receive_message_chain(
-                                            :case_assigned_to_another_user,
-                                            :deliver_later)
-      end
-
       it 'should not send email' do
         service.call
         expect(service.result).to eq :ok
-        expect(ActionNotificationsMailer).to_not have_received(:case_assigned_to_another_user)
       end
     end
 
@@ -153,12 +129,6 @@ describe UserReassignmentService do
 
       context 'Reassign the assignment' do
 
-        before do
-          allow(ActionNotificationsMailer).to receive_message_chain(
-                                              :case_assigned_to_another_user,
-                                              :deliver_later)
-        end
-
         it 'returns :ok' do
           expect(service.call).to eq :ok
         end
@@ -174,11 +144,6 @@ describe UserReassignmentService do
           assignment = unassigned_case.assignments
           service.call
           expect(unassigned_case.assignments).to eq assignment
-        end
-
-        it 'sends an email (only if different and user not assigning themselves' do
-          service.call
-          expect(ActionNotificationsMailer).to have_received(:case_assigned_to_another_user)
         end
       end
     end

--- a/spec/state_machines/configurable_state_machine/machine_spec.rb
+++ b/spec/state_machines/configurable_state_machine/machine_spec.rb
@@ -569,7 +569,68 @@ module ConfigurableStateMachine
       end
     end
 
+    describe '#config_for_event' do
+      before(:each) { @policy = double Case::FOI::StandardPolicy }
 
+      context 'role provided as a string parameter' do
+        context 'event can be triggered' do
+          context 'triggered as a result of an predicate returning true' do
+            it 'returns the event config' do
+              expect(Case::FOI::StandardPolicy)
+                .to receive(:new)
+                      .with(user: @manager, kase: @unassigned_case)
+                      .and_return(@policy)
+              expect(@policy).to receive(:can_add_message_to_case?).and_return(true)
+              machine = Machine.new(config: config, kase: @unassigned_case)
+              expect(machine.config_for_event(
+                       event_name: :add_message_to_case,
+                       metadata: {acting_user: @manager},
+                       roles: 'manager').to_h
+                    )
+                .to eq({ if: 'Case::FOI::StandardPolicy#can_add_message_to_case?' })
+            end
+          end
+
+          xcontext 'triggered as a result of no "if present' do
+            it 'returns true' do
+              expect(Case::FOI::StandardPolicy).not_to receive(:new)
+              config.user_roles.manager.states.unassigned.add_message_to_case.delete_field(:if)
+              expect(machine.can_trigger_event?(
+                                                event_name: :add_message_to_case,
+                                                metadata: {acting_user: @manager},
+                                                roles: 'manager')
+                                              ).to be true
+
+            end
+          end
+        end
+
+        xcontext 'event cannot be triggered' do
+          context 'not triggered as a result of a predicate returning false' do
+            it 'returns  false' do
+              expect(Case::FOI::StandardPolicy).to receive(:new).with(user: @manager, kase: @unassigned_case).and_return(@policy)
+              expect(@policy).to receive(:can_add_message_to_case?).and_return(false)
+              machine = Machine.new(config: config, kase: @unassigned_case)
+              expect(machine.can_trigger_event?(
+                                                event_name: :add_message_to_case,
+                                                metadata: {acting_user: @manager},
+                                                roles: 'manager')
+                                              ).to be false
+            end
+          end
+          context 'event not a valid event for role/state' do
+            it 'returns false' do
+              machine = Machine.new(config: config, kase: @unassigned_case)
+              expect(machine.can_trigger_event?(
+                                                event_name: :flag_for_press,
+                                                metadata: {acting_user: @manager},
+                                                roles: 'manager')
+                                              ).to be false
+            end
+          end
+        end
+      end
+    end
 
     describe '#trigger_event' do
       context 'invalid metadata' do

--- a/spec/state_machines/configurable_state_machine/machine_spec.rb
+++ b/spec/state_machines/configurable_state_machine/machine_spec.rb
@@ -591,7 +591,7 @@ module ConfigurableStateMachine
             end
           end
 
-          xcontext 'triggered as a result of no "if present' do
+          context 'triggered as a result of no "if present' do
             it 'returns true' do
               expect(Case::FOI::StandardPolicy).not_to receive(:new)
               config.user_roles.manager.states.unassigned.add_message_to_case.delete_field(:if)
@@ -605,7 +605,7 @@ module ConfigurableStateMachine
           end
         end
 
-        xcontext 'event cannot be triggered' do
+        context 'event cannot be triggered' do
           context 'not triggered as a result of a predicate returning false' do
             it 'returns  false' do
               expect(Case::FOI::StandardPolicy).to receive(:new).with(user: @manager, kase: @unassigned_case).and_return(@policy)

--- a/spec/state_machines/foi_event_spec.rb
+++ b/spec/state_machines/foi_event_spec.rb
@@ -1556,6 +1556,166 @@ describe 'state machine' do
       }
     end
 
+  ############## EMAIL TESTS ################
+
+
+    describe :add_message_to_case do
+      it {
+        should have_after_hook(
+          [:disclosure_bmt, :std_draft_foi],
+          [:disclosure_bmt, :std_awdis_foi],
+          [:disclosure_bmt, :std_responded_foi],
+          [:disclosure_bmt, :trig_draft_foi],
+          [:disclosure_bmt, :trig_pdacu_foi],
+          [:disclosure_bmt, :trig_awdis_foi],
+          [:disclosure_bmt, :trig_responded_foi],
+          [:disclosure_bmt, :full_draft_foi],
+          [:disclosure_bmt, :full_ppress_foi],
+          [:disclosure_bmt, :full_pprivate_foi],
+          [:disclosure_bmt, :full_awdis_foi],
+          [:disclosure_bmt, :full_responded_foi],
+          [:disclosure_bmt, :trig_draft_foi_accepted],
+          [:disclosure_bmt, :trig_pdacu_foi_accepted],
+          [:disclosure_bmt, :full_pdacu_foi_accepted],
+          [:disclosure_bmt, :full_pdacu_foi_unaccepted],
+          [:disclosure_bmt, :full_ppress_foi_accepted],
+          [:disclosure_bmt, :full_pprivate_foi_accepted],
+
+          [:disclosure_specialist, :trig_draft_foi],
+          [:disclosure_specialist, :trig_pdacu_foi],
+          [:disclosure_specialist, :trig_awdis_foi],
+          [:disclosure_specialist, :trig_responded_foi],
+          [:disclosure_specialist, :trig_draft_foi_accepted],
+          [:disclosure_specialist, :trig_pdacu_foi_accepted],
+          [:disclosure_specialist, :full_draft_foi],
+          [:disclosure_specialist, :full_ppress_foi],
+          [:disclosure_specialist, :full_pprivate_foi],
+          [:disclosure_specialist, :full_awdis_foi],
+          [:disclosure_specialist, :full_responded_foi],
+          [:disclosure_specialist, :full_pdacu_foi_accepted],
+          [:disclosure_specialist, :full_pdacu_foi_unaccepted],
+          [:disclosure_specialist, :full_ppress_foi_accepted],
+          [:disclosure_specialist, :full_pprivate_foi_accepted],
+
+          [:disclosure_specialist_coworker, :trig_draft_foi],
+          [:disclosure_specialist_coworker, :trig_pdacu_foi],
+          [:disclosure_specialist_coworker, :trig_draft_foi_accepted],
+          [:disclosure_specialist_coworker, :trig_pdacu_foi_accepted],
+          [:disclosure_specialist_coworker, :full_draft_foi],
+          [:disclosure_specialist_coworker, :full_ppress_foi],
+          [:disclosure_specialist_coworker, :full_pprivate_foi],
+          [:disclosure_specialist_coworker, :full_responded_foi],
+          [:disclosure_specialist_coworker, :full_pdacu_foi_accepted],
+          [:disclosure_specialist_coworker, :full_pdacu_foi_unaccepted],
+          [:disclosure_specialist_coworker, :full_ppress_foi_accepted],
+          [:disclosure_specialist_coworker, :full_pprivate_foi_accepted],
+
+          [:another_disclosure_specialist, :trig_draft_foi],
+          [:another_disclosure_specialist, :trig_draft_foi_accepted],
+          [:another_disclosure_specialist, :trig_pdacu_foi],
+          [:another_disclosure_specialist, :trig_pdacu_foi_accepted],
+
+          [:responder, :std_draft_foi],
+          [:responder, :std_awdis_foi],
+          [:responder, :std_responded_foi],
+          [:responder, :trig_draft_foi],
+          [:responder, :trig_pdacu_foi],
+          [:responder, :trig_awdis_foi],
+          [:responder, :trig_responded_foi],
+          [:responder, :trig_draft_foi_accepted],
+          [:responder, :trig_pdacu_foi_accepted],
+          [:responder, :full_draft_foi],
+          [:responder, :full_ppress_foi],
+          [:responder, :full_pprivate_foi],
+          [:responder, :full_awdis_foi],
+          [:responder, :full_responded_foi],
+          [:responder, :full_pdacu_foi_accepted],
+          [:responder, :full_pdacu_foi_unaccepted],
+          [:responder, :full_ppress_foi_accepted],
+          [:responder, :full_pprivate_foi_accepted],
+
+          [:another_responder_in_same_team, :std_draft_foi],
+          [:another_responder_in_same_team, :std_awdis_foi],
+          [:another_responder_in_same_team, :std_responded_foi],
+          [:another_responder_in_same_team, :trig_draft_foi],
+          [:another_responder_in_same_team, :trig_draft_foi_accepted],
+          [:another_responder_in_same_team, :trig_pdacu_foi],
+          [:another_responder_in_same_team, :trig_pdacu_foi_accepted],
+          [:another_responder_in_same_team, :trig_awdis_foi],
+          [:another_responder_in_same_team, :trig_responded_foi],
+          [:another_responder_in_same_team, :full_draft_foi],
+          [:another_responder_in_same_team, :full_ppress_foi],
+          [:another_responder_in_same_team, :full_pprivate_foi],
+          [:another_responder_in_same_team, :full_awdis_foi],
+          [:another_responder_in_same_team, :full_responded_foi],
+          [:another_responder_in_same_team, :full_pdacu_foi_accepted],
+          [:another_responder_in_same_team, :full_pdacu_foi_unaccepted],
+          [:another_responder_in_same_team, :full_ppress_foi_accepted],
+          [:another_responder_in_same_team, :full_pprivate_foi_accepted],
+
+          [:press_officer, :trig_draft_foi],
+          [:press_officer, :trig_pdacu_foi],
+          [:press_officer, :trig_draft_foi_accepted],
+          [:press_officer, :trig_pdacu_foi_accepted],
+          [:press_officer, :full_draft_foi],
+          [:press_officer, :full_ppress_foi],
+          [:press_officer, :full_pprivate_foi],
+          [:press_officer, :full_responded_foi],
+          [:press_officer, :full_pdacu_foi_accepted],
+          [:press_officer, :full_pdacu_foi_unaccepted],
+          [:press_officer, :full_ppress_foi_accepted],
+          [:press_officer, :full_pprivate_foi_accepted],
+
+          [:private_officer, :trig_draft_foi],
+          [:private_officer, :trig_pdacu_foi],
+          [:private_officer, :trig_draft_foi_accepted],
+          [:private_officer, :trig_pdacu_foi_accepted],
+          [:private_officer, :full_draft_foi],
+          [:private_officer, :full_ppress_foi],
+          [:private_officer, :full_pprivate_foi],
+          [:private_officer, :full_responded_foi],
+          [:private_officer, :full_pdacu_foi_accepted],
+          [:private_officer, :full_pdacu_foi_unaccepted],
+          [:private_officer, :full_ppress_foi_accepted],
+          [:private_officer, :full_pprivate_foi_accepted],
+
+       ).with_hook('Workflows::Hooks', :notify_responder_message_received)
+     }
+    end
+
+    describe :upload_response_and_return_for_redraft do
+      it {
+        should have_after_hook(
+          [:disclosure_specialist, :full_pdacu_foi_accepted],
+          [:disclosure_specialist, :trig_pdacu_foi_accepted],
+       ).with_hook('Workflows::Hooks', :notify_responder_redraft_requested)
+     }
+    end
+
+    describe :approve do
+      it {
+        should have_after_hook(
+          [:disclosure_specialist, :trig_pdacu_foi_accepted]
+       ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
+     }
+    end
+
+    describe :upload_response_and_approve do
+      it {
+        should have_after_hook(
+          [:disclosure_specialist, :trig_pdacu_foi_accepted]
+       ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
+     }
+    end
+
+    describe :upload_response_approve_and_bypass do
+      it {
+        should have_after_hook(
+          [:disclosure_specialist, :full_pdacu_foi_accepted],
+       ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
+     }
+    end
+
   end
 
   context 'with cases closed the old way' do

--- a/spec/state_machines/foi_event_spec.rb
+++ b/spec/state_machines/foi_event_spec.rb
@@ -1692,11 +1692,162 @@ describe 'state machine' do
      }
     end
 
+    describe :reassign_user do
+      it {
+        should have_after_hook(
+          [:disclosure_specialist, :trig_unassigned_foi_accepted],
+          [:disclosure_specialist, :trig_awresp_foi],
+          [:disclosure_specialist, :trig_awresp_foi_accepted],
+          [:disclosure_specialist, :trig_draft_foi],
+          [:disclosure_specialist, :trig_draft_foi_accepted],
+          [:disclosure_specialist, :trig_pdacu_foi],
+          [:disclosure_specialist, :trig_pdacu_foi_accepted],
+          [:disclosure_specialist, :trig_awdis_foi],
+          [:disclosure_specialist, :full_awresp_foi],
+          [:disclosure_specialist, :full_awresp_foi_accepted],
+          [:disclosure_specialist, :full_draft_foi],
+          [:disclosure_specialist, :full_pdacu_foi_accepted],
+          [:disclosure_specialist, :full_pdacu_foi_unaccepted],
+          [:disclosure_specialist, :full_ppress_foi],
+          [:disclosure_specialist, :full_ppress_foi_accepted],
+          [:disclosure_specialist, :full_pprivate_foi_accepted],
+          [:disclosure_specialist, :full_pprivate_foi],
+          [:disclosure_specialist, :full_awdis_foi],
+
+
+          [:disclosure_specialist_coworker, :trig_unassigned_foi_accepted],
+          [:disclosure_specialist_coworker, :trig_awresp_foi],
+          [:disclosure_specialist_coworker, :trig_awresp_foi_accepted],
+          [:disclosure_specialist_coworker, :trig_draft_foi],
+          [:disclosure_specialist_coworker, :trig_draft_foi_accepted],
+          [:disclosure_specialist_coworker, :trig_pdacu_foi],
+          [:disclosure_specialist_coworker, :trig_pdacu_foi_accepted],
+          [:disclosure_specialist_coworker, :trig_awdis_foi],
+          [:disclosure_specialist_coworker, :full_awresp_foi],
+          [:disclosure_specialist_coworker, :full_awresp_foi_accepted],
+          [:disclosure_specialist_coworker, :full_draft_foi],
+          [:disclosure_specialist_coworker, :full_pdacu_foi_accepted],
+          [:disclosure_specialist_coworker, :full_pdacu_foi_unaccepted],
+          [:disclosure_specialist_coworker, :full_ppress_foi],
+          [:disclosure_specialist_coworker, :full_ppress_foi_accepted],
+          [:disclosure_specialist_coworker, :full_pprivate_foi_accepted],
+          [:disclosure_specialist_coworker, :full_pprivate_foi],
+          [:disclosure_specialist_coworker, :full_awdis_foi],
+
+          [:another_disclosure_specialist, :trig_awresp_foi],
+          [:another_disclosure_specialist, :trig_awresp_foi_accepted],
+          [:another_disclosure_specialist, :trig_draft_foi],
+          [:another_disclosure_specialist, :trig_draft_foi_accepted],
+          [:another_disclosure_specialist, :trig_pdacu_foi],
+          [:another_disclosure_specialist, :trig_pdacu_foi_accepted],
+          [:another_disclosure_specialist, :full_awresp_foi],
+          [:another_disclosure_specialist, :full_awresp_foi_accepted],
+          [:another_disclosure_specialist, :full_draft_foi],
+          [:another_disclosure_specialist, :full_pdacu_foi_accepted],
+          [:another_disclosure_specialist, :full_pdacu_foi_unaccepted],
+
+          [:responder, :std_draft_foi],
+          [:responder, :std_awdis_foi],
+          [:responder, :trig_draft_foi],
+          [:responder, :trig_draft_foi_accepted],
+          [:responder, :trig_pdacu_foi],
+          [:responder, :trig_pdacu_foi_accepted],
+          [:responder, :trig_awdis_foi],
+          [:responder, :full_draft_foi],
+          [:responder, :full_pdacu_foi_accepted],
+          [:responder, :full_pdacu_foi_unaccepted],
+          [:responder, :full_ppress_foi],
+          [:responder, :full_ppress_foi_accepted],
+          [:responder, :full_pprivate_foi],
+          [:responder, :full_pprivate_foi_accepted],
+          [:responder, :full_awdis_foi],
+
+          [:another_responder_in_same_team, :std_draft_foi],
+          [:another_responder_in_same_team, :std_awdis_foi],
+          [:another_responder_in_same_team, :trig_draft_foi],
+          [:another_responder_in_same_team, :trig_draft_foi_accepted],
+          [:another_responder_in_same_team, :trig_pdacu_foi],
+          [:another_responder_in_same_team, :trig_pdacu_foi_accepted],
+          [:another_responder_in_same_team, :trig_awdis_foi],
+          [:another_responder_in_same_team, :full_draft_foi],
+          [:another_responder_in_same_team, :full_pdacu_foi_accepted],
+          [:another_responder_in_same_team, :full_pdacu_foi_unaccepted],
+          [:another_responder_in_same_team, :full_ppress_foi],
+          [:another_responder_in_same_team, :full_ppress_foi_accepted],
+          [:another_responder_in_same_team, :full_pprivate_foi],
+          [:another_responder_in_same_team, :full_pprivate_foi_accepted],
+          [:another_responder_in_same_team, :full_awdis_foi],
+
+          [:press_officer, :trig_awresp_foi],
+          [:press_officer, :trig_awresp_foi_accepted],
+          [:press_officer, :trig_draft_foi],
+          [:press_officer, :trig_draft_foi_accepted],
+          [:press_officer, :trig_pdacu_foi],
+          [:press_officer, :trig_pdacu_foi_accepted],
+          [:press_officer, :full_awresp_foi],
+          [:press_officer, :full_awresp_foi_accepted],
+          [:press_officer, :full_draft_foi],
+          [:press_officer, :full_pdacu_foi_accepted],
+          [:press_officer, :full_pdacu_foi_unaccepted],
+          [:press_officer, :full_ppress_foi],
+          [:press_officer, :full_ppress_foi_accepted],
+          [:press_officer, :full_pprivate_foi],
+          [:press_officer, :full_pprivate_foi_accepted],
+          [:press_officer, :full_awdis_foi],
+
+          [:private_officer, :trig_awresp_foi],
+          [:private_officer, :trig_awresp_foi_accepted],
+          [:private_officer, :trig_draft_foi],
+          [:private_officer, :trig_draft_foi_accepted],
+          [:private_officer, :trig_pdacu_foi],
+          [:private_officer, :trig_pdacu_foi_accepted],
+          [:private_officer, :full_awresp_foi],
+          [:private_officer, :full_awresp_foi_accepted],
+          [:private_officer, :full_draft_foi],
+          [:private_officer, :full_pdacu_foi_accepted],
+          [:private_officer, :full_pdacu_foi_unaccepted],
+          [:private_officer, :full_ppress_foi],
+          [:private_officer, :full_ppress_foi_accepted],
+          [:private_officer, :full_pprivate_foi],
+          [:private_officer, :full_pprivate_foi_accepted],
+          [:private_officer, :full_awdis_foi],
+       ).with_hook('Workflows::Hooks', :reassign_user_email)
+     }
+    end
+
     describe :approve do
       it {
         should have_after_hook(
           [:disclosure_specialist, :trig_pdacu_foi_accepted]
        ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
+     }
+    end
+
+    describe :assign_responder do
+      it {
+        should have_after_hook(
+          [:disclosure_bmt, :std_unassigned_foi],
+          [:disclosure_bmt, :trig_unassigned_foi],
+          [:disclosure_bmt, :trig_unassigned_foi_accepted],
+          [:disclosure_bmt, :full_unassigned_foi],
+       ).with_hook('Workflows::Hooks', :assign_responder_email)
+     }
+    end
+
+
+    describe :assign_to_new_team do
+      it {
+        should have_after_hook(
+          [:disclosure_bmt, :std_awresp_foi],
+          [:disclosure_bmt, :std_draft_foi],
+          [:disclosure_bmt, :trig_awresp_foi],
+          [:disclosure_bmt, :trig_awresp_foi_accepted],
+          [:disclosure_bmt, :trig_draft_foi],
+          [:disclosure_bmt, :trig_draft_foi_accepted],
+          [:disclosure_bmt, :full_awresp_foi],
+          [:disclosure_bmt, :full_awresp_foi_accepted],
+          [:disclosure_bmt, :full_draft_foi],
+       ).with_hook('Workflows::Hooks', :assign_responder_email)
      }
     end
 

--- a/spec/state_machines/foi_event_spec.rb
+++ b/spec/state_machines/foi_event_spec.rb
@@ -1680,7 +1680,7 @@ describe 'state machine' do
           [:private_officer, :full_pprivate_foi_accepted],
 
        ).with_hook('Workflows::Hooks', :notify_responder_message_received)
-     }
+      }
     end
 
     describe :upload_response_and_return_for_redraft do
@@ -1689,7 +1689,7 @@ describe 'state machine' do
           [:disclosure_specialist, :full_pdacu_foi_accepted],
           [:disclosure_specialist, :trig_pdacu_foi_accepted],
        ).with_hook('Workflows::Hooks', :notify_responder_redraft_requested)
-     }
+      }
     end
 
     describe :reassign_user do
@@ -1812,7 +1812,7 @@ describe 'state machine' do
           [:private_officer, :full_pprivate_foi_accepted],
           [:private_officer, :full_awdis_foi],
        ).with_hook('Workflows::Hooks', :reassign_user_email)
-     }
+      }
     end
 
     describe :approve do
@@ -1820,7 +1820,7 @@ describe 'state machine' do
         should have_after_hook(
           [:disclosure_specialist, :trig_pdacu_foi_accepted]
        ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
-     }
+      }
     end
 
     describe :assign_responder do
@@ -1831,7 +1831,7 @@ describe 'state machine' do
           [:disclosure_bmt, :trig_unassigned_foi_accepted],
           [:disclosure_bmt, :full_unassigned_foi],
        ).with_hook('Workflows::Hooks', :assign_responder_email)
-     }
+      }
     end
 
 
@@ -1848,7 +1848,7 @@ describe 'state machine' do
           [:disclosure_bmt, :full_awresp_foi_accepted],
           [:disclosure_bmt, :full_draft_foi],
        ).with_hook('Workflows::Hooks', :assign_responder_email)
-     }
+      }
     end
 
     describe :upload_response_and_approve do
@@ -1856,7 +1856,7 @@ describe 'state machine' do
         should have_after_hook(
           [:disclosure_specialist, :trig_pdacu_foi_accepted]
        ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
-     }
+      }
     end
 
     describe :upload_response_approve_and_bypass do
@@ -1864,7 +1864,7 @@ describe 'state machine' do
         should have_after_hook(
           [:disclosure_specialist, :full_pdacu_foi_accepted],
        ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
-     }
+      }
     end
 
   end

--- a/spec/state_machines/ico_event_spec.rb
+++ b/spec/state_machines/ico_event_spec.rb
@@ -746,16 +746,6 @@ describe 'state machine' do
      }
     end
 
-    describe :upload_response_and_return_for_redraft do
-      it {
-        should have_after_hook(
-          [:disclosure_specialist, :ico_sar_pending_dacu],
-          [:disclosure_specialist, :ico_foi_pending_dacu],
-
-       ).with_hook('Workflows::Hooks', :notify_responder_redraft_requested)
-     }
-    end
-
     describe :approve do
       it {
         should have_after_hook(
@@ -763,6 +753,81 @@ describe 'state machine' do
           [:disclosure_specialist, :ico_foi_pending_dacu],
 
        ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
+     }
+    end
+
+    describe :assign_responder do
+      it {
+        should have_after_hook(
+          [:disclosure_bmt, :ico_foi_unassigned],
+          [:disclosure_bmt, :ico_sar_unassigned],
+       ).with_hook('Workflows::Hooks', :assign_responder_email)
+     }
+    end
+
+
+    describe :assign_to_new_team do
+      it {
+        should have_after_hook(
+          [:disclosure_bmt, :ico_foi_awaiting_responder],
+          [:disclosure_bmt, :ico_foi_accepted],
+          [:disclosure_bmt, :ico_sar_awaiting_responder],
+          [:disclosure_bmt, :ico_sar_accepted],
+       ).with_hook('Workflows::Hooks', :assign_responder_email)
+     }
+    end
+
+
+    describe :reassign_user do
+      it {
+        should have_after_hook(
+          [:responder, :ico_foi_accepted],
+          [:responder, :ico_sar_accepted],
+          [:responder, :ico_foi_pending_dacu],
+          [:responder, :ico_sar_pending_dacu],
+          [:responder, :ico_foi_awaiting_dispatch],
+          [:responder, :ico_sar_awaiting_dispatch],
+
+          [:another_responder_in_same_team, :ico_foi_accepted],
+          [:another_responder_in_same_team, :ico_sar_accepted],
+          [:another_responder_in_same_team, :ico_foi_pending_dacu],
+          [:another_responder_in_same_team, :ico_sar_pending_dacu],
+          [:another_responder_in_same_team, :ico_foi_awaiting_dispatch],
+          [:another_responder_in_same_team, :ico_sar_awaiting_dispatch],
+
+          [:disclosure_specialist, :ico_foi_unassigned],
+          [:disclosure_specialist, :ico_foi_awaiting_responder],
+          [:disclosure_specialist, :ico_foi_accepted],
+          [:disclosure_specialist, :ico_foi_pending_dacu],
+          [:disclosure_specialist, :ico_foi_awaiting_dispatch],
+          [:disclosure_specialist, :ico_sar_unassigned],
+          [:disclosure_specialist, :ico_sar_awaiting_responder],
+          [:disclosure_specialist, :ico_sar_accepted],
+          [:disclosure_specialist, :ico_sar_pending_dacu],
+          [:disclosure_specialist, :ico_sar_awaiting_dispatch],
+
+          [:disclosure_specialist_coworker, :ico_foi_unassigned],
+          [:disclosure_specialist_coworker, :ico_foi_awaiting_responder],
+          [:disclosure_specialist_coworker, :ico_foi_accepted],
+          [:disclosure_specialist_coworker, :ico_foi_pending_dacu],
+          [:disclosure_specialist_coworker, :ico_foi_awaiting_dispatch],
+          [:disclosure_specialist_coworker, :ico_sar_unassigned],
+          [:disclosure_specialist_coworker, :ico_sar_awaiting_responder],
+          [:disclosure_specialist_coworker, :ico_sar_accepted],
+          [:disclosure_specialist_coworker, :ico_sar_pending_dacu],
+          [:disclosure_specialist_coworker, :ico_sar_awaiting_dispatch],
+
+       ).with_hook('Workflows::Hooks', :reassign_user_email)
+     }
+    end
+
+    describe :upload_response_and_return_for_redraft do
+      it {
+        should have_after_hook(
+          [:disclosure_specialist, :ico_sar_pending_dacu],
+          [:disclosure_specialist, :ico_foi_pending_dacu],
+
+       ).with_hook('Workflows::Hooks', :notify_responder_redraft_requested)
      }
     end
 

--- a/spec/state_machines/ico_event_spec.rb
+++ b/spec/state_machines/ico_event_spec.rb
@@ -743,7 +743,7 @@ describe 'state machine' do
           [:disclosure_specialist_coworker, :ico_sar_responded],
 
        ).with_hook('Workflows::Hooks', :notify_responder_message_received)
-     }
+      }
     end
 
     describe :approve do
@@ -753,7 +753,7 @@ describe 'state machine' do
           [:disclosure_specialist, :ico_foi_pending_dacu],
 
        ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
-     }
+      }
     end
 
     describe :assign_responder do
@@ -762,7 +762,7 @@ describe 'state machine' do
           [:disclosure_bmt, :ico_foi_unassigned],
           [:disclosure_bmt, :ico_sar_unassigned],
        ).with_hook('Workflows::Hooks', :assign_responder_email)
-     }
+      }
     end
 
 
@@ -774,7 +774,7 @@ describe 'state machine' do
           [:disclosure_bmt, :ico_sar_awaiting_responder],
           [:disclosure_bmt, :ico_sar_accepted],
        ).with_hook('Workflows::Hooks', :assign_responder_email)
-     }
+      }
     end
 
 
@@ -818,7 +818,7 @@ describe 'state machine' do
           [:disclosure_specialist_coworker, :ico_sar_awaiting_dispatch],
 
        ).with_hook('Workflows::Hooks', :reassign_user_email)
-     }
+      }
     end
 
     describe :upload_response_and_return_for_redraft do
@@ -828,7 +828,7 @@ describe 'state machine' do
           [:disclosure_specialist, :ico_foi_pending_dacu],
 
        ).with_hook('Workflows::Hooks', :notify_responder_redraft_requested)
-     }
+      }
     end
 
     describe :upload_response_and_approve do
@@ -838,7 +838,7 @@ describe 'state machine' do
           [:disclosure_specialist, :ico_foi_pending_dacu],
 
        ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
-     }
+      }
     end
   end
 end

--- a/spec/state_machines/ico_event_spec.rb
+++ b/spec/state_machines/ico_event_spec.rb
@@ -685,6 +685,95 @@ describe 'state machine' do
                )
       }
     end
-  end
 
+  ############## EMAIL TESTS ################
+
+
+    describe :add_message_to_case do
+      it {
+        should have_after_hook(
+          [:disclosure_bmt, :ico_foi_accepted],
+          [:disclosure_bmt, :ico_foi_pending_dacu],
+          [:disclosure_bmt, :ico_foi_awaiting_dispatch],
+          [:disclosure_bmt, :ico_foi_responded],
+
+          [:disclosure_bmt, :ico_sar_accepted],
+          [:disclosure_bmt, :ico_sar_pending_dacu],
+          [:disclosure_bmt, :ico_sar_awaiting_dispatch],
+          [:disclosure_bmt, :ico_sar_responded],
+
+          [:responder, :ico_foi_accepted],
+          [:responder, :ico_foi_pending_dacu],
+          [:responder, :ico_foi_awaiting_dispatch],
+          [:responder, :ico_foi_responded],
+
+          [:responder, :ico_sar_accepted],
+          [:responder, :ico_sar_pending_dacu],
+          [:responder, :ico_sar_awaiting_dispatch],
+          [:responder, :ico_sar_responded],
+
+          [:another_responder_in_same_team, :ico_foi_accepted],
+          [:another_responder_in_same_team, :ico_foi_pending_dacu],
+          [:another_responder_in_same_team, :ico_foi_awaiting_dispatch],
+          [:another_responder_in_same_team, :ico_foi_responded],
+
+          [:another_responder_in_same_team, :ico_sar_accepted],
+          [:another_responder_in_same_team, :ico_sar_pending_dacu],
+          [:another_responder_in_same_team, :ico_sar_awaiting_dispatch],
+          [:another_responder_in_same_team, :ico_sar_responded],
+
+          [:disclosure_specialist, :ico_foi_accepted],
+          [:disclosure_specialist, :ico_foi_pending_dacu],
+          [:disclosure_specialist, :ico_foi_awaiting_dispatch],
+          [:disclosure_specialist, :ico_foi_responded],
+
+          [:disclosure_specialist, :ico_sar_accepted],
+          [:disclosure_specialist, :ico_sar_pending_dacu],
+          [:disclosure_specialist, :ico_sar_awaiting_dispatch],
+          [:disclosure_specialist, :ico_sar_responded],
+
+          [:disclosure_specialist_coworker, :ico_foi_accepted],
+          [:disclosure_specialist_coworker, :ico_foi_pending_dacu],
+          [:disclosure_specialist_coworker, :ico_foi_awaiting_dispatch],
+          [:disclosure_specialist_coworker, :ico_foi_responded],
+
+          [:disclosure_specialist_coworker, :ico_sar_accepted],
+          [:disclosure_specialist_coworker, :ico_sar_pending_dacu],
+          [:disclosure_specialist_coworker, :ico_sar_awaiting_dispatch],
+          [:disclosure_specialist_coworker, :ico_sar_responded],
+
+       ).with_hook('Workflows::Hooks', :notify_responder_message_received)
+     }
+    end
+
+    describe :upload_response_and_return_for_redraft do
+      it {
+        should have_after_hook(
+          [:disclosure_specialist, :ico_sar_pending_dacu],
+          [:disclosure_specialist, :ico_foi_pending_dacu],
+
+       ).with_hook('Workflows::Hooks', :notify_responder_redraft_requested)
+     }
+    end
+
+    describe :approve do
+      it {
+        should have_after_hook(
+          [:disclosure_specialist, :ico_sar_pending_dacu],
+          [:disclosure_specialist, :ico_foi_pending_dacu],
+
+       ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
+     }
+    end
+
+    describe :upload_response_and_approve do
+      it {
+        should have_after_hook(
+          [:disclosure_specialist, :ico_sar_pending_dacu],
+          [:disclosure_specialist, :ico_foi_pending_dacu],
+
+       ).with_hook('Workflows::Hooks', :notify_responder_ready_to_send)
+     }
+    end
+  end
 end

--- a/spec/state_machines/overturned_sar_event_spec.rb
+++ b/spec/state_machines/overturned_sar_event_spec.rb
@@ -66,7 +66,7 @@ describe 'state machine' do
                [:disclosure_bmt, :ot_ico_sar_noff_awresp],
                [:disclosure_bmt, :ot_ico_sar_noff_draft],
                [:disclosure_bmt, :ot_ico_sar_noff_closed],
-             )}
+             ) }
   end
 
   describe :close do
@@ -102,9 +102,10 @@ describe 'state machine' do
   describe :reassign_user do
     it {
       should permit_event_to_be_triggered_only_by(
-        [:responder, :ot_ico_sar_noff_draft],
-        [:another_responder_in_same_team, :ot_ico_sar_noff_draft],
-    )  }
+               [:responder, :ot_ico_sar_noff_draft],
+               [:another_responder_in_same_team, :ot_ico_sar_noff_draft],
+             ) # .with_post_hook(Workflows::Hooks, :notify_managing_team_case_closed)
+    }
   end
 
   describe :reject_responder_assignment do

--- a/spec/state_machines/overturned_sar_event_spec.rb
+++ b/spec/state_machines/overturned_sar_event_spec.rb
@@ -102,9 +102,9 @@ describe 'state machine' do
   describe :reassign_user do
     it {
       should permit_event_to_be_triggered_only_by(
-               [:responder, :ot_ico_sar_noff_draft],
-               [:another_responder_in_same_team, :ot_ico_sar_noff_draft],
-             ) # .with_post_hook(Workflows::Hooks, :notify_managing_team_case_closed)
+        [:responder, :ot_ico_sar_noff_draft],
+        [:another_responder_in_same_team, :ot_ico_sar_noff_draft],
+      )
     }
   end
 
@@ -157,6 +157,24 @@ describe 'state machine' do
     }
   end
 
+  describe :assign_responder do
+    it {
+      should have_after_hook(
+        [:disclosure_bmt, :ot_ico_sar_noff_unassigned],
+     ).with_hook('Workflows::Hooks', :assign_responder_email)
+   }
+  end
+
+
+  describe :assign_to_new_team do
+    it {
+      should have_after_hook(
+        [:disclosure_bmt, :ot_ico_sar_noff_awresp],
+        [:disclosure_bmt, :ot_ico_sar_noff_draft],
+     ).with_hook('Workflows::Hooks', :assign_responder_email)
+   }
+  end
+
   describe :close do
     it {
       should have_after_hook(
@@ -166,6 +184,15 @@ describe 'state machine' do
 
      ).with_hook('Workflows::Hooks', :notify_managing_team_case_closed)
    }
+  end
+
+  describe :reassign_user do
+    it {
+      should have_after_hook(
+        [:responder, :ot_ico_sar_noff_draft],
+        [:another_responder_in_same_team, :ot_ico_sar_noff_draft]
+       ).with_hook('Workflows::Hooks', :reassign_user_email)
+    }
   end
 
 end

--- a/spec/state_machines/overturned_sar_event_spec.rb
+++ b/spec/state_machines/overturned_sar_event_spec.rb
@@ -142,4 +142,30 @@ describe 'state machine' do
       )}
   end
 
+############## EMAIL TESTS ################
+
+  describe :add_message_to_case do
+    it {
+      should have_after_hook(
+         [:disclosure_bmt, :ot_ico_sar_noff_draft],
+
+         [:responder, :ot_ico_sar_noff_draft],
+
+         [:another_responder_in_same_team, :ot_ico_sar_noff_draft],
+
+       ).with_hook('Workflows::Hooks', :notify_responder_message_received)
+    }
+  end
+
+  describe :close do
+    it {
+      should have_after_hook(
+       [:responder, :ot_ico_sar_noff_draft],
+
+       [:another_responder_in_same_team, :ot_ico_sar_noff_draft],
+
+     ).with_hook('Workflows::Hooks', :notify_managing_team_case_closed)
+   }
+  end
+
 end

--- a/spec/state_machines/overturned_sar_event_spec.rb
+++ b/spec/state_machines/overturned_sar_event_spec.rb
@@ -162,7 +162,7 @@ describe 'state machine' do
       should have_after_hook(
         [:disclosure_bmt, :ot_ico_sar_noff_unassigned],
      ).with_hook('Workflows::Hooks', :assign_responder_email)
-   }
+    }
   end
 
 
@@ -172,7 +172,7 @@ describe 'state machine' do
         [:disclosure_bmt, :ot_ico_sar_noff_awresp],
         [:disclosure_bmt, :ot_ico_sar_noff_draft],
      ).with_hook('Workflows::Hooks', :assign_responder_email)
-   }
+    }
   end
 
   describe :close do
@@ -183,7 +183,7 @@ describe 'state machine' do
        [:another_responder_in_same_team, :ot_ico_sar_noff_draft],
 
      ).with_hook('Workflows::Hooks', :notify_managing_team_case_closed)
-   }
+    }
   end
 
   describe :reassign_user do

--- a/spec/state_machines/sar_event_spec.rb
+++ b/spec/state_machines/sar_event_spec.rb
@@ -43,6 +43,39 @@ describe 'state machine' do
                 )}
   end
 
+  ############## EMAIL TESTS ################
+
+  describe :add_message_to_case do
+    it {
+      should have_after_hook(
+         [:disclosure_bmt, :sar_noff_draft],
+         [:disclosure_bmt, :sar_noff_trig_draft],
+         [:disclosure_bmt, :sar_noff_trig_draft_accepted],
+         [:disclosure_bmt, :sar_noff_trig_awdis],
+         [:responder, :sar_noff_draft],
+         [:responder, :sar_noff_trig_draft],
+         [:responder, :sar_noff_trig_draft_accepted],
+         [:responder, :sar_noff_trig_awdis],
+         [:another_responder_in_same_team, :sar_noff_draft],
+         [:another_responder_in_same_team, :sar_noff_trig_draft],
+         [:another_responder_in_same_team, :sar_noff_trig_draft_accepted],
+         [:another_responder_in_same_team, :sar_noff_trig_awdis],
+       ).with_hook('Workflows::Hooks', :notify_responder_message_received)
+    }
+  end
+
+  describe :close do
+    it {
+      should have_after_hook(
+       [:responder, :sar_noff_draft],
+       [:responder, :sar_noff_trig_awdis],
+       [:another_responder_in_same_team, :sar_noff_draft],
+       [:another_responder_in_same_team, :sar_noff_trig_awdis],
+
+     ).with_hook('Workflows::Hooks', :notify_managing_team_case_closed)
+   }
+  end
+
   def all_user_teams
     @setup.user_teams
   end

--- a/spec/state_machines/sar_event_spec.rb
+++ b/spec/state_machines/sar_event_spec.rb
@@ -69,7 +69,7 @@ describe 'state machine' do
       should have_after_hook(
         [:disclosure_bmt, :sar_noff_unassigned]
      ).with_hook('Workflows::Hooks', :assign_responder_email)
-   }
+    }
   end
 
 
@@ -83,7 +83,7 @@ describe 'state machine' do
         [:disclosure_bmt, :sar_noff_trig_draft],
         [:disclosure_bmt, :sar_noff_trig_draft_accepted],
      ).with_hook('Workflows::Hooks', :assign_responder_email)
-   }
+    }
   end
 
   describe :close do
@@ -95,7 +95,7 @@ describe 'state machine' do
        [:another_responder_in_same_team, :sar_noff_trig_awdis],
 
      ).with_hook('Workflows::Hooks', :notify_managing_team_case_closed)
-   }
+    }
   end
 
   describe :reassign_user do
@@ -121,7 +121,7 @@ describe 'state machine' do
 
 
      ).with_hook('Workflows::Hooks', :reassign_user_email)
-   }
+    }
   end
 
   def all_user_teams

--- a/spec/state_machines/sar_event_spec.rb
+++ b/spec/state_machines/sar_event_spec.rb
@@ -64,6 +64,28 @@ describe 'state machine' do
     }
   end
 
+  describe :assign_responder do
+    it {
+      should have_after_hook(
+        [:disclosure_bmt, :sar_noff_unassigned]
+     ).with_hook('Workflows::Hooks', :assign_responder_email)
+   }
+  end
+
+
+  describe :assign_to_new_team do
+    it {
+      should have_after_hook(
+        [:disclosure_bmt, :sar_noff_awresp],
+        [:disclosure_bmt, :sar_noff_draft],
+        [:disclosure_bmt, :sar_noff_trig_awresp],
+        [:disclosure_bmt, :sar_noff_trig_awresp_accepted],
+        [:disclosure_bmt, :sar_noff_trig_draft],
+        [:disclosure_bmt, :sar_noff_trig_draft_accepted],
+     ).with_hook('Workflows::Hooks', :assign_responder_email)
+   }
+  end
+
   describe :close do
     it {
       should have_after_hook(
@@ -73,6 +95,32 @@ describe 'state machine' do
        [:another_responder_in_same_team, :sar_noff_trig_awdis],
 
      ).with_hook('Workflows::Hooks', :notify_managing_team_case_closed)
+   }
+  end
+
+  describe :reassign_user do
+    it {
+      should have_after_hook(
+        [:disclosure_specialist, :sar_noff_trig_awdis],
+        [:disclosure_specialist, :sar_noff_trig_awresp_accepted],
+        [:disclosure_specialist, :sar_noff_trig_draft_accepted],
+
+        [:disclosure_specialist_coworker, :sar_noff_trig_awdis],
+        [:disclosure_specialist_coworker, :sar_noff_trig_awresp_accepted],
+        [:disclosure_specialist_coworker, :sar_noff_trig_draft_accepted],
+
+        [:responder, :sar_noff_draft],
+        [:responder, :sar_noff_trig_awdis],
+        [:responder, :sar_noff_trig_draft_accepted],
+        [:responder, :sar_noff_trig_draft],
+
+        [:another_responder_in_same_team, :sar_noff_draft],
+        [:another_responder_in_same_team, :sar_noff_trig_awdis],
+        [:another_responder_in_same_team, :sar_noff_trig_draft_accepted],
+        [:another_responder_in_same_team, :sar_noff_trig_draft],
+
+
+     ).with_hook('Workflows::Hooks', :reassign_user_email)
    }
   end
 

--- a/spec/state_machines/workflows/hooks_spec.rb
+++ b/spec/state_machines/workflows/hooks_spec.rb
@@ -1,9 +1,14 @@
 require "rails_helper"
 
 describe Workflows::Hooks do
-  let(:user)     { create(:responder) }
-  let(:kase)     { create(:foi_case)  }
-  let(:workflow) { described_class.new(user: user, kase: kase, metadata: nil) }
+  let(:responder)               { create(:responder, responding_teams: [responding_team]) }
+  let(:another_responder)       { create :responder, responding_teams: [responding_team] }
+  let(:approver)                { create :disclosure_specialist}
+  let(:another_approver)        { create :disclosure_specialist}
+  let(:kase)                    { create(:accepted_case, :flagged_accepted, :dacu_disclosure, approver: approver, responder: responder)  }
+  let(:responding_team)         { find_or_create(:responding_team) }
+  let(:another_responding_team) { create :responding_team, email: 'madeupemail@test.com'}
+  let(:workflow)                { described_class.new(user: responder, kase: kase, metadata: nil) }
 
   describe '#notify_managing_team_case_closed' do
     before do
@@ -16,6 +21,69 @@ describe Workflows::Hooks do
       expect(ActionNotificationsMailer)
         .to have_received(:notify_team)
               .with(kase.managing_team, kase, 'Case closed')
+    end
+  end
+
+  describe '#reassign_user_email' do
+    before do
+      allow(ActionNotificationsMailer).to receive_message_chain(:case_assigned_to_another_user,
+                                                                :deliver_later)
+    end
+    context 'responder reassigning' do
+      context 'current user is not assigning to themselves' do
+        let(:workflow) { described_class.new(user: responder, kase: kase, metadata: {target_user: another_responder}) }
+
+        it 'sends the notification' do
+          workflow.reassign_user_email
+          expect(ActionNotificationsMailer)
+            .to have_received(:case_assigned_to_another_user)
+                  .with(kase, another_responder)
+        end
+      end
+
+      context 'current_user assigns to themselves' do
+        let(:workflow) { described_class.new(user: responder, kase: kase, metadata: {target_user: responder}) }
+
+        it 'does not send the notification' do
+          workflow.reassign_user_email
+          expect(ActionNotificationsMailer)
+            .not_to have_received(:case_assigned_to_another_user)
+                  .with(kase, another_responder)
+        end
+      end
+    end
+
+    context 'approver reassigning' do
+      context 'current user is not assigning to themselves' do
+        let(:workflow) { described_class.new(user: responder, kase: kase, metadata: {target_user: another_approver}) }
+
+        it 'sends the notification' do
+          workflow.reassign_user_email
+          expect(ActionNotificationsMailer)
+            .to have_received(:case_assigned_to_another_user)
+                  .with(kase, another_approver)
+        end
+      end
+    end
+  end
+
+  describe '#assign_responder_email' do
+    let(:workflow)    { described_class.new(user: responder, kase: kase, metadata: {target_team: another_responding_team}) }
+
+    before do
+      allow(ActionNotificationsMailer).to receive_message_chain(:new_assignment,
+                                                                :deliver_later)
+    end
+
+    context 'responder reassigning' do
+      context 'team has email adress' do
+        it 'sends a notification' do
+          workflow.assign_responder_email
+          expect(ActionNotificationsMailer)
+            .to have_received(:new_assignment)
+                  .with(kase.responder_assignment, another_responding_team.email)
+        end
+      end
     end
   end
 end

--- a/spec/state_machines/workflows/hooks_spec.rb
+++ b/spec/state_machines/workflows/hooks_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Workflows::Hooks do
   let(:user)     { create(:responder) }
   let(:kase)     { create(:foi_case)  }
-  let(:workflow) { described_class.new(user: user, kase: kase) }
+  let(:workflow) { described_class.new(user: user, kase: kase, metadata: nil) }
 
   describe '#notify_managing_team_case_closed' do
     before do

--- a/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
+++ b/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
@@ -359,8 +359,7 @@ describe ConfigurableStateMachine::Machine do
                        :remove_linked_case,
                        :unaccept_approver_assignment,
                        :upload_response_and_approve,
-                       :upload_response_and_return_for_redraft,
-                       :upload_response_approve_and_bypass ]
+                       :upload_response_and_return_for_redraft]
           end
         end
 
@@ -458,8 +457,7 @@ describe ConfigurableStateMachine::Machine do
                                                                          :reassign_user, :remove_linked_case,
                                                                          :unaccept_approver_assignment,
                                                                          :upload_response_and_approve,
-                                                                         :upload_response_and_return_for_redraft,
-                                                                         :upload_response_approve_and_bypass]
+                                                                         :upload_response_and_return_for_redraft]
           end
         end
         context 'awaiting_dispatch state' do

--- a/spec/support/matchers/have_after_hook.rb
+++ b/spec/support/matchers/have_after_hook.rb
@@ -1,0 +1,65 @@
+module PermitTriggerEvent
+  RSpec::Matchers.define :have_after_hook do |*permitted_combinations|
+    match do |event|
+      permitted_combinations.each do |user_and_team, kase|
+        unless all_user_teams.key?(user_and_team)
+          @error_message = "User #{user_and_team} not found in all_user_teams()."
+          return false
+        end
+
+        unless all_cases.key?(kase)
+          @error_message = "Case #{kase} not found in all_cases()."
+          return false
+        end
+      end
+
+      @errors = []
+      all_user_teams.each do |user_type, user_and_team|
+        all_cases.each do |case_type, kase|
+          user, team = user_and_team
+          state_machine = kase.state_machine
+          config = state_machine.config_for_event(event_name: event,
+                                                  metadata: {
+                                                    acting_user: user,
+                                                    acting_team: team
+                                                  })
+
+            result = !config.nil? && config.after_transition == @expected_hook
+          if [user_type, case_type].in?(permitted_combinations) ^ result
+            (binding).pry if @debug_on_error && $stdout.tty?
+            @errors << [user_type, case_type, !config.nil?]
+          end
+        end
+      end
+      @errors.empty?
+    end
+
+    chain :with_hook do |klass, method|
+      @expected_hook = "#{klass}##{method}"
+    end
+
+    # Use this to run binding.pry if a particular combination fails a test.
+    # Handy to be able to get a peek into the context where the error occured.
+    # The debugger is also protected so that it doesn't appear if STDOUT is not
+    # a TTY.
+    chain :debug do
+      @debug_on_error = true
+    end
+
+    failure_message do |event|
+      unless @errors.nil? || @errors.empty?
+        @error_message = "Event #{event} failed for the combinations:\n"
+        @errors.each do |user_type, kase_type, result|
+          if result
+            @error_message <<
+                "  The after hook #{@expected_hook} was not present for #{user_type} on #{kase_type}.\n"
+          else
+            @error_message <<
+                "  We expected the after hook #{@expected_hook} to be present for #{user_type} on #{kase_type} cases, but it is not.\n"
+          end
+        end
+      end
+      @error_message
+    end
+  end
+end

--- a/spec/support/matchers/permit_trigger_event.rb
+++ b/spec/support/matchers/permit_trigger_event.rb
@@ -54,11 +54,6 @@ module PermitTriggerEvent
       @transition_to = target_state.to_s
     end
 
-    chain :with_post_hook do |klass, method|
-      @post_hook_class = klass
-      @post_hook_method = method
-    end
-
     # Use this to run binding.pry if a particular combination fails a test.
     # Handy to be able to get a peek into the context where the error occured.
     # The debugger is also protected so that it doesn't appear if STDOUT is not

--- a/spec/support/matchers/permit_trigger_event.rb
+++ b/spec/support/matchers/permit_trigger_event.rb
@@ -42,7 +42,6 @@ module PermitTriggerEvent
             #
             #    kase : the case currently being tested
             #    user : the user currently being tested
-            # unexpected_result = state_machine.can_trigger_event?(event_name: event, metadata: {acting_user: user, acting_team: team})
             @errors << [user_type, case_type, !config.nil?]
           end
         end


### PR DESCRIPTION
This changes the notifications by
- moving some of the notification calls into the state machine
- adding a new matcher to test that the email method is called in the state machine, to cover more states and case types