### PR TITLE
 Ct 2017 upload response awaiting dispatch trigger

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -828,10 +828,9 @@ class CasesController < ApplicationController
 
   def authorize_upload_response_for_action(kase, action)
     case action
-    when nil, 'upload'    then authorize kase, 'upload_responses?'
-    when 'upload-flagged' then authorize kase, 'upload_responses?'
-    when 'upload-approve' then authorize kase, 'upload_responses_for_approve?'
-    when 'upload-redraft' then authorize kase, 'upload_responses_for_redraft?'
+    when nil, 'upload', 'upload-flagged'  then authorize kase, 'upload_responses?'
+    when 'upload-approve'                 then authorize kase, 'upload_responses_for_approve?'
+    when 'upload-redraft'                 then authorize kase, 'upload_responses_for_redraft?'
     end
   end
 

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -829,7 +829,7 @@ class CasesController < ApplicationController
   def authorize_upload_response_for_action(kase, action)
     case action
     when nil, 'upload'    then authorize kase, 'upload_responses?'
-    when 'upload-flagged' then authorize kase, 'upload_responses_for_flagged?'
+    when 'upload-flagged' then authorize kase, 'upload_responses?'
     when 'upload-approve' then authorize kase, 'upload_responses_for_approve?'
     when 'upload-redraft' then authorize kase, 'upload_responses_for_redraft?'
     end

--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -259,12 +259,6 @@ class Case::BasePolicy < ApplicationPolicy
         check_can_trigger_event(:add_responses)
   end
 
-  # def upload_responses_for_flagged?
-  #   clear_failed_checks
-  #   check_user_is_in_current_team &&
-  #       check_can_trigger_event(:add_response_to_flagged_case)
-  # end
-
   def upload_responses_for_approve?
     clear_failed_checks
     check_user_is_in_current_team &&

--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -259,11 +259,11 @@ class Case::BasePolicy < ApplicationPolicy
         check_can_trigger_event(:add_responses)
   end
 
-  def upload_responses_for_flagged?
-    clear_failed_checks
-    check_user_is_in_current_team &&
-        check_can_trigger_event(:add_response_to_flagged_case)
-  end
+  # def upload_responses_for_flagged?
+  #   clear_failed_checks
+  #   check_user_is_in_current_team &&
+  #       check_can_trigger_event(:add_response_to_flagged_case)
+  # end
 
   def upload_responses_for_approve?
     clear_failed_checks

--- a/app/services/response_uploader_service.rb
+++ b/app/services/response_uploader_service.rb
@@ -58,11 +58,6 @@ class ResponseUploaderService
                                            acting_team: @case.responding_team,
                                            filenames: filenames,
                                            message: @case.upload_comment)
-      # when 'upload-flagged'
-      #   @case.state_machine.add_responses!(acting_user: @current_user,
-      #                                      acting_team: @case.responding_team,
-      #                                      filenames: filenames,
-      #                                      message: @case.upload_comment)
       when 'upload-approve'
         upload_approve(filenames)
       when 'upload-redraft'

--- a/app/services/response_uploader_service.rb
+++ b/app/services/response_uploader_service.rb
@@ -53,16 +53,16 @@ class ResponseUploaderService
       @case.upload_comment = @bypass_params_manager.params[:upload_comment]
       filenames = response_attachments.map(&:filename)
       case @action
-      when 'upload'
+      when 'upload', 'upload-flagged'
         @case.state_machine.add_responses!(acting_user: @current_user,
                                            acting_team: @case.responding_team,
                                            filenames: filenames,
                                            message: @case.upload_comment)
-      when 'upload-flagged'
-        @case.state_machine.add_responses!(acting_user: @current_user,
-                                           acting_team: @case.responding_team,
-                                           filenames: filenames,
-                                           message: @case.upload_comment)
+      # when 'upload-flagged'
+      #   @case.state_machine.add_responses!(acting_user: @current_user,
+      #                                      acting_team: @case.responding_team,
+      #                                      filenames: filenames,
+      #                                      message: @case.upload_comment)
       when 'upload-approve'
         upload_approve(filenames)
       when 'upload-redraft'

--- a/app/services/response_uploader_service.rb
+++ b/app/services/response_uploader_service.rb
@@ -59,10 +59,10 @@ class ResponseUploaderService
                                            filenames: filenames,
                                            message: @case.upload_comment)
       when 'upload-flagged'
