### PR TITLE
Ct 2143 spike excel rag reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'activerecord-session_store'
 gem 'acts_as_tree', '~> 2.8'
 # Gems to help generating with Excel spreadsheets
-# undeclared dependency on rubyzip
+# undeclared (but documented) dependency on rubyzip
 gem 'rubyzip', '>= 1.2.1'
 gem 'axlsx', git: 'https://github.com/randym/axlsx.git', ref: 'c8ac844'
 gem 'axlsx_rails'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,13 @@ source 'https://rubygems.org'
 
 gem 'activerecord-session_store'
 gem 'acts_as_tree', '~> 2.8'
+# Gems to help generating with Excel spreadsheets
+# undeclared dependency on rubyzip
+gem 'rubyzip', '>= 1.2.1'
+gem 'axlsx', git: 'https://github.com/randym/axlsx.git', ref: 'c8ac844'
+gem 'axlsx_rails'
+gem 'axlsx_styler'
+
 gem 'awesome_print'
 gem 'aws-sdk'
 gem 'bank_holiday', git: 'https://github.com/ministryofjustice/bank_holiday.git', branch: 'bundler-fix'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,17 @@ GIT
     bank_holiday (0.0.4)
       dish
 
+GIT
+  remote: https://github.com/randym/axlsx.git
+  revision: c8ac844572b25fda358cc01d2104720c4c42f450
+  ref: c8ac844
+  specs:
+    axlsx (2.1.0.pre)
+      htmlentities (~> 4.3.4)
+      mimemagic (~> 0.3)
+      nokogiri (>= 1.6.6)
+      rubyzip (>= 1.2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -76,6 +87,12 @@ GEM
     aws-sdk-resources (2.7.3)
       aws-sdk-core (= 2.7.3)
     aws-sigv4 (1.0.0)
+    axlsx_rails (0.1.5)
+      axlsx
+      rails (>= 3.1)
+    axlsx_styler (0.2.0)
+      activesupport (>= 3.1)
+      axlsx (>= 2.0, < 4)
     bcrypt (3.1.12)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
@@ -234,6 +251,7 @@ GEM
       guard (~> 2.0)
       rubocop (~> 0.20)
     highline (2.0.0)
+    htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     humanize_boolean (0.0.2)
@@ -321,6 +339,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mimemagic (0.3.3)
     mimetype-fu (0.1.2)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
@@ -579,6 +598,9 @@ DEPENDENCIES
   annotate
   awesome_print
   aws-sdk
+  axlsx!
+  axlsx_rails
+  axlsx_styler
   bank_holiday!
   better_errors
   binding_of_caller
@@ -639,6 +661,7 @@ DEPENDENCIES
   rubocop (~> 0.65.0)
   rubocop-rspec
   ruby-progressbar
+  rubyzip (>= 1.2.1)
   sass-rails (~> 5.0)
   schema_plus_enums (~> 0.1)
   selenium-webdriver

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -65,15 +65,15 @@ class StatsController < ApplicationController
 
   def cell_colour(value, thresholds)
     if value < thresholds[:red]
-               'FF0000'
-             elsif value < thresholds[:amber]
-               'FF0000'
-             else
-               '00FF00'
-             end
+      'FF0000'
+    elsif value < thresholds[:amber]
+      'FF0000'
+    else
+      '00FF00'
+    end
   end
 
-  def download_custom_report
+  def download_custom_report #rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
     report= Report.find(params[:id])
     filename = report.report_type.filename
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -75,7 +75,7 @@ class StatsController < ApplicationController
     end
   end
 
-  def download_custom_report #rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+  def download_custom_report #rubocop:disable Metrics/MethodLength
     report = Report.find(params[:id])
     filename = report.report_type.filename
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -67,11 +67,11 @@ class StatsController < ApplicationController
 
   def cell_colour(value, thresholds)
     if value < thresholds[:red]
-      'FF0000'
+      'FF0000' #Red - bright
     elsif value < thresholds[:amber]
-      'FF0000'
+      'FFFF00' #Yellow - again very bright
     else
-      '00FF00'
+      '00FF00' #Green - quite bright (Lime)
     end
   end
 

--- a/spec/features/user_journeys/foi/downloading_stats_spec.rb
+++ b/spec/features/user_journeys/foi/downloading_stats_spec.rb
@@ -22,9 +22,7 @@ require 'rails_helper'
 require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
 require File.join(Rails.root, 'db', 'seeders', 'report_type_seeder')
 
-
 # ReportTypeSeeder.new.seed!
-
 
 feature "Downloading stats(csv) from the system" do
   given(:manager)   { find_or_create :disclosure_bmt_user }
@@ -156,7 +154,7 @@ feature "Downloading stats(csv) from the system" do
   def download_custom_r003_report
     stats_custom_page.success_message.download_link.click
     expect(page.response_headers['Content-Disposition'])
-        .to match(/filename="r003_business_unit_performance_report\.csv"/)
+        .to match(/filename="r003_business_unit_performance_report\.xlsx"/)
 
     stats_custom_page.load
   end


### PR DESCRIPTION
Spike - use of XLSX library to generate excel spreadsheets. All code currently in controller - needs to wait for performance improvements so that reports can be run as inline CSVs. Once this happens code can run to_csv on the query items, and then convert to XLSX format rather than loading and parsing a CSV string as here.