### PR TITLE
CT-2025 Background creation of report R005

### DIFF
--- a/config/sidekiq-background-jobs.yml
+++ b/config/sidekiq-background-jobs.yml
@@ -14,12 +14,19 @@ r003_report_definition: &r003_report_definition
   class: ReportGeneratorJob
   queue: report_generator
   args: ['R003']
-  description: This job generates the R003 YTD Bunsiness unit performance report
+  description: This job generates the R003 YTD Business unit performance report
 
 :schedule:
   R003 YTD Business unit performance report: 
     <<: *r003_report_definition
     cron: '0 0 * * * *' # Run on the hour
+
+  R005 Monthly performance report:
+    class: ReportGeneratorJob
+    queue: report_generator
+    args: ['R005']
+    description: This job generates the R005 Monthly performance report
+    cron: '5 0 * * * *' # Five minutes past each hour
 
 development:
   :schedule:


### PR DESCRIPTION
Currently, there is no configuration for R005 in the config/sidekq-backgound-jobs.yml
which means when the stats controller gets a request to donwload R005, it will always
generate a new report, rather than look to see if there is anb existing one in the database.

This report is now taking too long to generate and the request times out.

This adds a configuration to generate the rport every hour (at five past the hour),
and so shuold obviate this problem