-        @case.state_machine.add_response_to_flagged_case!(acting_user: @current_user,
-                                                          acting_team: @case.responding_team,
-                                                          filenames: filenames,
-                                                          message: @case.upload_comment)
+        @case.state_machine.add_responses!(acting_user: @current_user,
+                                           acting_team: @case.responding_team,
+                                           filenames: filenames,
+                                           message: @case.upload_comment)
       when 'upload-approve'
         upload_approve(filenames)
       when 'upload-redraft'

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -24,8 +24,8 @@ div id="case-#{@correspondence_type_key}" class="case"
           = action_button_for(:approve)
         - if policy(@case).upload_responses?
           = action_button_for(:add_responses)
-        - if policy(@case).upload_responses_for_flagged?
-          = action_button_for(:add_response_to_flagged_case)
+        / - if policy(@case).upload_responses_for_flagged?
+        /   = action_button_for(:add_response_to_flagged_case)
         - if policy(@case).upload_responses_for_approve?
           = action_button_for(:upload_response_and_approve)
         - if policy(@case).upload_responses_for_redraft?

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -34,7 +34,7 @@ div id="case-#{@correspondence_type_key}" class="case"
         - if policy(@case).can_respond?
           = action_button_for(:respond)
 
-        - permitted_events = @permitted_events - [:add_responses, :add_response_to_flagged_case, :approve, :respond, :reassign_user, :upload_response_and_approve, :upload_response_and_return_for_redraft]
+        - permitted_events = @permitted_events - [:add_responses, :approve, :respond, :reassign_user, :upload_response_and_approve, :upload_response_and_return_for_redraft]
         - if @case.type_abbreviation.in? %w( SAR OVERTURNED_SAR )
           - permitted_events.delete(:close)
 

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -24,8 +24,6 @@ div id="case-#{@correspondence_type_key}" class="case"
           = action_button_for(:approve)
         - if policy(@case).upload_responses?
           = action_button_for(:add_responses)
-        / - if policy(@case).upload_responses_for_flagged?
-        /   = action_button_for(:add_response_to_flagged_case)
         - if policy(@case).upload_responses_for_approve?
           = action_button_for(:upload_response_and_approve)
         - if policy(@case).upload_responses_for_redraft?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,7 @@ en:
       show?: You are not authorised to view this case.
       unflag_for_clearance?: 'You are not authorised to remove clearance from this case'
       update?: You are not authorised to edit this case.
+      upload_responses_for_flagged?: 'You are not authorised to upload attachments to this case.'
     case/ico/foi_policy:
       can_close_case?: You are not authorised to close this case
       can_accept_or_reject_responder_assignment?: You are not allowed to accept or reject responder assignment

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,7 +179,6 @@ en:
       show?: You are not authorised to view this case.
       unflag_for_clearance?: 'You are not authorised to remove clearance from this case'
       update?: You are not authorised to edit this case.
-      upload_responses_for_flagged?: 'You are not authorised to upload attachments to this case.'
     case/ico/foi_policy:
       can_close_case?: You are not authorised to close this case
       can_accept_or_reject_responder_assignment?: You are not allowed to accept or reject responder assignment

--- a/config/state_machine/configs/00_moj/10_foi_case_type/20_foi_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/20_foi_standard_workflow.yml
@@ -204,7 +204,7 @@
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 add_responses:
-                  if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   transition_to: awaiting_dispatch
                 link_a_case:
                 reassign_user:
@@ -217,7 +217,7 @@
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?
                    after_transition: Workflows::Hooks#notify_responder_message_received
                  add_responses:
-                  if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                  link_a_case:
                  reassign_user:
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?

--- a/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
@@ -236,7 +236,7 @@
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-                add_response_to_flagged_case:
+                add_responses:
                   if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
                   transition_to: pending_dacu_clearance
                 link_a_case:

--- a/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
@@ -237,7 +237,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_responses:
-                  if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   transition_to: pending_dacu_clearance
                 link_a_case:
                 reassign_user:
@@ -262,7 +262,7 @@
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 add_responses:
-                  if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 link_a_case:
                 reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user

--- a/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
@@ -297,7 +297,7 @@
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-                add_response_to_flagged_case:
+                add_responses:
                   if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
                   transition_to: pending_dacu_clearance
                 link_a_case:
