### PR TITLE
Ct 2140 reduce csv resource usage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ group :development, :test do
   gem 'annotate'
   gem 'better_errors'
   gem 'binding_of_caller'
+  # Used to try and track down N+1 query problems
+  gem 'bullet'
   gem 'byebug', platform: :mri
   gem 'chromedriver-helper'
   gem 'colorize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
     browser_sync_rails (0.1.1)
       rails
     builder (3.2.3)
+    bullet (5.9.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     business_time (0.9.3)
       activesupport (>= 3.2.0)
       tzinfo
@@ -551,6 +554,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (1.4.1)
+    uniform_notifier (1.12.1)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.7.0)
@@ -579,6 +583,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   browser_sync_rails
+  bullet
   business_time
   byebug
   capybara

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,10 @@ class ApplicationController < ActionController::Base
     @user = current_user
   end
 
+  def current_user
+    super
+  end
+
   private
 
   def download_csv_request?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,10 +26,6 @@ class ApplicationController < ActionController::Base
     @user = current_user
   end
 
-  def current_user
-    super
-  end
-
   private
 
   def download_csv_request?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,8 +42,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-
-
   # Don't bother setting the global nav for requests with paths in GLOBAL_NAV_EXCLUSION_PATHS
   def global_nav_required?
     GLOBAL_NAV_EXCLUSION_PATHS.exclude?(request.path)
@@ -62,5 +60,12 @@ class ApplicationController < ActionController::Base
       request,
       Settings.global_navigation,
     )
+  end
+
+  def send_csv_cases(action_string)
+    headers["Content-Type"] = 'text/csv; charset=utf-8'
+    headers["Content-Disposition"] =
+      %(attachment; filename="#{CSVGenerator.filename(action_string)}")
+    self.response_body = CSVGenerator.new(@cases)
   end
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -104,7 +104,7 @@ class CasesController < ApplicationController
     respond_to do |format|
       format.html     { render :closed_cases }
       format.csv do
-        send_csv_cases('closed')
+        send_csv_cases'closed'
       end
     end
   end
@@ -132,7 +132,7 @@ class CasesController < ApplicationController
     respond_to do |format|
       format.html     { render :index }
       format.csv do
-        send_csv_cases('my-open')
+        send_csv_cases'my-open'
       end
     end
   end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -88,9 +88,14 @@ class CasesController < ApplicationController
 
   def closed_cases
     unpaginated_cases =  @global_nav_manager
-                             .current_page_or_tab
-                             .cases
-                             .by_last_transitioned_date
+                           .current_page_or_tab
+                           .cases
+                           .includes(:outcome,
+                                     :info_held_status,
+                                     :assignments,
+                                     :cases_exemptions,
+                                     :exemptions)
+                           .by_last_transitioned_date
     if download_csv_request?
       @cases = unpaginated_cases
     else

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -78,7 +78,6 @@ class CasesController < ApplicationController
 
   def index
     @cases = CaseFinderService.new(current_user)
-               .for_user
                .for_params(request.params)
                .scope
                .page(params[:page])

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -93,14 +93,14 @@ class CasesController < ApplicationController
                              .cases
                              .by_last_transitioned_date
     if download_csv_request?
-      @cases = unpaginated_cases.limit(1000)
+      @cases = unpaginated_cases
     else
       @cases = unpaginated_cases.page(params[:page]).decorate
     end
     respond_to do |format|
       format.html     { render :closed_cases }
       format.csv do
-        send_data CSVGenerator.new(@cases).to_csv, CSVGenerator.options('closed')
+        send_csv_cases('closed')
       end
     end
   end
@@ -128,7 +128,7 @@ class CasesController < ApplicationController
     respond_to do |format|
       format.html     { render :index }
       format.csv do
-        send_data CSVGenerator.new(@cases).to_csv, CSVGenerator.options('my-open')
+        send_csv_cases('my-open')
       end
     end
   end
@@ -155,7 +155,7 @@ class CasesController < ApplicationController
     respond_to do |format|
       format.html     { render :index }
       format.csv do
-        send_data CSVGenerator.new(@cases).to_csv, CSVGenerator.options('open')
+        send_csv_cases 'open'
       end
     end
   end
@@ -631,7 +631,7 @@ class CasesController < ApplicationController
     respond_to do |format|
       format.html     { render :search }
       format.csv do
