### PR TITLE
CT-1883 Change case status name to include the word 'closed'

### DIFF
--- a/config/locales/state.en.yml
+++ b/config/locales/state.en.yml
@@ -13,5 +13,5 @@ en:
     closed_status: Case closed
     case/ico:
       awaiting_dispatch: Ready to send to ICO
-      responded: Awaiting ICO decision
+      responded: Closed - awaiting ICO decision
 

--- a/spec/decorators/case/base_decorator_spec.rb
+++ b/spec/decorators/case/base_decorator_spec.rb
@@ -332,7 +332,7 @@ describe Case::BaseDecorator, type: :model do
     end
 
     it 'returns a responded status for ico' do
-      expect(responded_ico.status).to eq 'Awaiting ICO decision'
+      expect(responded_ico.status).to eq 'Closed - awaiting ICO decision'
     end
 
     context 'closed ico - ICO decisions' do

--- a/spec/features/user_journeys/ico/trigger_e2e_journey_spec.rb
+++ b/spec/features/user_journeys/ico/trigger_e2e_journey_spec.rb
@@ -64,7 +64,7 @@ feature 'ICO FOI case requiring clearance' do
 
     mark_case_as_sent kase: kase,
                       user: disclosure_specialist,
-                      expected_status: 'Awaiting ICO decision',
+                      expected_status: 'Closed - awaiting ICO decision',
                       expected_to_be_with: 'Disclosure'
 
     close_ico_appeal_case kase: kase,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -317,9 +317,10 @@ RSpec.describe User, type: :model do
     let(:team2)     { create :responding_team }
     let(:team3)     { create :responding_team }
 
-
     it 'prints out the other teams' do
-      expect(user.other_teams_names(team1)).to eq("#{team2.name} and #{team3.name}")
+      team1_other_team_names = user.other_teams_names(team1)
+      expect(team1_other_team_names).to include(team2.name, team3.name)
+      expect(team1_other_team_names).not_to include(team1.name)
     end
   end
 end


### PR DESCRIPTION
### Summary
Alters the Status label shown to the user for better user experience. Now displays 'Closed - awaiting ICO decision'.

### Ticket
https://dsdmoj.atlassian.net/browse/CT-1883

### Screenshots

**Before**
![screen shot 2019-01-29 at 17 20 34](https://user-images.githubusercontent.com/47113046/51926929-5791c080-23ea-11e9-8b82-37d5ae411790.png)


**After**
![screen shot 2019-01-29 at 17 20 22](https://user-images.githubusercontent.com/47113046/51926940-5cef0b00-23ea-11e9-9f49-f689b277fe0b.png)