@@ -342,7 +342,7 @@
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?
                    after_transition: Workflows::Hooks#notify_responder_message_received
                  add_responses:
-                  if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                   if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
                  link_a_case:
                  reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user

--- a/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
@@ -243,7 +243,7 @@
                   if: Workflows::Predicates#user_is_approver_on_case?
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 add_responses:
-                  if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                  if: Workflows::Predicates#user_is_assigned_disclosure_specialist?
                 flag_for_clearance:
                 link_a_case:
                 reassign_user:
@@ -298,7 +298,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_responses:
-                  if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   transition_to: pending_dacu_clearance
                 link_a_case:
                 reassign_user:
@@ -342,7 +342,7 @@
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?
                    after_transition: Workflows::Hooks#notify_responder_message_received
                  add_responses:
-                   if: Case::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                  link_a_case:
                  reassign_user:
                   if: Workflows::Predicates#case_is_assigned_to_responder_or_approver_in_same_team_as_current_user

--- a/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
@@ -191,7 +191,7 @@
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   after_transition: Workflows::Hooks#notify_responder_message_received
                 add_responses:
-                  if: Case::ICO::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   transition_to: pending_dacu_clearance
                 link_a_case:
                 reassign_user:
@@ -214,7 +214,7 @@
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?
                    after_transition: Workflows::Hooks#notify_responder_message_received
                  add_responses:
-                  if: Case::ICO::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
+                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                  link_a_case:
                  reassign_user:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?

--- a/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
@@ -190,7 +190,7 @@
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                add_response_to_flagged_case:
+                add_responses:
                   if: Case::ICO::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
                   transition_to: pending_dacu_clearance
                 link_a_case:

--- a/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/30_ico/20_ico_trigger_workflow.yml
@@ -213,7 +213,7 @@
                  add_message_to_case:
                    if: Workflows::Predicates#responder_is_member_of_assigned_team?
                    after_transition: Workflows::Hooks#notify_responder_message_received
-                 add_response_to_flagged_case:
+                 add_responses:
                   if: Case::ICO::BasePolicy#can_add_attachment_to_flagged_and_unflagged_cases?
                  link_a_case:
                  reassign_user:

--- a/lib/cts/cases/create.rb
+++ b/lib/cts/cases/create.rb
@@ -302,9 +302,9 @@ module CTS::Cases
                                            BypassParamsManager.new({}),
                                            nil)
          rus.seed!('spec/fixtures/eon.pdf')
-         kase.state_machine.add_response_to_flagged_case!(acting_user: responder,
-                                                          acting_team:responding_team,
-                                                          filenames: kase.attachments)
+         kase.state_machine.add_responses!(acting_user: responder,
+                                           acting_team:responding_team,
+                                           filenames: kase.attachments)
 
       end
     end

--- a/lib/cts/demo_setup.rb
+++ b/lib/cts/demo_setup.rb
@@ -102,7 +102,7 @@ module CTS
       upload_group = Time.now.strftime('%Y%m%d%H%M%S')
       kase.attachments << [ build_response(kase, upload_group, 1),  build_response(kase, upload_group, 2) ]
       if kase.requires_clearance?
-        kase.state_machine.add_response_to_flagged_case!(kase.responder, kase.responding_team, ['Demo_file_1.pdf', 'Demo_file_2.pdf'])
+        kase.state_machine.add_responses!(kase.responder, kase.responding_team, ['Demo_file_1.pdf', 'Demo_file_2.pdf'])
       end
     end
 

--- a/spec/controllers/cases_controller/show_spec.rb
+++ b/spec/controllers/cases_controller/show_spec.rb
@@ -102,7 +102,7 @@ describe CasesController, type: :controller do
       end
 
       it { should have_permitted_events_including :add_message_to_case,
-                                                  :add_response_to_flagged_case,
+                                                  :add_responses,
                                                   :reassign_user }
 
       it 'renders the show page' do

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -489,7 +489,7 @@ RSpec.describe CasesController, type: :controller do
       end
 
       it {should have_permitted_events_including :add_message_to_case,
-                                                 :add_response_to_flagged_case,
+                                                 :add_responses,
                                                  :reassign_user }
 
       it 'renders the show page' do