-        send_data CSVGenerator.new(@cases).to_csv, CSVGenerator.options('search')
+        send_csv_cases 'search'
       end
     end
   end
@@ -907,6 +907,13 @@ class CasesController < ApplicationController
   end
 
   private
+
+  def send_csv_cases(action_string)
+    headers["Content-Type"] = CSVGenerator.type
+    headers["Content-Disposition"] =
+      %(attachment; filename="#{CSVGenerator.filename(action_string)}")
+    self.response_body = CSVGenerator.new(@cases)
+  end
 
   def prepare_open_cases_collection(service)
     @parent_id = @query.id

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -908,13 +908,6 @@ class CasesController < ApplicationController
 
   private
 
-  def send_csv_cases(action_string)
-    headers["Content-Type"] = CSVGenerator.type
-    headers["Content-Disposition"] =
-      %(attachment; filename="#{CSVGenerator.filename(action_string)}")
-    self.response_body = CSVGenerator.new(@cases)
-  end
-
   def prepare_open_cases_collection(service)
     @parent_id = @query.id
     @page = params[:page] || '1'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
     respond_to do |format|
       format.html     { render :show }
       format.csv do
-        send_data CSVGenerator.new(@cases).to_csv, CSVGenerator.options("#{@user.full_name.downcase.tr(' ', '_')}")
+        send_csv_cases @user.full_name.downcase.tr(' ', '_')
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,8 @@ class User < ApplicationRecord
 
   has_paper_trail only: [:email, :encrypted_password, :full_name, :deleted_at]
 
+  # Most uses of User are in authentication - so preload team_roles and teams
+  # so that we don't issue lots of DB queries when constantly asking what a user can do.
   default_scope { includes(:team_roles, :teams) }
 
   has_many :cases, through: :assignments

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,8 @@ class User < ApplicationRecord
 
   has_paper_trail only: [:email, :encrypted_password, :full_name, :deleted_at]
 
+  default_scope { includes(:team_roles, :teams) }
+
   has_many :cases, through: :assignments
   has_many :assignments
   has_many :team_roles, class_name: 'TeamsUsersRole'

--- a/app/services/csv_generator.rb
+++ b/app/services/csv_generator.rb
@@ -1,5 +1,6 @@
 require 'csv'
 
+# Lazy generation of CSV data so that we don't fill up memory when downloading
 class CSVGenerator
   include Enumerable
 
@@ -17,17 +18,6 @@ class CSVGenerator
   class << self
     def filename(action_string)
       "#{action_string}-cases-#{Time.now.strftime('%y-%m-%d-%H%M%S')}.csv"
-    end
-
-    def type
-      'text/csv; charset=utf-8'
-    end
-
-    def options(action_string)
-      {
-        filename: self.filename(action_string),
-        type: self.type
-      }
     end
   end
 end

--- a/app/services/csv_generator.rb
+++ b/app/services/csv_generator.rb
@@ -1,23 +1,33 @@
 require 'csv'
 
 class CSVGenerator
+  include Enumerable
 
   def initialize(kases)
     @kases = kases
   end
 
-  def to_csv
-    CSV.generate do |csv|
-      csv << CSVExporter::CSV_COLUMN_HEADINGS
-      @kases.each { |kase| csv << kase.to_csv }
+  def each
+    yield CSV.generate_line CSVExporter::CSV_COLUMN_HEADINGS
+    @kases.each do |kase|
+      yield CSV.generate_line kase.to_csv
     end
   end
 
-  def self.options(action_string)
-    {
-        filename: "#{action_string}-cases-#{Time.now.strftime('%y-%m-%d-%H%M%S')}.csv",
-        type: 'text/csv; charset=utf-8'
-    }
-  end
+  class << self
+    def filename(action_string)
+      "#{action_string}-cases-#{Time.now.strftime('%y-%m-%d-%H%M%S')}.csv"
+    end
 
+    def type
+      'text/csv; charset=utf-8'
+    end
+
+    def options(action_string)
+      {
+        filename: self.filename(action_string),
+        type: self.type
+      }
+    end
+  end
 end

--- a/app/services/global_nav_manager.rb
+++ b/app/services/global_nav_manager.rb
@@ -31,7 +31,7 @@ class GlobalNavManager
   end
 
   def finder
-    CaseFinderService.new(user).for_user.for_params(request.params)
+    CaseFinderService.new(user).for_params(request.params)
   end
 
   private

