### PR TITLE
CT-2077 Add temporary limit to closed case CSV output

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -84,7 +84,7 @@ class CasesController < ApplicationController
                              .cases
                              .by_last_transitioned_date
     if download_csv_request?
-      @cases = unpaginated_cases
+      @cases = unpaginated_cases.limit(1000)
     else
       @cases = unpaginated_cases.page(params[:page]).decorate
     end

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -18,6 +18,7 @@ def stub_current_case_finder_for_closed_cases_with(result)
   cases = double 'ActiveRecord Cases', by_last_transitioned_date: cases_by_last_transitioned_date
   page = instance_double GlobalNavManager::Page, cases: cases
   gnm = instance_double GlobalNavManager, current_page_or_tab: page
+  allow(cases_by_last_transitioned_date).to receive(:limit).and_return(cases_by_last_transitioned_date)
   allow(GlobalNavManager).to receive(:new).and_return gnm
   gnm
 end


### PR DESCRIPTION
There are around 8,000 closed cases on the live system, and
requesting a CSV download of all thses was causing server timeout
on live.  While investigation is continuing on how to stream these
in a production environment, a temporary fix to limit output to
the first 1000 cases (by last transitions date in descending order)
has been implemented.