--- a/spec/factories/case_transitions.rb
+++ b/spec/factories/case_transitions.rb
@@ -152,7 +152,7 @@ FactoryBot.define do
     acting_user_id { responder.id }
     acting_team_id { responding_team.id }
     filenames      { ['file1.pdf', 'file2.pdf'] }
-    event          { 'add_response_to_flagged_case' }
+    event          { 'add_responses' }
   end
 
   factory :case_transition_approve, parent: :case_transition do

--- a/spec/factory_specs/overturned_ico_foi_factory_spec.rb
+++ b/spec/factory_specs/overturned_ico_foi_factory_spec.rb
@@ -134,7 +134,7 @@ describe 'Overturned ICO FOI cases factory' do
       expect(kase.transitions.size).to eq 4
       expect(kase.workflow).to eq 'trigger'
       transition = kase.transitions.last
-      expect(transition.event).to eq 'add_response_to_flagged_case'
+      expect(transition.event).to eq 'add_responses'
       expect(transition.acting_team_id).to eq responding_team.id
       expect(transition.acting_user_id).to eq responder.id
       expect(transition.target_team_id).to be_nil

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -1142,7 +1142,7 @@ RSpec.describe Case::Base, type: :model do
 
     def upload_response(kase, t, acting_team)
       Timecop.freeze(Time.at(Time.parse(t))) do
-        create_transition(kase, 'add_response_to_flagged_case', 'pending_dacu_clearance', acting_team)
+        create_transition(kase, 'add_responses', 'pending_dacu_clearance', acting_team)
       end
     end
 

--- a/spec/models/case/foi/standard_spec.rb
+++ b/spec/models/case/foi/standard_spec.rb
@@ -123,7 +123,7 @@ describe Case::FOI::Standard do
               expect(responder_assignments.first.state).to eq 'accepted'
 
               expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 7.business_days.ago.to_date
-              expect(kase.transitions.where(event: 'add_response_to_flagged_case').last.created_at.to_date).to eq 3.business_days.ago.to_date
+              expect(kase.transitions.where(event: 'add_responses').last.created_at.to_date).to eq 3.business_days.ago.to_date
 
               # then
               expect(kase.business_unit_responded_in_time?).to be true
@@ -164,7 +164,7 @@ describe Case::FOI::Standard do
               expect(responder_assignments.first.state).to eq 'accepted'
 
               expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 14.business_days.ago.to_date
-              expect(kase.transitions.where(event: 'add_response_to_flagged_case').last.created_at.to_date).to eq 3.business_days.ago.to_date
+              expect(kase.transitions.where(event: 'add_responses').last.created_at.to_date).to eq 3.business_days.ago.to_date
 
               # then
               expect(kase.business_unit_responded_in_time?).to be false
@@ -211,7 +211,7 @@ describe Case::FOI::Standard do
               expect(responder_assignments[2].state).to eq 'accepted'
 
               expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 7.business_days.ago.to_date
-              expect(kase.transitions.where(event: 'add_response_to_flagged_case').last.created_at.to_date).to eq 3.business_days.ago.to_date
+              expect(kase.transitions.where(event: 'add_responses').last.created_at.to_date).to eq 3.business_days.ago.to_date
 
               # then
               expect(kase.business_unit_responded_in_time?).to be true
@@ -255,7 +255,7 @@ describe Case::FOI::Standard do
               expect(responder_assignments[2].state).to eq 'accepted'
 
               expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 14.business_days.ago.to_date
-              expect(kase.transitions.where(event: 'add_response_to_flagged_case').last.created_at.to_date).to eq 1.business_days.ago.to_date
+              expect(kase.transitions.where(event: 'add_responses').last.created_at.to_date).to eq 1.business_days.ago.to_date
 
               # then
               expect(kase.business_unit_responded_in_time?).to be false
@@ -552,9 +552,9 @@ describe Case::FOI::Standard do
     responding_team = kase.responding_team
     responder = responding_team.users.first
 
-    kase.state_machine.add_response_to_flagged_case!(acting_user: responder,
-                                                       acting_team: responding_team,
-                                                       filenames: filenames)
+    kase.state_machine.add_responses!(acting_user: responder,
+                                      acting_team: responding_team,
+                                      filenames: filenames)
     kase.state_machine.accept_approver_assignment!(acting_user: approver, acting_team: approving_team)
     approver_assignment = kase.assignments.approving.where(team_id: approving_team.id).first
     approver_assignment.update(state: 'accepted', user_id: approver.id)