--- a/app/services/user_active_case_count_service.rb
+++ b/app/services/user_active_case_count_service.rb
@@ -14,14 +14,14 @@ class UserActiveCaseCountService
 
   def active_cases_for_user(user)
     scopes = get_scopes_for_user(user)
-    CaseFinderService.new(user).for_user.for_scopes(scopes).scope
+    CaseFinderService.new(user).for_scopes(scopes).scope
   end
 
   private
 
   def get_counts_for_user(user)
     scopes = get_scopes_for_user(user)
-    case_count = CaseFinderService.new(user).for_user.for_scopes(scopes).scope.size
+    case_count = CaseFinderService.new(user).for_scopes(scopes).scope.size
     @case_counts_by_user[user.id] = case_count
   end
 

--- a/app/views/layouts/_global_nav.html.slim
+++ b/app/views/layouts/_global_nav.html.slim
@@ -2,5 +2,5 @@ nav.global-nav
   ul
     - @global_nav_manager.each do |page|
       li class="global-nav-item"
-        = link_to t("nav.pages.#{page.name}", count: current_user.teams.count), page.fullpath, {class: active_link_class(page.fullpath)}
+        = link_to t("nav.pages.#{page.name}", count: current_user.teams.size), page.fullpath, {class: active_link_class(page.fullpath)}
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,6 +7,13 @@ Rails.application.configure do
   # Bullet.growl         = true
     Bullet.rails_logger  = true
     Bullet.add_footer    = true
+    # Closed cases action - for some reason the CSV download needs the eager loading, but
+    # the main display is less interested.
+    [:outcome, :info_held_status, :assignments, :cases_exemptions, :exemptions].each do |foi_assoc|
+      Bullet.add_whitelist :type => :unused_eager_loading,
+                           :class_name => "Case::FOI::Standard",
+                           :association => foi_assoc
+    end
     Bullet.raise         = false # raise an error if n+1 query occurs
   end
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,12 +1,12 @@
 Rails.application.configure do
   config.after_initialize do
     Bullet.enable        = true
-    Bullet.alert         = true
+    Bullet.alert         = false
     Bullet.bullet_logger = true
     Bullet.console       = true
   # Bullet.growl         = true
-    Bullet.rails_logger  = true
-    Bullet.add_footer    = true
+    Bullet.rails_logger  = false
+    Bullet.add_footer    = false
     # Closed cases action - for some reason the CSV download needs the eager loading, but
     # the main display is less interested.
     [:outcome, :info_held_status, :assignments, :cases_exemptions, :exemptions].each do |foi_assoc|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,14 @@
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+  # Bullet.growl         = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+    Bullet.raise         = false # raise an error if n+1 query occurs
+  end
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,11 @@
 Rails.application.configure do
+
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    # Enable this to track down most of the N+1 query issues
+    Bullet.raise         = false # raise an error if n+1 query occurs
+  end
   # Settings specified here will take precedence over those in config/application.rb.
 
   # The test environment is used exclusively to run your application's

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -189,20 +189,16 @@ RSpec.describe CasesController, type: :controller do
 
       context 'csv format' do
         it 'generates a file and downloads it' do
-          generator = double CSVGenerator
-          expect(CSVGenerator).to receive(:new).and_return(generator)
-          expect(CSVGenerator).to receive(:options).with('closed').and_return({filename: 'abc.csv', type: 'text/csv; charset=utf-8'})
-          expect(generator).to receive(:to_csv).and_return('csv data')
+          expect(CSVGenerator).to receive(:filename).with('closed').and_return('abc.csv')
 
           get :closed_cases, format: 'csv'
           expect(response.status).to eq 200
           expect(response.header['Content-Disposition']).to eq %q{attachment; filename="abc.csv"}
-          expect(response.body).to eq 'csv data'
+          expect(response.body).to eq CSV.generate_line(CSVExporter::CSV_COLUMN_HEADINGS)
         end
 
         it 'does not paginate the result set' do
           gnm = stub_current_case_finder_for_closed_cases_with(:closed_cases_result)
-          allow_any_instance_of(CSVGenerator).to receive(:to_csv).and_return ''
           get :closed_cases, format: 'csv', params: { page: 'our_page' }
 
           expect(gnm.current_page_or_tab.cases.by_last_transitioned_date)
@@ -467,15 +463,12 @@ RSpec.describe CasesController, type: :controller do
 
       context 'csv request' do
         it 'downloads a csv file' do
