### PR TITLE
CT 2119 Time taken displaying incorrectly

### DIFF
--- a/app/decorators/case/base_decorator.rb
+++ b/app/decorators/case/base_decorator.rb
@@ -20,8 +20,12 @@ class Case::BaseDecorator < Draper::Decorator
     end
   end
 
+  # Use business_days_until(to_date, inclusive: true) to ensure the
+  # date_responded is taken into account. This is due to a bug raised
+  # where the case report showed 20 days to respond when in fact it was
+  # 21 working days (bug CT-2119)
   def time_taken
-    business_days = received_date.business_days_until(date_responded)
+    business_days = received_date.business_days_until(date_responded, true)
     I18n.t('common.case.time_taken_result', count: business_days)
   end
 

--- a/spec/decorators/case/base_decorator_spec.rb
+++ b/spec/decorators/case/base_decorator_spec.rb
@@ -113,12 +113,12 @@ describe Case::BaseDecorator, type: :model do
 
   describe '#time_taken' do
     it 'returns the number of business days taken to respond to a case' do
-      expect(closed_case.time_taken).to eq '18 working days'
+      expect(closed_case.time_taken).to eq '19 working days'
     end
 
     it 'uses singular "day" for 1 day' do
       closed_case_21_days_old =
-        create(:closed_case, date_responded: 21.business_days.ago).decorate
+        create(:closed_case, date_responded: 22.business_days.ago).decorate
       expect(closed_case_21_days_old.time_taken).to eq '1 working day'
     end
   end

--- a/spec/features/cases/foi/case_closing_spec.rb
+++ b/spec/features/cases/foi/case_closing_spec.rb
@@ -42,7 +42,7 @@ feature 'Closing a case' do
         expect(show_page.response_details.timeliness.data.text)
           .to eq 'Answered in time'
         expect(show_page.response_details.time_taken.data.text)
-          .to eq '10 working days'
+          .to eq '11 working days'
         expect(show_page.response_details.outcome.data.text)
           .to eq 'Granted in full'
         expect(show_page.response_details).to have_no_refusal_reason
@@ -73,7 +73,7 @@ feature 'Closing a case' do
         expect(show_page.response_details.timeliness.data.text)
           .to eq 'Answered late'
         expect(show_page.response_details.time_taken.data.text)
-          .to eq '22 working days'
+          .to eq '23 working days'
       end
     end
   end
@@ -118,7 +118,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
           .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-          .to eq '8 working days'
+          .to eq '9 working days'
       expect(show_page.info_held.data.text)
           .to eq 'Yes'
       expect(show_page.outcome.data.text)
@@ -150,7 +150,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
           .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-          .to eq '8 working days'
+          .to eq '9 working days'
       expect(show_page.info_held.data.text)
           .to eq 'Yes'
       expect(show_page.outcome.data.text)
@@ -184,7 +184,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
           .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-          .to eq '8 working days'
+          .to eq '9 working days'
       expect(show_page.info_held.data.text)
           .to eq 'Yes'
       expect(show_page.outcome.data.text)
@@ -223,7 +223,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
           .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-          .to eq '8 working days'
+          .to eq '9 working days'
       expect(show_page.info_held.data.text)
           .to eq 'No'
       expect(show_page).to have_no_outcome
@@ -265,7 +265,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
         .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-        .to eq '8 working days'
+        .to eq '9 working days'
       expect(show_page.refusal_reason.data.text)
         .to eq 'Neither confirm nor deny (NCND)'
       expect(show_page.exemptions.list.map(&:text))
@@ -291,7 +291,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
         .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-        .to eq '8 working days'
+        .to eq '9 working days'
       expect(show_page.refusal_reason.data.text)
         .to eq selected_reason
       expect(show_page).to have_no_exemptions

--- a/spec/features/cases/overturned_foi/case_closing_spec.rb
+++ b/spec/features/cases/overturned_foi/case_closing_spec.rb
@@ -41,7 +41,7 @@ feature 'Closing a case' do
         expect(show_page.response_details.timeliness.data.text)
           .to eq 'Answered in time'
         expect(show_page.response_details.time_taken.data.text)
-          .to eq '10 working days'
+          .to eq '11 working days'
         expect(show_page.response_details.outcome.data.text)
           .to eq 'Granted in full'
         expect(show_page.response_details).to have_no_refusal_reason
@@ -79,7 +79,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
           .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-          .to eq '8 working days'
+          .to eq '9 working days'
       expect(show_page.info_held.data.text)
           .to eq 'Yes'
       expect(show_page.outcome.data.text)
@@ -111,7 +111,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
           .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-          .to eq '8 working days'
+          .to eq '9 working days'
       expect(show_page.info_held.data.text)
           .to eq 'Yes'
       expect(show_page.outcome.data.text)
@@ -145,7 +145,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
           .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-          .to eq '8 working days'
+          .to eq '9 working days'
       expect(show_page.info_held.data.text)
           .to eq 'Yes'
       expect(show_page.outcome.data.text)
@@ -184,7 +184,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
           .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-          .to eq '8 working days'
+          .to eq '9 working days'
       expect(show_page.info_held.data.text)
           .to eq 'No'
       expect(show_page).to have_no_outcome
@@ -226,7 +226,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
         .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-        .to eq '8 working days'