--- a/spec/policies/cases/base_policy_spec.rb
+++ b/spec/policies/cases/base_policy_spec.rb
@@ -478,24 +478,24 @@ describe Case::BasePolicy do
     it { should_not permit(press_officer,          pending_press_clearance_case) }
   end
 
-  permissions :upload_responses_for_flagged? do
-    it { should_not permit(manager,                accepted_case) }
-    it { should_not permit(responder,              accepted_case) }
-    it { should_not permit(disclosure_specialist,  accepted_case) }
-    it { should_not permit(press_officer,          accepted_case) }
-    it { should_not permit(manager,                flagged_accepted_case) }
-    it { should     permit(responder,              flagged_accepted_case) }
-    it { should_not permit(disclosure_specialist,  flagged_accepted_case) }
-    it { should_not permit(press_officer,          flagged_accepted_case) }
-    it { should_not permit(manager,                pending_dacu_clearance_case) }
-    it { should_not permit(responder,              pending_dacu_clearance_case) }
-    it { should_not permit(disclosure_specialist,  pending_dacu_clearance_case) }
-    it { should_not permit(press_officer,          pending_dacu_clearance_case) }
-    it { should_not permit(manager,                pending_press_clearance_case) }
-    it { should_not permit(responder,              pending_press_clearance_case) }
-    it { should_not permit(disclosure_specialist,  pending_press_clearance_case) }
-    it { should_not permit(press_officer,          pending_press_clearance_case) }
-  end
+  # permissions :upload_responses_for_flagged? do
+  #   it { should_not permit(manager,                accepted_case) }
+  #   it { should_not permit(responder,              accepted_case) }
+  #   it { should_not permit(disclosure_specialist,  accepted_case) }
+  #   it { should_not permit(press_officer,          accepted_case) }
+  #   it { should_not permit(manager,                flagged_accepted_case) }
+  #   it { should     permit(responder,              flagged_accepted_case) }
+  #   it { should_not permit(disclosure_specialist,  flagged_accepted_case) }
+  #   it { should_not permit(press_officer,          flagged_accepted_case) }
+  #   it { should_not permit(manager,                pending_dacu_clearance_case) }
+  #   it { should_not permit(responder,              pending_dacu_clearance_case) }
+  #   it { should_not permit(disclosure_specialist,  pending_dacu_clearance_case) }
+  #   it { should_not permit(press_officer,          pending_dacu_clearance_case) }
+  #   it { should_not permit(manager,                pending_press_clearance_case) }
+  #   it { should_not permit(responder,              pending_press_clearance_case) }
+  #   it { should_not permit(disclosure_specialist,  pending_press_clearance_case) }
+  #   it { should_not permit(press_officer,          pending_press_clearance_case) }
+  # end
 
   permissions :upload_responses_for_approve? do
     it { should_not permit(manager,                accepted_case) }

--- a/spec/policies/cases/base_policy_spec.rb
+++ b/spec/policies/cases/base_policy_spec.rb
@@ -478,25 +478,6 @@ describe Case::BasePolicy do
     it { should_not permit(press_officer,          pending_press_clearance_case) }
   end
 
-  # permissions :upload_responses_for_flagged? do
-  #   it { should_not permit(manager,                accepted_case) }
-  #   it { should_not permit(responder,              accepted_case) }
-  #   it { should_not permit(disclosure_specialist,  accepted_case) }
-  #   it { should_not permit(press_officer,          accepted_case) }
-  #   it { should_not permit(manager,                flagged_accepted_case) }
-  #   it { should     permit(responder,              flagged_accepted_case) }
-  #   it { should_not permit(disclosure_specialist,  flagged_accepted_case) }
-  #   it { should_not permit(press_officer,          flagged_accepted_case) }
-  #   it { should_not permit(manager,                pending_dacu_clearance_case) }
-  #   it { should_not permit(responder,              pending_dacu_clearance_case) }
-  #   it { should_not permit(disclosure_specialist,  pending_dacu_clearance_case) }
-  #   it { should_not permit(press_officer,          pending_dacu_clearance_case) }
-  #   it { should_not permit(manager,                pending_press_clearance_case) }
-  #   it { should_not permit(responder,              pending_press_clearance_case) }
-  #   it { should_not permit(disclosure_specialist,  pending_press_clearance_case) }
-  #   it { should_not permit(press_officer,          pending_press_clearance_case) }
-  # end
-
   permissions :upload_responses_for_approve? do
     it { should_not permit(manager,                accepted_case) }
     it { should_not permit(responder,              accepted_case) }