-          generator = double CSVGenerator
-          expect(CSVGenerator).to receive(:new).and_return(generator)
-          expect(CSVGenerator).to receive(:options).with('my-open').and_return({filename: 'abc.csv', type: 'text/csv; charset=utf-8'})
-          expect(generator).to receive(:to_csv).and_return('csv data')
+          expect(CSVGenerator).to receive(:filename).with('my-open').and_return('abc.csv')
 
           get :my_open_cases, params: { tab: 'in_time' }, format: 'csv'
           expect(response.status).to eq 200
           expect(response.header['Content-Disposition']).to eq %q{attachment; filename="abc.csv"}
-          expect(response.body).to eq 'csv data'
+          expect(response.body).to eq CSV.generate_line(CSVExporter::CSV_COLUMN_HEADINGS)
         end
       end
     end

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe CasesController, type: :controller do
       end
 
       context 'csv format' do
-        it 'generates a file and downloads it' do
+        it 'redirects' do
           expect(CSVGenerator).not_to receive(:new)
 
           get :closed_cases, format: 'csv'

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
 
-
 def stub_current_case_finder_cases_with(result)
   pager = double 'Kaminari Pager', decorate: result
   cases_by_deadline = double 'ActiveRecord Cases by Deadline', page: pager
@@ -349,7 +348,6 @@ RSpec.describe CasesController, type: :controller do
 
     before do
       allow(CaseFinderService).to receive(:new).and_return(finder)
-      allow(finder).to receive(:for_user).and_return(finder)
       allow(finder).to receive(:for_params).and_return(finder)
     end
 

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -18,6 +18,7 @@ def stub_current_case_finder_for_closed_cases_with(result)
   page = instance_double GlobalNavManager::Page, cases: cases
   gnm = instance_double GlobalNavManager, current_page_or_tab: page
   allow(cases_by_last_transitioned_date).to receive(:limit).and_return(cases_by_last_transitioned_date)
+  allow(cases).to receive(:includes).and_return(cases)
   allow(GlobalNavManager).to receive(:new).and_return gnm
   gnm
 end

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -1,28 +1,6 @@
 require 'rails_helper'
 require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
 
-def stub_current_case_finder_cases_with(result)
-  pager = double 'Kaminari Pager', decorate: result
-  cases_by_deadline = double 'ActiveRecord Cases by Deadline', page: pager
-  cases = double 'ActiveRecord Cases', by_deadline: cases_by_deadline
-  page = instance_double GlobalNavManager::Page, cases: cases
-  gnm = instance_double GlobalNavManager, current_page_or_tab: page
-  allow(GlobalNavManager).to receive(:new).and_return gnm
-  gnm
-end
-
-def stub_current_case_finder_for_closed_cases_with(result)
-  pager = double 'Kaminari Pager', decorate: result
-  cases_by_last_transitioned_date = double 'ActiveRecord Cases by last transitioned', page: pager
-  cases = double 'ActiveRecord Cases', by_last_transitioned_date: cases_by_last_transitioned_date
-  page = instance_double GlobalNavManager::Page, cases: cases
-  gnm = instance_double GlobalNavManager, current_page_or_tab: page
-  allow(cases_by_last_transitioned_date).to receive(:limit).and_return(cases_by_last_transitioned_date)
-  allow(cases).to receive(:includes).and_return(cases)
-  allow(GlobalNavManager).to receive(:new).and_return gnm
-  gnm
-end
-
 RSpec.describe CasesController, type: :controller do
 
   let(:all_cases)             { create_list(:case, 5)   }
@@ -1275,6 +1253,28 @@ RSpec.describe CasesController, type: :controller do
     #   before { sign_in responder }
     # end
 
