### PR TITLE
CT-2113 humanise outputs for csv

### DIFF
--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -11,14 +11,14 @@ class CSVExporter
       'Responder',
       'Date received',
       'Internal deadline',
-      'External_deadline',
+      'External deadline',
       'Date responded',
       'Date compliant draft uploaded',
-      'Workflow',
+      'Trigger',
       'Name',
       'Requester type',
       'Message',
-      'Info_held',
+      'Info held',
       'Outcome',
       'Refusal reason',
       'Exemptions',
@@ -41,34 +41,32 @@ class CSVExporter
   def to_csv #rubocop:disable Metrics/MethodLength,Metrics/CyclomaticComplexity
     begin
       [
-          @kase.number,
-          @kase.decorate.pretty_type,
-          @kase.current_state,
-          @kase.responding_team&.name,
-          @kase.responder&.full_name,
-          @kase.received_date&.to_s,
-          @kase.internal_deadline&.to_s,
-          @kase.external_deadline&.to_s,
-          @kase.date_responded&.to_s,
-          @kase.date_draft_compliant&.to_s,
-          @kase.workflow,
-          @kase.name,
-          @kase.requester_type,
-          dequote_and_truncate(@kase.message),
-          @kase.info_held_status&.name,
-          @kase.outcome&.name,
-          @kase.refusal_reason&.name,
-          @kase.exemptions.map{ |x| CaseClosure::Exemption.section_number_from_id(x.abbreviation) }.join(','),
-          @kase.postal_address,
-          @kase.email,
-          @kase.appeal_outcome&.name,
-          @kase.respond_to?(:third_party) ? @kase.third_party : nil,
-          @kase.respond_to?(:reply_method) ? @kase.reply_method : nil,
-          @kase.respond_to?(:subject_type) ? @kase.subject_type : nil,
-          @kase.respond_to?(:subject_full_name) ? @kase.subject_full_name : nil,
-          @kase.decorate.late_team_name,
-          kase_extended?(@kase) ? 'Yes' : 'No',
-          extension_count(@kase),
+        @kase.number,
+        @kase.decorate.pretty_type,
+        I18n.t("state.#{@kase.current_state}").downcase,
+        @kase.responding_team&.name,
+        @kase.responder&.full_name,
+        @kase.received_date&.to_s,
+        @kase.flagged? ? @kase.internal_deadline&.to_s : nil,
+        @kase.external_deadline&.to_s,
+        @kase.date_responded&.to_s,
+        @kase.date_draft_compliant&.to_s,
+        @kase.flagged? ? 'Yes' : nil,
+        @kase.name,
+        @kase.sar? ? nil : @kase.requester_type.humanize,
+        dequote_and_truncate(@kase.message),
+        @kase.info_held_status&.name,
+        @kase.outcome&.name,
+        @kase.refusal_reason&.name,
+        @kase.exemptions.map{ |x| CaseClosure::Exemption.section_number_from_id(x.abbreviation) }.join(','),
+        @kase.postal_address,
+        @kase.email,
+        @kase.appeal_outcome&.name,
+        @kase.respond_to?(:third_party) ? humanize_boolean(@kase.third_party) : nil,
+        @kase.respond_to?(:reply_method) ? @kase.reply_method.humanize : nil,
+        @kase.respond_to?(:subject_type) ? @kase.subject_type.humanize : nil,
+        @kase.respond_to?(:subject_full_name) ? @kase.subject_full_name : nil,
+        @kase.decorate.late_team_name
       ]
     rescue => err
       raise CSVExporterError.new("Error encountered formatting case id #{@kase.id} as CSV:\nOriginal error: #{err.class} #{err.message}")
@@ -104,5 +102,9 @@ class CSVExporter
 
   def dequote_and_truncate(text)
     text.tr('"', '').tr("'", '')[0..4000]