--- a/spec/policies/cases/base_policy_spec.rb
+++ b/spec/policies/cases/base_policy_spec.rb
@@ -462,10 +462,10 @@ describe Case::BasePolicy do
   permissions :upload_responses? do
     it { should_not permit(manager,                accepted_case) }
     it { should     permit(responder,              accepted_case) }
+    it { should     permit(responder,              flagged_accepted_case) }
     it { should_not permit(disclosure_specialist,  accepted_case) }
     it { should_not permit(press_officer,          accepted_case) }
     it { should_not permit(manager,                flagged_accepted_case) }
-    it { should_not permit(responder,              flagged_accepted_case) }
     it { should_not permit(disclosure_specialist,  flagged_accepted_case) }
     it { should_not permit(press_officer,          flagged_accepted_case) }
     it { should_not permit(manager,                pending_dacu_clearance_case) }

--- a/spec/services/response_uploader_service_spec.rb
+++ b/spec/services/response_uploader_service_spec.rb
@@ -170,7 +170,7 @@ describe ResponseUploaderService do
     let(:action)  { 'upload' }
     let(:kase)    { create :accepted_case, :flagged }
 
-    it 'calls add_response_to_flagged_case! on state machine' do
+    it 'calls add_responses! on state machine' do
       expect(kase.state_machine).to receive(:add_responses!)
       rus.upload!
     end

--- a/spec/services/response_uploader_service_spec.rb
+++ b/spec/services/response_uploader_service_spec.rb
@@ -167,25 +167,25 @@ describe ResponseUploaderService do
 
   context 'action upload-flagged' do
 
-    let(:action)  { 'upload-flagged' }
+    let(:action)  { 'upload' }
     let(:kase)    { create :accepted_case, :flagged }
 
     it 'calls add_response_to_flagged_case! on state machine' do
-      expect(kase.state_machine).to receive(:add_response_to_flagged_case!)
+      expect(kase.state_machine).to receive(:add_responses!)
       rus.upload!
     end
 
     it 'creates a transition' do
       rus.upload!
       transition = kase.transitions.last
-      expect(transition.event).to eq 'add_response_to_flagged_case'
+      expect(transition.event).to eq 'add_responses'
       expect(transition.metadata).to eq({ 'filenames' => [filename], 'message' => nil })
     end
 
     it 'creates a transition with a message' do
       rus_with_message.upload!
       transition = kase.transitions.last
-      expect(transition.event).to eq 'add_response_to_flagged_case'
+      expect(transition.event).to eq 'add_responses'
       expect(transition.metadata).to eq({ 'filenames' => [filename], 'message' => 'This is my upload message' })
     end
   end
@@ -298,4 +298,3 @@ describe ResponseUploaderService do
     end
   end
 end
-

--- a/spec/state_machines/foi_event_spec.rb
+++ b/spec/state_machines/foi_event_spec.rb
@@ -370,29 +370,42 @@ describe 'state machine' do
       }
     end
 
