### PR TITLE
Ct 2105 edit late responder team

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -263,6 +263,7 @@ class CasesController < ApplicationController
     authorize @case, :update_closure?
     @s3_direct_post = S3Uploader.s3_direct_post_for_case(@case, 'responses')
     @case = @case.decorate
+    @team_collection = CaseTeamCollection.new(@case)
   end
 
   def confirm_destroy

--- a/app/views/cases/foi/_close_form.html.slim
+++ b/app/views/cases/foi/_close_form.html.slim
@@ -9,6 +9,8 @@
             form_hint_text: t('.date_example'),
             today_button: {class: ''} }
 
+  - if @case.responded_late?
+    = render partial: 'cases/shared/team_caused_late_response', locals: {kase: @case, f: f}
 
   - if @case.is_internal_review?
     .appeal-outcome-group

--- a/spec/features/cases/foi/editing_case_closure_spec.rb
+++ b/spec/features/cases/foi/editing_case_closure_spec.rb
@@ -13,6 +13,16 @@ feature 'editing case closure information' do
     CaseClosure::MetadataSeeder.unseed!
   end
 
+  scenario 'editing a late closed case', js: true do
+    kase = create :closed_case, :late
+
+    login_as manager
+    cases_show_page.load(id: kase.id)
+    edit_foi_case_closure_step(kase: kase,
+                               date_responded: 10.business_days.ago,
+                               late_team_id: (kase.transitions.map(&:acting_team_id).uniq - [kase.late_team_id]).first)
+  end
+
   scenario 'bmt changes case from held/granted to other/tmm', js: true do
     kase = create :closed_case
 

--- a/spec/features/cases/foi/editing_case_closure_spec.rb
+++ b/spec/features/cases/foi/editing_case_closure_spec.rb
@@ -18,9 +18,11 @@ feature 'editing case closure information' do
 
     login_as manager
     cases_show_page.load(id: kase.id)
+    # find some (non-current) late team ids so the test can change it to another valid one
+    possible_late_team_ids = kase.transitions.map(&:acting_team_id).uniq - [kase.late_team_id]
     edit_foi_case_closure_step(kase: kase,
                                date_responded: 10.business_days.ago,
-                               late_team_id: (kase.transitions.map(&:acting_team_id).uniq - [kase.late_team_id]).first)
+                               late_team_id: possible_late_team_ids.first)
   end
 
   scenario 'bmt changes case from held/granted to other/tmm', js: true do

--- a/spec/site_prism/page_objects/pages/cases/close_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/close_page.rb
@@ -21,6 +21,9 @@ module PageObjects
         element :date_responded_year_ico, :case_form_element, 'date_ico_decision_received_yyyy'
 
         element :uploaded_request_file_input, '#uploadedRequestFileInput'
+        section :late_team_name, '.late_team_id' do
+
+        end
 
         section :appeal_outcome, '.appeal-outcome-group' do
           element :upheld, 'label[for="case_foi_appeal_outcome_name_upheld"]'
@@ -98,6 +101,10 @@ module PageObjects
           exemption = CaseClosure::Exemption.find_by(abbreviation: abbreviation)
           exemptions.find("input#case_foi_exemption_ids_#{exemption.id}",
                           visible: false)
+        end
+
+        def get_late_team(team_id)
+          find("#case_foi_late_team_id_#{team_id}", visible: false)
         end
 
         def drop_in_dropzone(file_path)

--- a/spec/site_prism/page_objects/pages/cases/close_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/close_page.rb
@@ -21,7 +21,6 @@ module PageObjects
         element :date_responded_year_ico, :case_form_element, 'date_ico_decision_received_yyyy'
 
         element :uploaded_request_file_input, '#uploadedRequestFileInput'
-        element :late_team_name, '.late_team_id'
 
         section :appeal_outcome, '.appeal-outcome-group' do
           element :upheld, 'label[for="case_foi_appeal_outcome_name_upheld"]'

--- a/spec/site_prism/page_objects/pages/cases/close_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/close_page.rb
@@ -21,9 +21,7 @@ module PageObjects
         element :date_responded_year_ico, :case_form_element, 'date_ico_decision_received_yyyy'
 
         element :uploaded_request_file_input, '#uploadedRequestFileInput'
-        section :late_team_name, '.late_team_id' do
-
-        end
+        element :late_team_name, '.late_team_id'
 
         section :appeal_outcome, '.appeal-outcome-group' do
           element :upheld, 'label[for="case_foi_appeal_outcome_name_upheld"]'