+  end
+
+  def humanize_boolean(boolean)
+    boolean ? 'Yes' : nil
   end
 end

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -66,7 +66,9 @@ class CSVExporter
         @kase.respond_to?(:reply_method) ? @kase.reply_method.humanize : nil,
         @kase.respond_to?(:subject_type) ? @kase.subject_type.humanize : nil,
         @kase.respond_to?(:subject_full_name) ? @kase.subject_full_name : nil,
-        @kase.decorate.late_team_name
+        @kase.decorate.late_team_name,
+        kase_extended?(@kase) ? 'Yes' : 'No',
+        extension_count(@kase)
       ]
     rescue => err
       raise CSVExporterError.new("Error encountered formatting case id #{@kase.id} as CSV:\nOriginal error: #{err.class} #{err.message}")

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe CSVExporter do
 
+<<<<<<< HEAD
   let(:late_team) { create :responding_team, name: 'Transport for London' }
   let(:late_foi_case) { create :closed_case, :fully_refused_exempt_s40,
                           :late,
@@ -25,6 +26,20 @@ describe CSVExporter do
                                    email: 'dave@moj.com',
                                    message: 'foi message',
                                    postal_address: nil }
+=======
+  let(:foi_case)          { create :closed_case, :fully_refused_exempt_s40,
+                                   name: 'FOI Case name',
+                                   email: 'dave@moj.com',
+                                   message: 'foi message',
+                                   postal_address: nil }
+  let(:sar_case)          { create :closed_sar,
+                                   name: 'SAR case name',
+                                   postal_address: "2 High Street\nAnytown\nAY2 4FF",
+                                   subject: 'Full details required',
+                                   email: 'theresa@moj.com',
+                                   message: 'my SAR message',
+                                   subject_full_name: 'Theresa Cant' }
+>>>>>>> CT-2113 humanise outputs for csv
 
   context 'late FOI' do
     it 'returns an array of fields' do
@@ -37,14 +52,22 @@ describe CSVExporter do
                              'closed',
                              'FOI Responding Team',
                              'foi responding user',
+<<<<<<< HEAD
                              '2018-08-17',
                              '2018-09-03',
                              '2018-09-17',
                              '2018-09-28',
                              '2018-09-28',
                              'standard',
+=======
+                             '2018-08-30',
+                             nil,
+                             '2018-09-27',
+                             '2018-09-25',
+                             nil,
+>>>>>>> CT-2113 humanise outputs for csv
                              'FOI Case name',
-                             'member_of_the_public',
+                             'Member of the public',
                              'foi message',
                              'Yes',
                              'Refused fully',
@@ -106,11 +129,12 @@ describe CSVExporter do
                               'SAR Responding Team',
                               'sar responding user',
                               '2018-08-30',
-                              '2018-09-09',
+                              nil,
                               '2018-09-29',
                               '2018-09-25',
                               nil,
                               'standard',
+                              nil,
                               'SAR case name',
                               nil,
                               'my SAR message',
@@ -121,6 +145,7 @@ describe CSVExporter do
                               "2 High Street\nAnytown\nAY2 4FF",
                               'theresa@moj.com',
                               nil,
+<<<<<<< HEAD
                               false,
                               'send_by_email',
                               'offender',
@@ -128,6 +153,13 @@ describe CSVExporter do
                               'N/A',
                               'No',
                               0
+                              'N/A'
+=======
+                              nil,
+                              'Send by email',
+                              'Offender',
+                              'Theresa Cant'
+>>>>>>> CT-2113 humanise outputs for csv
                           ]
       end
     end

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 describe CSVExporter do
-
-<<<<<<< HEAD
   let(:late_team) { create :responding_team, name: 'Transport for London' }
   let(:late_foi_case) { create :closed_case, :fully_refused_exempt_s40,
                           :late,
+                          :flagged,
                           name: 'FOI Case name',
                           email: 'dave@moj.com',
                           message: 'foi message',
@@ -26,20 +25,6 @@ describe CSVExporter do
                                    email: 'dave@moj.com',
                                    message: 'foi message',
                                    postal_address: nil }