-    describe :add_response_to_flagged_case do
-      it {
-        should permit_event_to_be_triggered_only_by(
-                 [:responder, :trig_draft_foi],
-                 [:responder, :trig_draft_foi_accepted],
-                 [:responder, :full_draft_foi],
-                 [:another_responder_in_same_team, :trig_draft_foi],
-                 [:another_responder_in_same_team, :full_draft_foi],
-                 [:another_responder_in_same_team, :trig_draft_foi_accepted]
-               )}
-    end
+    # describe :add_response_to_flagged_case do
+    #   it {
+    #     should permit_event_to_be_triggered_only_by(
+    #              [:responder, :trig_draft_foi],
+    #              [:responder, :trig_draft_foi_accepted],
+    #              [:responder, :full_draft_foi],
+    #              [:responder, :trig_awdis_foi],
+    #              [:responder, :full_awdis_foi],
+    #              [:another_responder_in_same_team, :trig_draft_foi],
+    #              [:another_responder_in_same_team, :full_draft_foi],
+    #              [:another_responder_in_same_team, :trig_draft_foi_accepted],
+    #              [:another_responder_in_same_team, :trig_awdis_foi],
+    #              [:another_responder_in_same_team, :full_awdis_foi],
+    #
+    #            )}
+    # end
 
     describe :add_responses do
       it {
         should permit_event_to_be_triggered_only_by(
                  [:responder, :std_draft_foi],
                  [:responder, :std_awdis_foi],
-                 [:responder, :trig_awdis_foi],
-                 [:responder, :full_awdis_foi],
                  [:another_responder_in_same_team, :std_draft_foi],
                  [:another_responder_in_same_team, :std_awdis_foi],
-                 [:another_responder_in_same_team, :trig_awdis_foi],
-                 [:another_responder_in_same_team, :full_awdis_foi],
+
+                [:responder, :trig_draft_foi],
+                [:responder, :trig_draft_foi_accepted],
+                [:responder, :full_draft_foi],
+                [:responder, :trig_awdis_foi],
+                [:responder, :full_awdis_foi],
+                [:another_responder_in_same_team, :trig_draft_foi],
+                [:another_responder_in_same_team, :full_draft_foi],
+                [:another_responder_in_same_team, :trig_draft_foi_accepted],
+                [:another_responder_in_same_team, :trig_awdis_foi],
+                [:another_responder_in_same_team, :full_awdis_foi],
+
                )}
     end
 

--- a/spec/state_machines/foi_event_spec.rb
+++ b/spec/state_machines/foi_event_spec.rb
@@ -370,23 +370,6 @@ describe 'state machine' do
       }
     end
 
