### PR TITLE
CT-2013 State machine bugfix

### DIFF
--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -49,8 +49,7 @@ module ConfigurableStateMachine
 
     def can_trigger_event?(event_name:, metadata:, roles: nil)
       configs = configs_for_event(event_name: event_name, metadata: metadata, roles: roles)
-      results = configs.map{ |config| event_triggerable_in_config?(config: config, user: @user ) }
-      results.include?(true)
+      configs.map{ |config| event_triggerable_in_config?(config: config, user: @user ) }.any?
     end
 
     def configs_for_event(event_name:, metadata:, roles:)


### PR DESCRIPTION
users with multiple roles were not able to add messages if their first role
was prvented from doing so by a predicate returning false, even though
subsequent roles allowed them to.

This has been fixed by evaluating the configs for all roles, and returning true
if any of them resolve to true

Tests for this edgecase have been added