+  end
+
+  def stub_current_case_finder_cases_with(result)
+    pager = double 'Kaminari Pager', decorate: result
+    cases_by_deadline = double 'ActiveRecord Cases by Deadline', page: pager
+    cases = double 'ActiveRecord Cases', by_deadline: cases_by_deadline
+    page = instance_double GlobalNavManager::Page, cases: cases
+    gnm = instance_double GlobalNavManager, current_page_or_tab: page
+    allow(GlobalNavManager).to receive(:new).and_return gnm
+    gnm
+  end
+
+  def stub_current_case_finder_for_closed_cases_with(result)
+    pager = double 'Kaminari Pager', decorate: result
+    cases_by_last_transitioned_date = double 'ActiveRecord Cases by last transitioned', page: pager
+    cases = double 'ActiveRecord Cases', by_last_transitioned_date: cases_by_last_transitioned_date
+    page = instance_double GlobalNavManager::Page, cases: cases
+    gnm = instance_double GlobalNavManager, current_page_or_tab: page
+    allow(cases_by_last_transitioned_date).to receive(:limit).and_return(cases_by_last_transitioned_date)
+    allow(cases).to receive(:includes).and_return(cases)
+    allow(GlobalNavManager).to receive(:new).and_return gnm
+    gnm
   end
 
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,13 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe UsersController, type: :controller do
-  # let(:manager) { create :manager, full_name: 'John Doe' }
   let(:manager) { find_or_create :disclosure_bmt_user }
   let(:dacu)    { find_or_create :team_dacu }
 
   describe 'GET show' do
     let(:service)                         { double UserActiveCaseCountService }
-    let(:generator)                       { double CSVGenerator }
     let(:unpaginated_cases)               { double 'Unapaginated cases collection', page: paginated_cases, decorate: all_decorated_cases }
     let(:paginated_cases)                 { double 'Paginated cases collection', decorate: paginated_decorated_cases }
     let(:paginated_decorated_cases)       { double 'Paginaged decorated_cases' }
@@ -36,36 +34,26 @@ RSpec.describe UsersController, type: :controller do
     end
 
     context 'csv request' do
-      it 'does not paginate' do
-        expect(UserActiveCaseCountService).to receive(:new).and_return(service)
-        expect(service).to receive(:active_cases_for_user).with(manager).and_return(unpaginated_cases)
-        expect(CSVGenerator).to receive(:new).with(all_decorated_cases).and_return(generator)
-        expect(generator).to receive(:to_csv).and_return('a,csv,file')
+      let(:csv_case) { double('Example Case') }
 
-        get :show, format: 'csv', params: {id: manager.id }
-      end
-
-      it 'sends data' do
+      it 'returns the csv file in the body' do
+        # so that the filename is fixed
         Timecop.freeze Time.local(2018, 11, 9, 13, 48, 22) do
           allow(UserActiveCaseCountService).to receive(:new).and_return(service)
           allow(service).to receive(:active_cases_for_user).with(manager).and_return(unpaginated_cases)
-          allow(CSVGenerator).to receive(:new).with(all_decorated_cases).and_return(generator)
-          allow(generator).to receive(:to_csv).and_return('a,csv,file')
+          expect(all_decorated_cases).to receive(:each).and_yield(csv_case)
+          expect(csv_case).to receive(:to_csv).and_return(['a','csv','file'])
+
           get :show, format: 'csv', params: {id: manager.id }
+          expect(response).to be_success
 
-          expect(response.headers['Content-Disposition']).to eq %q{attachment; filename="disclosure-bmt_managing_user-cases-18-11-09-134822.csv"}
+          expect(response.headers['Content-Disposition'])
+            .to eq %q{attachment; filename="disclosure-bmt_managing_user-cases-18-11-09-134822.csv"}
           expect(response.headers['Content-Type']).to eq 'text/csv; charset=utf-8'
+
+          expect(response.body).to eq [CSVExporter::CSV_COLUMN_HEADINGS.join(','),
+                                       "a,csv,file\n"].join("\n")
         end
-      end
-
-      it 'returns the csv file in the body' do
-        allow(UserActiveCaseCountService).to receive(:new).and_return(service)
-        allow(service).to receive(:active_cases_for_user).with(manager).and_return(unpaginated_cases)
-        allow(CSVGenerator).to receive(:new).with(all_decorated_cases).and_return(generator)
-        allow(generator).to receive(:to_csv).and_return('a,csv,file')
-
-        get :show, format: 'csv', params: {id: manager.id }
-        expect(response.body).to eq 'a,csv,file'
       end
     end
   end

--- a/spec/services/case_finder_service_spec.rb
+++ b/spec/services/case_finder_service_spec.rb
@@ -237,8 +237,8 @@ describe CaseFinderService do
       end
     end
 
-    describe '#for_user' do
-      it 'returns a finder that with a finder scoped to the users cases' do
+    describe '#new' do
+      it 'returns a finder scoped to the users cases' do
         expected = [
           @accepted_case,
           @accepted_overturned_ico_foi,
@@ -273,7 +273,7 @@ describe CaseFinderService do
         ]
 
         finder = CaseFinderService.new(@responder)
