### PR TITLE
CT-2138 fix places where Timecop.freeze isn't rolled back during tests

### DIFF
--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -231,8 +231,9 @@ RSpec.describe Assignment, type: :model do
         it 'queues the job' do
           t = Time.now
           expect {
-            Timecop.freeze(t)
-            create :assignment, :responding, case_id: kase.id
+            Timecop.freeze(t) do
+              create :assignment, :responding, case_id: kase.id
+            end
           }.to have_enqueued_job(SearchIndexUpdaterJob).at(t + 10.seconds).at_least(1)
         end
       end

--- a/spec/services/case_remove_pit_extension_service_spec.rb
+++ b/spec/services/case_remove_pit_extension_service_spec.rb
@@ -4,6 +4,9 @@ describe CaseRemovePITExtensionService do
   before do
     Timecop.freeze(Time.local(2018, 10, 3))
   end
+  after do
+    Timecop.return
+  end
 
   let(:received_date) { Date.new 2018, 9, 27 }
   let(:team_dacu)     { find_or_create :team_disclosure_bmt }


### PR DESCRIPTION
Running all the tests fails sporadically due to some tests failing to use correct Timecop.freeze patterns - either 
a) using a block or 
b) before { Timecop.freeze(t) } 
     after { Timecop.return }

This PR fixes (I think) all tests that exhibit this behaviour