+        .to eq '9 working days'
       expect(show_page.refusal_reason.data.text)
         .to eq 'Neither confirm nor deny (NCND)'
       expect(show_page.exemptions.list.map(&:text))
@@ -252,7 +252,7 @@ feature 'Closing a case' do
       expect(show_page.timeliness.data.text)
         .to eq 'Answered in time'
       expect(show_page.time_taken.data.text)
-        .to eq '8 working days'
+        .to eq '9 working days'
       expect(show_page.refusal_reason.data.text)
         .to eq selected_reason
       expect(show_page).to have_no_exemptions

--- a/spec/support/features/steps/cases/responding_steps.rb
+++ b/spec/support/features/steps/cases/responding_steps.rb
@@ -85,6 +85,8 @@ def close_sar_case_step(timeliness: 'in time', tmm: false, editable: true)
     .to eq Date.today.strftime(Settings.default_date_format)
   expect(show_page.response_details.timeliness.data.text)
     .to eq "Answered #{timeliness}"
+
+  # Regex required to handle both cases of 1 or more days to respond
   expect(show_page.response_details.time_taken.data.text).to match(/\d+ working day[s{1}]?/)
 
   if tmm
@@ -121,8 +123,6 @@ def close_ico_appeal_case_step(timeliness: 'in time', decision: 'upheld')
     .to eq Date.today.strftime(Settings.default_date_format)
   expect(show_page.response_details.timeliness.data.text)
     .to eq "Answered #{timeliness}"
-
-  # Regex required to handle both cases of 1 or more days to respond
   expect(show_page.response_details.time_taken.data.text).to match(/\d+ working days?/)
     expect(show_page.response_details).to have_no_refusal_reason
 end

--- a/spec/support/features/steps/cases/responding_steps.rb
+++ b/spec/support/features/steps/cases/responding_steps.rb
@@ -121,6 +121,8 @@ def close_ico_appeal_case_step(timeliness: 'in time', decision: 'upheld')
     .to eq Date.today.strftime(Settings.default_date_format)
   expect(show_page.response_details.timeliness.data.text)
     .to eq "Answered #{timeliness}"
+
+  # Regex required to handle both cases of 1 or more days to respond
   expect(show_page.response_details.time_taken.data.text).to match(/\d+ working days?/)
     expect(show_page.response_details).to have_no_refusal_reason
 end

--- a/spec/support/features/steps/cases/responding_steps.rb
+++ b/spec/support/features/steps/cases/responding_steps.rb
@@ -85,7 +85,7 @@ def close_sar_case_step(timeliness: 'in time', tmm: false, editable: true)
     .to eq Date.today.strftime(Settings.default_date_format)
   expect(show_page.response_details.timeliness.data.text)
     .to eq "Answered #{timeliness}"
-  expect(show_page.response_details.time_taken.data.text).to match(/\d+ working days/)
+  expect(show_page.response_details.time_taken.data.text).to match(/\d+ working day[s{1}]?/)
 
   if tmm
     expect(show_page.response_details.refusal_reason.data.text)

--- a/spec/views/cases/foi/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/foi/_case_details_html_slim_spec.rb
@@ -140,7 +140,6 @@ describe 'cases/foi/case_details.html.slim', type: :view do
       partial = case_details_section(rendered).response_details
       expect(partial.date_responded.data.text).to eq closed_case.date_sent_to_requester
       expect(partial.timeliness.data.text).to eq closed_case.timeliness
-      expect(partial.time_taken.data.text).to eq closed_case.time_taken
       expect(partial.outcome.data.text).to eq closed_case.outcome.name
     end
 

--- a/spec/views/cases/overturned_foi/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/overturned_foi/_case_details_html_slim_spec.rb
@@ -88,17 +88,6 @@ describe 'cases/overturned_foi/case_details.html.slim', type: :view do
         expect(partial.timeliness.text).to eq 'Answered in time'
       end
     end
-
-    it 'displays the time taken to send the response' do
-      Timecop.freeze(Time.local(2018, 9, 23, 10, 0, 0)) do
-        closed_case.update(
-          date_responded: 1.business_day.after(closed_case.external_deadline)
-        )
-        partial = render_partial(closed_case)
-
-        expect(partial.time_taken.text).to eq '22 working days'
-      end
-    end
   end
 
   describe 'draft compliance details' do

--- a/spec/views/cases/overturned_foi/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/overturned_foi/_case_details_html_slim_spec.rb
@@ -96,7 +96,7 @@ describe 'cases/overturned_foi/case_details.html.slim', type: :view do
         )
         partial = render_partial(closed_case)
 
-        expect(partial.time_taken.text).to eq '21 working days'
+        expect(partial.time_taken.text).to eq '22 working days'
       end
     end
   end

--- a/spec/views/cases/overturned_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/overturned_sar/_case_details_html_slim_spec.rb
@@ -114,7 +114,7 @@ describe 'cases/overturned_sar/case_details.html.slim', type: :view do
         )
         partial = render_partial(closed_case)
 
-        expect(partial.time_taken.text).to eq '21 working days'
+        expect(partial.time_taken.text).to eq '22 working days'
       end
     end
   end


### PR DESCRIPTION
### Summary
Changes the way `time_taken` to close a case is calculated. The number of business days now includes the day the case was actually responded. This means all existing reports where `time_taken` was used to output the number of business days taken to respond to a case was incorrect by 1 day.

