### PR TITLE
CT-2060 Upload during escalation period bugfix

### DIFF
--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -40,7 +40,7 @@ module CasesHelper
               assign_to_new_team_case_assignment_path(@case, @case .responder_assignment),
               id: 'action--assign-new-team',
               class: 'button'
-    when :add_responses, :add_response_to_flagged_case
+    when :add_responses
       link_to t('common.case.upload_response'),
               new_response_upload_case_path(@case, 'mode' => determine_action),
               id: 'action--upload-response',

--- a/app/state_machines/workflows/predicates.rb
+++ b/app/state_machines/workflows/predicates.rb
@@ -122,7 +122,7 @@ class Workflows::Predicates
     @kase.extended_for_pit?
   end
 
-  def case_respondable?   # member of assigned team and outstide escalation period
+  def assigned_team_member_and_case_outside_escalation_period?
     responder_is_member_of_assigned_team? && @kase.outside_escalation_deadline?
   end
 

--- a/app/state_machines/workflows/predicates.rb
+++ b/app/state_machines/workflows/predicates.rb
@@ -122,6 +122,10 @@ class Workflows::Predicates
     @kase.extended_for_pit?
   end
 
+  def case_respondable?   # member of assigned team and outstide escalation period
+    responder_is_member_of_assigned_team? && @kase.outside_escalation_deadline?
+  end
+
 
   private
 

--- a/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
@@ -243,7 +243,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_responses:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  if: Workflows::Predicates#case_respondable?   # member of assigned team and outstide escalation period
                   transition_to: pending_dacu_clearance
                 link_a_case:
                 reassign_user:

--- a/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/30_foi_trigger_workflow.yml
@@ -251,7 +251,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_responses:
-                  if: Workflows::Predicates#case_respondable?   # member of assigned team and outstide escalation period
+                  if: Workflows::Predicates#assigned_team_member_and_case_outside_escalation_period?
                   transition_to: pending_dacu_clearance
                 link_a_case:
                 reassign_user:

--- a/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
@@ -318,7 +318,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_responses:
-                  if: Workflows::Predicates#case_respondable?   # member of assigned team and outstide escalation period
+                  if: Workflows::Predicates#assigned_team_member_and_case_outside_escalation_period?
                   transition_to: pending_dacu_clearance
                 link_a_case:
                 reassign_user:

--- a/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
+++ b/config/state_machine/configs/00_moj/10_foi_case_type/40_foi_full_approval_workflow.yml
@@ -306,7 +306,7 @@
                   after_transition: Workflows::Hooks#notify_responder_message_received
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_responses:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
+                  if: Workflows::Predicates#case_respondable?   # member of assigned team and outstide escalation period
                   transition_to: pending_dacu_clearance
                 link_a_case:
                 reassign_user:

--- a/spec/state_machines/workflows/predicates_spec.rb
+++ b/spec/state_machines/workflows/predicates_spec.rb
@@ -253,5 +253,49 @@ module Workflows
         end
       end
     end
+
+    describe :case_respondable? do
+      let(:kase)        { @all_cases[:case_drafting] }
+      let(:predicate)   { Predicates.new(user: user, kase: kase) }
+
+      context 'manager' do
+        let(:user)    { @disclosure_bmt_user }
+        it 'returns false' do
+          expect(predicate.case_respondable?).to be false
+        end
+      end
+
+      context 'approver' do
+        let(:user)      { @disclosure_specialist }
+        it 'returns false' do
+          expect(predicate.case_respondable?).to be false
+        end
+      end
+
+      context 'responder' do
+        let(:user)        { @assigned_responder }
+        context 'in same team' do
+          context 'within escalation deadline' do
+            it 'returns false' do
+              allow(kase).to receive(:escalation_deadline).and_return(2.days.from_now)
+              expect(predicate.case_respondable?).to be false
+            end
+          end
+          context 'outside escalation deadline' do
+            it 'returns true' do
+              allow(kase).to receive(:escalation_deadline).and_return(2.days.ago)
+              expect(predicate.case_respondable?).to be true
+            end
+          end
+        end
+
+        context 'in different team' do
+          let(:user)      { @another_responder }
+          it 'returns false' do
+            expect(predicate.case_respondable?).to be false
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/state_machines/workflows/predicates_spec.rb
+++ b/spec/state_machines/workflows/predicates_spec.rb
@@ -254,21 +254,21 @@ module Workflows
       end
     end
 
-    describe :case_respondable? do
+    describe :assigned_team_member_and_case_outside_escalation_period? do
       let(:kase)        { @all_cases[:case_drafting] }
       let(:predicate)   { Predicates.new(user: user, kase: kase) }
 
       context 'manager' do
         let(:user)    { @disclosure_bmt_user }
         it 'returns false' do
-          expect(predicate.case_respondable?).to be false
+          expect(predicate.assigned_team_member_and_case_outside_escalation_period?).to be false
         end
       end
 
       context 'approver' do
         let(:user)      { @disclosure_specialist }
         it 'returns false' do
-          expect(predicate.case_respondable?).to be false
+          expect(predicate.assigned_team_member_and_case_outside_escalation_period?).to be false
         end
       end
 
@@ -278,13 +278,13 @@ module Workflows
           context 'within escalation deadline' do
             it 'returns false' do
               allow(kase).to receive(:escalation_deadline).and_return(2.days.from_now)
-              expect(predicate.case_respondable?).to be false
+              expect(predicate.assigned_team_member_and_case_outside_escalation_period?).to be false
             end
           end
           context 'outside escalation deadline' do
             it 'returns true' do
               allow(kase).to receive(:escalation_deadline).and_return(2.days.ago)
-              expect(predicate.case_respondable?).to be true
+              expect(predicate.assigned_team_member_and_case_outside_escalation_period?).to be true
             end
           end
         end
@@ -292,7 +292,7 @@ module Workflows
         context 'in different team' do
           let(:user)      { @another_responder }
           it 'returns false' do
-            expect(predicate.case_respondable?).to be false
+            expect(predicate.assigned_team_member_and_case_outside_escalation_period?).to be false
           end
         end
       end


### PR DESCRIPTION
REsponders should not be permitted to upload a response until 3
days (the escalation perios) has elapsed to give approvers enough
time to view the dase and take it on if they deem necessary.

There was a bug which allowed them to upload the response during
that escalation period.  This PR fixes that bug.