-        expect(finder.for_user.scope).to match_array expected
+        expect(finder.scope).to match_array expected
       end
     end
 
@@ -350,7 +350,6 @@ describe CaseFinderService do
                 @accepted_overturned_ico_foi_original,
                 @accepted_overturned_ico_foi_original_appeal,
                 @closed_overturned_ico_foi,
-
               ]
       end
     end
@@ -420,7 +419,6 @@ describe CaseFinderService do
                 @overturned_ico_foi,
                 @awaiting_responder_overturned_ico_foi,
                 @accepted_overturned_ico_foi
-
               ]
       end
     end
@@ -482,7 +480,6 @@ describe CaseFinderService do
                   @overturned_ico_foi_original_appeal,
                   @awaiting_responder_overturned_ico_foi_original_appeal,
                   @accepted_overturned_ico_foi_original_appeal
-
                 ]
         end
       end
@@ -529,7 +526,6 @@ describe CaseFinderService do
               @overturned_ico_foi,
               @awaiting_responder_overturned_ico_foi,
               @accepted_overturned_ico_foi
-
           ]
         end
       end

--- a/spec/services/csv_generator_spec.rb
+++ b/spec/services/csv_generator_spec.rb
@@ -18,16 +18,11 @@ describe 'CSVGenerator' do
     end
   end
 
-  describe '.options' do
-    it 'returns send_data_options' do
+  describe '#filename' do
+    it 'returns a filename based on time and action' do
       Timecop.freeze Time.local(2018, 11, 7, 13, 44, 55) do
-        expect(CSVGenerator.options('closed')).to eq(
-          {
-            filename: 'closed-cases-18-11-07-134455.csv',
-            type: 'text/csv; charset=utf-8'
-          })
+        expect(CSVGenerator.filename('closed')).to eq('closed-cases-18-11-07-134455.csv')
       end
     end
   end
-
 end

--- a/spec/services/csv_generator_spec.rb
+++ b/spec/services/csv_generator_spec.rb
@@ -11,8 +11,10 @@ describe 'CSVGenerator' do
       kase2 = double Case::Base, to_csv: k2_fields
 
       generator = CSVGenerator.new([kase1, kase2])
-      expected = "#{CSVExporter::CSV_COLUMN_HEADINGS.join(',')}\n#{k1_fields.join(',')}\n#{k2_fields.join(',')}\n"
-      expect(generator.to_csv).to eq expected
+      expected = ["#{CSVExporter::CSV_COLUMN_HEADINGS.join(',')}\n",
+                  "#{k1_fields.join(',')}\n",
+                  "#{k2_fields.join(',')}\n"]
+      expect(generator.to_a).to eq expected
     end
   end
 

--- a/spec/services/global_nav_manager_spec.rb
+++ b/spec/services/global_nav_manager_spec.rb
@@ -123,8 +123,6 @@ describe GlobalNavManager do
     before do
       allow(CaseFinderService).to receive(:new)
                                     .and_return case_finder_service
-      allow(case_finder_service).to receive(:for_user)
-                                      .and_return case_finder_service
       allow(case_finder_service).to receive(:for_params)
                                       .and_return case_finder_service
     end
@@ -135,7 +133,6 @@ describe GlobalNavManager do
 
     it 'customizes for user and params' do
       gnm.finder
-      expect(case_finder_service).to have_received(:for_user)
       expect(case_finder_service).to have_received(:for_params)
                                        .with({ 'state' => 'unequivocal' })
     end

--- a/spec/services/user_deletion_service_spec.rb
+++ b/spec/services/user_deletion_service_spec.rb
@@ -29,7 +29,7 @@ describe UserDeletionService do
       it 'deletes the teams users role' do
         expect(responder.team_roles.size).to eq 1
         service.call
-        expect(responder.team_roles.size).to eq 0
+        expect(responder.reload.team_roles.size).to eq 0
       end
     end
 
@@ -45,7 +45,7 @@ describe UserDeletionService do
       it 'deletes the teams users role' do
         expect(responder.team_roles.size).to eq 2
         service.call
-        expect(responder.team_roles.size).to eq 1
+        expect(responder.reload.team_roles.size).to eq 1
         expect(responder.team_roles.last.team).to eq(team_2)
       end
 


### PR DESCRIPTION
Converted CSV download to use a lazy enumerator (so the time-to-first-byte is small). Found and fixed quite a few N+1 query issues specific to closed case determinations. 