### PR TITLE
CT-2017 allow upload to trigger fois in awaiting_dispatch

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,7 @@ en:
       show?: You are not authorised to view this case.
       unflag_for_clearance?: 'You are not authorised to remove clearance from this case'
       update?: You are not authorised to edit this case.
+      upload_responses_for_flagged?: 'You are not authorised to upload attachments to this case.'
     case/ico/foi_policy:
       can_close_case?: You are not authorised to close this case
       can_accept_or_reject_responder_assignment?: You are not allowed to accept or reject responder assignment

--- a/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
@@ -261,7 +261,7 @@
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                add_responses:
+                add_response_to_flagged_case:
                   if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
                 link_a_case:
                 reassign_user:

--- a/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
@@ -341,8 +341,8 @@
                  add_message_to_case:
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?
                    after_transition: Workflows::Hooks#notify_responder_message_received
-                 add_responses:
-                  if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                 add_response_to_flagged_case:
+                   if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
                  link_a_case:
                  reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user

--- a/spec/state_machines/foi_event_spec.rb
+++ b/spec/state_machines/foi_event_spec.rb
@@ -376,9 +376,14 @@ describe 'state machine' do
                  [:responder, :trig_draft_foi],
                  [:responder, :trig_draft_foi_accepted],
                  [:responder, :full_draft_foi],
+                 [:responder, :trig_awdis_foi],
+                 [:responder, :full_awdis_foi],
                  [:another_responder_in_same_team, :trig_draft_foi],
                  [:another_responder_in_same_team, :full_draft_foi],
-                 [:another_responder_in_same_team, :trig_draft_foi_accepted]
+                 [:another_responder_in_same_team, :trig_draft_foi_accepted],
+                 [:another_responder_in_same_team, :trig_awdis_foi],
+                 [:another_responder_in_same_team, :full_awdis_foi],
+
                )}
     end
 
@@ -387,12 +392,8 @@ describe 'state machine' do
         should permit_event_to_be_triggered_only_by(
                  [:responder, :std_draft_foi],
                  [:responder, :std_awdis_foi],
-                 [:responder, :trig_awdis_foi],
-                 [:responder, :full_awdis_foi],
                  [:another_responder_in_same_team, :std_draft_foi],
                  [:another_responder_in_same_team, :std_awdis_foi],
-                 [:another_responder_in_same_team, :trig_awdis_foi],
-                 [:another_responder_in_same_team, :full_awdis_foi],
                )}
     end
 

--- a/spec/state_machines/workflows/foi_permitted_events/full_approval_spec.rb
+++ b/spec/state_machines/workflows/foi_permitted_events/full_approval_spec.rb
@@ -327,7 +327,7 @@ describe ConfigurableStateMachine::Machine do
             expect(k.workflow).to eq 'full_approval'
             expect(k.current_state).to eq 'awaiting_dispatch'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_responses,
+                                                                          :add_response_to_flagged_case,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_linked_case,

--- a/spec/state_machines/workflows/foi_permitted_events/trigger_spec.rb
+++ b/spec/state_machines/workflows/foi_permitted_events/trigger_spec.rb
@@ -241,7 +241,7 @@ describe ConfigurableStateMachine::Machine do
             expect(k.workflow).to eq 'trigger'
             expect(k.current_state).to eq 'awaiting_dispatch'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_responses,
+                                                                          :add_response_to_flagged_case,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_last_response,

--- a/spec/state_machines/workflows/overturned_foi_permitted_events/full_approval_spec.rb
+++ b/spec/state_machines/workflows/overturned_foi_permitted_events/full_approval_spec.rb
@@ -327,7 +327,7 @@ describe ConfigurableStateMachine::Machine do
             expect(k.workflow).to eq 'full_approval'
             expect(k.current_state).to eq 'awaiting_dispatch'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_responses,
+                                                                          :add_response_to_flagged_case,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_linked_case,

--- a/spec/state_machines/workflows/overturned_foi_permitted_events/trigger_spec.rb
+++ b/spec/state_machines/workflows/overturned_foi_permitted_events/trigger_spec.rb
@@ -255,7 +255,7 @@ describe ConfigurableStateMachine::Machine do
             expect(k.workflow).to eq 'trigger'
             expect(k.current_state).to eq 'awaiting_dispatch'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_responses,
+                                                                          :add_response_to_flagged_case,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_last_response,


### PR DESCRIPTION
A user reported an issue where they could not upload a file to a case
in awaiting dispatch, on further investigatiion the action was checking
whether upload response to falgged case was in the state machine, it was
not however add_response was meanign the button was showing, as a quick
fix I have changed these events so now add_response_to_flagged_case has
replaced add_responses in the trigger and full_approval workflow.

This whole journey needs to be refactored since we no longer need two
separate events and the policies check lots of things that aren't
necessary