-=======
-  let(:foi_case)          { create :closed_case, :fully_refused_exempt_s40,
-                                   name: 'FOI Case name',
-                                   email: 'dave@moj.com',
-                                   message: 'foi message',
-                                   postal_address: nil }
-  let(:sar_case)          { create :closed_sar,
-                                   name: 'SAR case name',
-                                   postal_address: "2 High Street\nAnytown\nAY2 4FF",
-                                   subject: 'Full details required',
-                                   email: 'theresa@moj.com',
-                                   message: 'my SAR message',
-                                   subject_full_name: 'Theresa Cant' }
->>>>>>> CT-2113 humanise outputs for csv
 
   context 'late FOI' do
     it 'returns an array of fields' do
@@ -52,20 +37,16 @@ describe CSVExporter do
                              'closed',
                              'FOI Responding Team',
                              'foi responding user',
-<<<<<<< HEAD
                              '2018-08-17',
                              '2018-09-03',
                              '2018-09-17',
                              '2018-09-28',
-                             '2018-09-28',
                              'standard',
-=======
                              '2018-08-30',
                              nil,
                              '2018-09-27',
                              '2018-09-25',
                              nil,
->>>>>>> CT-2113 humanise outputs for csv
                              'FOI Case name',
                              'Member of the public',
                              'foi message',
@@ -80,10 +61,8 @@ describe CSVExporter do
                              nil,
                              nil,
                              nil,
-                             late_team.name,
-                             'No',
-                             0
-                          ]
+                             late_team.name
+                         ]
       end
     end
   end
@@ -133,8 +112,6 @@ describe CSVExporter do
                               '2018-09-29',
                               '2018-09-25',
                               nil,
-                              'standard',
-                              nil,
                               'SAR case name',
                               nil,
                               'my SAR message',
@@ -145,21 +122,11 @@ describe CSVExporter do
                               "2 High Street\nAnytown\nAY2 4FF",
                               'theresa@moj.com',
                               nil,
-<<<<<<< HEAD
                               false,
                               'send_by_email',
                               'offender',
                               'Theresa Cant',
-                              'N/A',
-                              'No',
-                              0
                               'N/A'
-=======
-                              nil,
-                              'Send by email',
-                              'Offender',
-                              'Theresa Cant'
->>>>>>> CT-2113 humanise outputs for csv
                           ]
       end
     end

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -122,12 +122,11 @@ describe CSVExporter do
                               "2 High Street\nAnytown\nAY2 4FF",
                               'theresa@moj.com',
                               nil,
-                              false,
-                              'send_by_email',
-                              'offender',
-                              'Theresa Cant',
-                              'N/A'
-                          ]
+                              nil,
+                              'Send by email',
+                              'Offender',
+                              'Theresa Cant'
+        ]
       end
     end
   end

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -125,7 +125,10 @@ describe CSVExporter do
                               nil,
                               'Send by email',
                               'Offender',
-                              'Theresa Cant'
+                              'Theresa Cant',
+                              'No',
+                              0,
+                              'N/A'
         ]
       end
     end

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -41,12 +41,8 @@ describe CSVExporter do
                              '2018-09-03',
                              '2018-09-17',
                              '2018-09-28',
-                             'standard',
-                             '2018-08-30',
-                             nil,
-                             '2018-09-27',
-                             '2018-09-25',
-                             nil,
+                             '2018-09-28',
+                             'Yes',
                              'FOI Case name',
                              'Member of the public',
                              'foi message',
@@ -61,7 +57,9 @@ describe CSVExporter do
                              nil,
                              nil,
                              nil,
-                             late_team.name
+                             late_team.name,
+                             'No',
+                             0
                          ]
       end
     end
@@ -112,6 +110,7 @@ describe CSVExporter do
                               '2018-09-29',
                               '2018-09-25',
                               nil,