-    # describe :add_response_to_flagged_case do
-    #   it {
-    #     should permit_event_to_be_triggered_only_by(
-    #              [:responder, :trig_draft_foi],
-    #              [:responder, :trig_draft_foi_accepted],
-    #              [:responder, :full_draft_foi],
-    #              [:responder, :trig_awdis_foi],
-    #              [:responder, :full_awdis_foi],
-    #              [:another_responder_in_same_team, :trig_draft_foi],
-    #              [:another_responder_in_same_team, :full_draft_foi],
-    #              [:another_responder_in_same_team, :trig_draft_foi_accepted],
-    #              [:another_responder_in_same_team, :trig_awdis_foi],
-    #              [:another_responder_in_same_team, :full_awdis_foi],
-    #
-    #            )}
-    # end
-
     describe :add_responses do
       it {
         should permit_event_to_be_triggered_only_by(

--- a/spec/state_machines/ico_event_spec.rb
+++ b/spec/state_machines/ico_event_spec.rb
@@ -189,21 +189,6 @@ describe 'state machine' do
       }
     end
 
-    # describe :add_response_to_flagged_case do
-    #   it {
-    #     should permit_event_to_be_triggered_only_by(
-    #       [:responder, :ico_foi_accepted],
-    #       [:responder, :ico_sar_accepted],
-    #       [:responder, :ico_foi_awaiting_dispatch],
-    #       [:responder, :ico_sar_awaiting_dispatch],
-    #       [:another_responder_in_same_team, :ico_foi_accepted],
-    #       [:another_responder_in_same_team, :ico_sar_accepted],
-    #       [:another_responder_in_same_team, :ico_foi_awaiting_dispatch],
-    #       [:another_responder_in_same_team, :ico_sar_awaiting_dispatch],
-    #
-    #      )}
-    # end
-
     describe :approve do
       it {
         should permit_event_to_be_triggered_only_by(

--- a/spec/state_machines/ico_event_spec.rb
+++ b/spec/state_machines/ico_event_spec.rb
@@ -189,20 +189,20 @@ describe 'state machine' do
       }
     end
 
-    describe :add_response_to_flagged_case do
-      it {
-        should permit_event_to_be_triggered_only_by(
-          [:responder, :ico_foi_accepted],
-          [:responder, :ico_sar_accepted],
-          [:responder, :ico_foi_awaiting_dispatch],
-          [:responder, :ico_sar_awaiting_dispatch],
-          [:another_responder_in_same_team, :ico_foi_accepted],
-          [:another_responder_in_same_team, :ico_sar_accepted],
-          [:another_responder_in_same_team, :ico_foi_awaiting_dispatch],
-          [:another_responder_in_same_team, :ico_sar_awaiting_dispatch],
-
-         )}
-    end
+    # describe :add_response_to_flagged_case do
+    #   it {
+    #     should permit_event_to_be_triggered_only_by(
+    #       [:responder, :ico_foi_accepted],
+    #       [:responder, :ico_sar_accepted],
+    #       [:responder, :ico_foi_awaiting_dispatch],
+    #       [:responder, :ico_sar_awaiting_dispatch],
+    #       [:another_responder_in_same_team, :ico_foi_accepted],
+    #       [:another_responder_in_same_team, :ico_sar_accepted],
+    #       [:another_responder_in_same_team, :ico_foi_awaiting_dispatch],
+    #       [:another_responder_in_same_team, :ico_sar_awaiting_dispatch],
+    #
+    #      )}
+    # end
 
     describe :approve do
       it {

--- a/spec/state_machines/workflows/foi_permitted_events/full_approval_spec.rb
+++ b/spec/state_machines/workflows/foi_permitted_events/full_approval_spec.rb
@@ -269,7 +269,7 @@ describe ConfigurableStateMachine::Machine do
             expect(k.workflow).to eq 'full_approval'
             expect(k.current_state).to eq 'drafting'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_response_to_flagged_case,
+                                                                          :add_responses,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_linked_case,

--- a/spec/state_machines/workflows/foi_permitted_events/trigger_spec.rb
+++ b/spec/state_machines/workflows/foi_permitted_events/trigger_spec.rb
@@ -211,7 +211,7 @@ describe ConfigurableStateMachine::Machine do
             expect(k.workflow).to eq 'trigger'
             expect(k.current_state).to eq 'drafting'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_response_to_flagged_case,
+                                                                          :add_responses,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_linked_case,

--- a/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
+++ b/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
@@ -209,7 +209,7 @@ describe ConfigurableStateMachine::Machine do
 
             expect(k.current_state).to eq 'drafting'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_response_to_flagged_case,
+                                                                          :add_responses,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_linked_case]
@@ -236,7 +236,7 @@ describe ConfigurableStateMachine::Machine do
 
             expect(k.current_state).to eq 'awaiting_dispatch'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_response_to_flagged_case,
+                                                                          :add_responses,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_linked_case,

--- a/spec/state_machines/workflows/overturned_foi_permitted_events/full_approval_spec.rb
+++ b/spec/state_machines/workflows/overturned_foi_permitted_events/full_approval_spec.rb
@@ -269,7 +269,7 @@ describe ConfigurableStateMachine::Machine do
             expect(k.workflow).to eq 'full_approval'
             expect(k.current_state).to eq 'drafting'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_response_to_flagged_case,
+                                                                          :add_responses,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_linked_case,

--- a/spec/state_machines/workflows/overturned_foi_permitted_events/trigger_spec.rb
+++ b/spec/state_machines/workflows/overturned_foi_permitted_events/trigger_spec.rb
@@ -224,7 +224,7 @@ describe ConfigurableStateMachine::Machine do
             expect(k.workflow).to eq 'trigger'
             expect(k.current_state).to eq 'drafting'
             expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                          :add_response_to_flagged_case,
+                                                                          :add_responses,
                                                                           :link_a_case,
                                                                           :reassign_user,
                                                                           :remove_linked_case,

--- a/spec/views/cases/show_html_slim_spec.rb
+++ b/spec/views/cases/show_html_slim_spec.rb
@@ -8,7 +8,6 @@ describe 'cases/show.html.slim', type: :view do
 
   def setup_policies(policies)
     policy_names = [
-      :add_response_to_flagged_case?,
       :assignments_execute_reassign_user?,
       :can_remove_attachment?,
       :can_respond?,
@@ -279,8 +278,6 @@ describe 'cases/show.html.slim', type: :view do
                      remove_clearance?: false,
                      execute_response_approval?: false,
                      upload_responses?: false,
-                     upload_responses_for_flagged?: false,
-                     add_response_to_flagged_case?: false,
                      upload_responses_for_approve?: false,
                      upload_responses_for_redraft?: false
 


### PR DESCRIPTION
Since we introduced the new state machine it seems unnecessary to have two events for uploading responses (add_responses and add_response_to_flagged_case).

This PR  changes the system to only use add_responses.

This was prompted by a bug where users could not upload responses to trigger cases in awaiting dispatch.