### PR TITLE
Use ipv4.pool.sks-keyservers.net instead of p80.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y apt-transport-https && \
 
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
-RUN apt-key adv --batch --no-tty --keyserver hkp://85.25.207.23:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 # Add PostgreSQL repo to sources
 RUN . /etc/os-release ; release="${VERSION#* (}" ; release="${release%)}" ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y apt-transport-https && \
 
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
-RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+RUN apt-key adv --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 # Add PostgreSQL repo to sources
 RUN . /etc/os-release ; release="${VERSION#* (}" ; release="${release%)}" ; \


### PR DESCRIPTION
Apparently the p80 is a subset of the pool that is available on port 80, while
ha is the larger pool and should be more generally available.

https://askubuntu.com/questions/720517/key-server-times-out-while-installing-docker-on-ubuntu-14-04