+                              nil,
                               'SAR case name',
                               nil,
                               'my SAR message',
@@ -126,9 +125,9 @@ describe CSVExporter do
                               'Send by email',
                               'Offender',
                               'Theresa Cant',
+                              'N/A',
                               'No',
                               0,
-                              'N/A'
         ]
       end
     end

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -80,7 +80,6 @@ describe CSVExporter do
                           message: 'foi message',
                           postal_address: nil }
       it 'marks case as having an extended count of 1' do
-        # noinspection RubyResolve
         expect(csv_data).to include(
                               { 'Extended' => 'Yes',
                                 'Extension Count' => 1
@@ -94,7 +93,6 @@ describe CSVExporter do
                           subject_full_name: 'Theresa Cant' }
 
       it 'marks an extended SAR having an extended count of 1' do
-        # noinspection RubyResolve
         expect(csv_data).to include({
                                       'Extended' => 'Yes',
                                       'Extension Count' => 1

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -31,36 +31,37 @@ describe CSVExporter do
       Timecop.freeze Time.local(2018, 10, 1, 13, 21, 33) do
         csv = CSVExporter.new(late_foi_case).to_csv
         expect(csv.size).to eq(CSVExporter::CSV_COLUMN_HEADINGS.size)
-        expect(csv).to eq [
-                             '180817001',
-                             'FOI',
-                             'closed',
-                             'FOI Responding Team',
-                             'foi responding user',
-                             '2018-08-17',
-                             '2018-09-03',
-                             '2018-09-17',
-                             '2018-09-28',
-                             '2018-09-28',
-                             'Yes',
-                             'FOI Case name',
-                             'Member of the public',
-                             'foi message',
-                             'Yes',
-                             'Refused fully',
-                             nil,
-                             's40',
-                             nil,
-                             'dave@moj.com',
-                             nil,
-                             nil,
-                             nil,
-                             nil,
-                             nil,
-                             late_team.name,
-                             'No',
-                             0
-                         ]
+        expect(CSVExporter::CSV_COLUMN_HEADINGS.zip(csv).to_h)
+          .to eq({
+                   'Number' => '180817001',
+                   'Case type' => 'FOI',
+                   'Current state' => 'closed',
+                   'Responding team' => 'FOI Responding Team',
+                   'Responder' => 'foi responding user',
+                   'Date received' => '2018-08-17',
+                   'Internal deadline' => '2018-09-03',
+                   'External deadline' => '2018-09-17',
+                   'Date responded' => '2018-09-28',
+                   'Date compliant draft uploaded' => '2018-09-28',
+                   'Trigger' => 'Yes',
+                   'Name' => 'FOI Case name',
+                   'Requester type' => 'Member of the public',
+                   'Message' => 'foi message',
+                   'Info held' => 'Yes',
+                   'Outcome' => 'Refused fully',
+                   'Refusal reason' => nil,
+                   'Exemptions' => 's40',
+                   'Postal address' => nil,
+                   'Email' => 'dave@moj.com',
+                   'Appeal outcome' => nil,
+                   'Third party' => nil,
+                   'Reply method' => nil,
+                   'SAR Subject type' => nil,
+                   'SAR Subject full name' => nil,
+                   'Business unit responsible for late response' => late_team.name,
+                   'Extended' => 'No',
+                   'Extension Count' => 0
+                 })
       end
     end
   end
@@ -68,7 +69,7 @@ describe CSVExporter do
   context 'extended' do
     let(:csv_data) do
       Timecop.freeze Time.local(2018, 10, 1, 13, 21, 33) do
-        CSVExporter.new(kase).to_csv[26..27]
+        CSVExporter::CSV_COLUMN_HEADINGS.zip(CSVExporter.new(kase).to_csv).to_h
       end
     end
 
@@ -79,7 +80,11 @@ describe CSVExporter do
                           message: 'foi message',
                           postal_address: nil }
       it 'marks case as having an extended count of 1' do
-        expect(csv_data).to eq ['Yes', 1]
+        # noinspection RubyResolve
+        expect(csv_data).to include(
+                              { 'Extended' => 'Yes',
+                                'Extension Count' => 1
+                              })
       end
     end
 
@@ -89,7 +94,11 @@ describe CSVExporter do
                           subject_full_name: 'Theresa Cant' }
 
       it 'marks an extended SAR having an extended count of 1' do
-        expect(csv_data).to eq ['Yes', 1]
+        # noinspection RubyResolve
+        expect(csv_data).to include({
+                                      'Extended' => 'Yes',
+                                      'Extension Count' => 1
+                                    })
       end
     end
   end
@@ -99,36 +108,37 @@ describe CSVExporter do
       Timecop.freeze Time.local(2018, 10, 1, 13, 21, 33) do
         csv = CSVExporter.new(sar_case).to_csv
         expect(csv.size).to eq(CSVExporter::CSV_COLUMN_HEADINGS.size)
-        expect(csv).to eq [
-                              '180830001',
-                              'SAR',
-                              'closed',
-                              'SAR Responding Team',
-                              'sar responding user',
-                              '2018-08-30',
-                              nil,
-                              '2018-09-29',
-                              '2018-09-25',
-                              nil,
-                              nil,
-                              'SAR case name',
-                              nil,
-                              'my SAR message',
-                              nil,
-                              nil,
-                              nil,
-                              '',
-                              "2 High Street\nAnytown\nAY2 4FF",
-                              'theresa@moj.com',
-                              nil,
-                              nil,
-                              'Send by email',
-                              'Offender',
-                              'Theresa Cant',
-                              'N/A',
-                              'No',
-                              0,
-        ]
+        expect(CSVExporter::CSV_COLUMN_HEADINGS.zip(csv).to_h)
+          .to eq({
+                   'Number' => '180830001',
+                   'Case type' => 'SAR',
+                   'Current state' => 'closed',
+                   'Responding team' => 'SAR Responding Team',
+                   'Responder' => 'sar responding user',
+                   'Date received' => '2018-08-30',
+                   'Internal deadline' => nil,
+                   'External deadline' => '2018-09-29',
+                   'Date responded' => '2018-09-25',
+                   'Date compliant draft uploaded' => nil,
+                   'Trigger' => nil,
+                   'Name' => 'SAR case name',
+                   'Requester type' => nil,
+                   'Message' => 'my SAR message',
+                   'Info held' => nil,
+                   'Outcome' => nil,
+                   'Refusal reason' => nil,
+                   'Exemptions' => '',
+                   'Postal address' => "2 High Street\nAnytown\nAY2 4FF",
+                   'Email' => 'theresa@moj.com',
+                   'Appeal outcome' => nil,
+                   'Third party' => nil,
+                   'Reply method' => 'Send by email',
+                   'SAR Subject type' => 'Offender',
+                   'SAR Subject full name' => 'Theresa Cant',
+                   'Business unit responsible for late response' => 'N/A',
+                   'Extended' => 'No',
+                   'Extension Count' => 0})
+
       end
     end
   end


### PR DESCRIPTION
Remove draft deadline for non-trigger cases - A draft deadline is showing for non-trigger cases, this should be blank.

Improve 'Request status' column - Values in this column should match the text in the service e.g. 'Needs reassigning', 'To be accepted' etc.

Improve 'Workflow' column - This column should be called 'Trigger' and should have the value 'Yes' if true

References to DACU should be removed - Instances of DACU should be replaced with "Disclosure Team"

Improve 'Third party' column - Should have the value 'Yes' if true

Improve 'Requester type' column - Replace '_' with spaces, e.g. 'member_of_the_public' → member of the public

Make column headings consistent - 'Info_held' → 'Info held' and 'External_deadline' → 'External deadline'

humanise reply method