### PR TITLE
Ct 2006 ico create display all errors

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -203,7 +203,7 @@ class CasesController < ApplicationController
         render :new
       end
     rescue ActiveRecord::RecordNotUnique
-      flash[:notice] = t('activerecord.errors.models.case.attributes.number.duplication')
+      flash.now[:notice] = t('activerecord.errors.models.case.attributes.number.duplication')
       render :new
     end
   end

--- a/app/services/case_create_service.rb
+++ b/app/services/case_create_service.rb
@@ -93,19 +93,14 @@ class CaseCreateService
   end
 
   def determine_case_class
-
     case_class_service = GetCaseClassFromParamsService.new(
         type: @correspondence_type,
         params: @params["case_#{@correspondence_type_key}"]
       )
     case_class_service.call
 
-    # TODO - no point setting the error on a case that we're just about to overwrite
-    if case_class_service.error?
-      @result = :error
-      case_class_service.case_class
-    else
-      case_class_service.case_class
-    end
+    @result = :error if case_class_service.error?
+
+    case_class_service.case_class
   end
 end

--- a/app/services/get_case_class_from_params_service.rb
+++ b/app/services/get_case_class_from_params_service.rb
@@ -2,14 +2,13 @@ class GetCaseClassFromParamsService
   attr_accessor :case_class
 
   def initialize(type:, params:)
-    @type = type
-    @type_key = @type.abbreviation.downcase
+    @type_key = type.abbreviation.downcase
     @params = params
     @error_field = nil
     @error_message = nil
   end
 
-  def call()
+  def call
     @case_class = case @type_key
                   when 'foi' then get_foi_case_class_from_params
                   when 'ico' then get_ico_case_class_from_params
@@ -43,13 +42,13 @@ class GetCaseClassFromParamsService
     if @params[:type].blank?
       @error_field = :type
       @error_message = :blank
-      nil
+      Case::FOI::Standard
     elsif @params[:type].in? %w{ Standard TimelinessReview ComplianceReview }
-      "Case::FOI::#{@params.fetch(:type)}".safe_constantize
+      "Case::FOI::#{@params.fetch(:type)}".constantize
     else
       @error_field = :type
       @error_message = :invalid
-      nil
+      Case::FOI::Standard
     end
   end
 
@@ -57,7 +56,7 @@ class GetCaseClassFromParamsService
     if !@params.key?(:original_case_id)
       @error_field = :original_case_id
       @error_message = :blank
-      nil
+      Case::ICO::FOI
     else
       original_case_id = @params.fetch(:original_case_id)
       original_case = Case::Base.find(original_case_id)
@@ -67,11 +66,12 @@ class GetCaseClassFromParamsService
         else
           @error_field = :original_case_number
           @error_message = :invalid
+          Case::ICO::FOI
       end
     end
   end
 
-  def get_sar_case_class_from_params()
+  def get_sar_case_class_from_params
     Case::SAR
   end
 

--- a/spec/features/cases/ico/case_creating/invalid_params_spec.rb
+++ b/spec/features/cases/ico/case_creating/invalid_params_spec.rb
@@ -27,4 +27,12 @@ feature 'creating ICO with invalid params' do
     expect(cases_new_ico_page.errors.details.first)
       .to have_content('Draft deadline cannot be after final deadline')
   end
+
+  scenario 'creating case with no data entry', js: true do
+    cases_new_ico_page.load
+
+    click_button 'Create case'
+    # TODO - this behaviour is ingrained due to the design. No easy fix
+    expect(cases_new_ico_page.errors.details.count).to eq 1
+  end
 end

--- a/spec/features/cases/ico/case_creating/invalid_params_spec.rb
+++ b/spec/features/cases/ico/case_creating/invalid_params_spec.rb
@@ -32,7 +32,7 @@ feature 'creating ICO with invalid params' do
     cases_new_ico_page.load
 
     click_button 'Create case'
-    # TODO - this behaviour is ingrained due to the design. No easy fix
-    expect(cases_new_ico_page.errors.details.count).to eq 1
+
+    expect(cases_new_ico_page.errors.details.count).to eq 7
   end
 end

--- a/spec/services/get_case_class_from_params_service_spec.rb
+++ b/spec/services/get_case_class_from_params_service_spec.rb
@@ -46,7 +46,7 @@ describe GetCaseClassFromParamsService do
 
       get_case_class_service.call
       expect(get_case_class_service.error?).to be_truthy
-      expect(get_case_class_service.case_class).to eq nil
+      expect(get_case_class_service.case_class).to eq Case::FOI::Standard
     end
   end
 


### PR DESCRIPTION
Refactor case_create_service slightly to make more progress when an error is encountered. 
As a result it now calls new() on the case even when the original case number isn't filled in - that way this also fixes CT-2005 (wiping data from the screen) as invoking the model validations both creates errors and populates the model data for re-display. 