--- a/spec/support/features/steps/cases/edit_steps.rb
+++ b/spec/support/features/steps/cases/edit_steps.rb
@@ -45,6 +45,7 @@ def edit_foi_case_closure_step(kase:, # rubocop:disable Metrics/MethodLength, Me
                                info_held_status: 'not_confirmed',
                                refusal_reason: 'tmm',
                                outcome: nil,
+                               late_team_id: nil,
                                exemptions: [],
                                preselected_exemptions: [])
   expect(cases_show_page).to be_displayed(id: kase.id)
@@ -60,6 +61,13 @@ def edit_foi_case_closure_step(kase:, # rubocop:disable Metrics/MethodLength, Me
     .to eq kase.date_responded.month.to_s
   expect(cases_edit_closure_page.date_responded_year.value)
     .to eq kase.date_responded.year.to_s
+  if kase.responded_late?
+    expect(cases_edit_closure_page.get_late_team(kase.late_team_id)).to be_checked
+    expect(kase.late_team_id).not_to eq(late_team_id)
+    if late_team_id
+      cases_edit_closure_page.get_late_team(late_team_id).click
+    end
+  end
   preselected_exemptions.each do |abbreviation|
     expect(cases_close_page.get_exemption(abbreviation: abbreviation)).to be_checked
   end
@@ -107,6 +115,10 @@ def edit_foi_case_closure_step(kase:, # rubocop:disable Metrics/MethodLength, Me
     exemption = CaseClosure::Exemption.find_by(abbreviation: abbreviation)
     expect(cases_show_page.case_details.response_details.exemptions)
       .to have_text exemption.name
+  end
+
+  if late_team_id
+    expect(kase.late_team_id).to eq(late_team_id)
   end
 end
 

--- a/spec/support/features/steps/cases/edit_steps.rb
+++ b/spec/support/features/steps/cases/edit_steps.rb
@@ -40,7 +40,8 @@ def edit_ico_case_step(kase:, **params)
   end
 end
 
-def edit_foi_case_closure_step(kase:, # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+# rubocop:disable Metrics/MethodLength, Metrics/ParameterLists, Metrics/CyclomaticComplexity
+def edit_foi_case_closure_step(kase:,
                                date_responded: Date.today,
                                info_held_status: 'not_confirmed',
                                refusal_reason: 'tmm',
@@ -121,6 +122,7 @@ def edit_foi_case_closure_step(kase:, # rubocop:disable Metrics/MethodLength, Me
     expect(kase.reload.late_team_id).to eq(late_team_id)
   end
 end
+# rubocop:enable Metrics/MethodLength, Metrics/ParameterLists, Metrics/CyclomaticComplexity
 
 def edit_sar_case_closure_step(kase:, date_responded: Date.today, tmm: false) # rubocop:disable Metrics/MethodLength
   expect(cases_show_page).to be_displayed(id: kase.id)

--- a/spec/support/features/steps/cases/edit_steps.rb
+++ b/spec/support/features/steps/cases/edit_steps.rb
@@ -118,7 +118,7 @@ def edit_foi_case_closure_step(kase:, # rubocop:disable Metrics/MethodLength, Me
   end
 
   if late_team_id
-    expect(kase.late_team_id).to eq(late_team_id)
+    expect(kase.reload.late_team_id).to eq(late_team_id)
   end
 end
 

--- a/spec/support/features/steps/cases/edit_steps.rb
+++ b/spec/support/features/steps/cases/edit_steps.rb
@@ -1,3 +1,4 @@
+# TODO - this doesn't run any tests as kase.correspondence_type is not a string
 def edit_case_step(kase:, **args)
   case kase.correspondence_type
   when 'foi' then edit_foi_case_step(kase, args)
@@ -40,8 +41,8 @@ def edit_ico_case_step(kase:, **params)
   end
 end
 
-# rubocop:disable Metrics/MethodLength, Metrics/ParameterLists, Metrics/CyclomaticComplexity
-def edit_foi_case_closure_step(kase:,
+def edit_foi_case_closure_step(kase:, # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists, Metrics/CyclomaticComplexity
+
                                date_responded: Date.today,
                                info_held_status: 'not_confirmed',
                                refusal_reason: 'tmm',
@@ -122,7 +123,6 @@ def edit_foi_case_closure_step(kase:,
     expect(kase.reload.late_team_id).to eq(late_team_id)
   end
 end
-# rubocop:enable Metrics/MethodLength, Metrics/ParameterLists, Metrics/CyclomaticComplexity
 
 def edit_sar_case_closure_step(kase:, date_responded: Date.today, tmm: false) # rubocop:disable Metrics/MethodLength
   expect(cases_show_page).to be_displayed(id: kase.id)


### PR DESCRIPTION
Allow editing of the team responsible for a case lateness when the closing data is being edited.