### PR TITLE
Ct 2131 code coverage optional

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,6 @@
 if ENV['COVERAGE'].present?
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start 'rails'
 end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,7 @@
-require 'simplecov'
-SimpleCov.start
+if ENV['COVERAGE'].present?
+  require 'simplecov'
+  SimpleCov.start
+end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,13 @@
 if ENV['COVERAGE'].present?
   require 'simplecov'
-  SimpleCov.start 'rails'
+  SimpleCov.start 'rails' do
+    add_group "Services", "app/services"
+    add_group "Policies", "app/policies"
+    add_group "Decorators", "app/decorators"
+    add_group "Validators", "app/validators"
+    # application doesn't use action cable
+    add_filter '/app/channels/'
+  end
 end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'


### PR DESCRIPTION
Make code coverage optional (via a COVERAGE variable) as it speeds up local builds. 
Added 'rails' profile to split out models, controllers etc and remove specs from coverage.
Added extra sections to report for validators, services, policies and decorators.