### PR TITLE
Ct 2150 multi role user unable to post to trigger cases

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -22,10 +22,14 @@ class MessagesController < ApplicationController
   private
 
   def case_team
+    User.sort_teams_by_roles(case_teams).first
+  end
+
+  def case_teams
     if current_user.teams_for_case(@case).any?
-      current_user.team_for_case(@case)
+      current_user.teams_for_case(@case)
     else
-      User.sort_teams_by_roles(current_user.teams).first
+      current_user.teams
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -21,6 +21,8 @@ class MessagesController < ApplicationController
 
   private
 
+  # need to sort with manager first so that if we are both manager and something else, we don't
+  # try to execute the action with our lower authority (which might fail)
   def case_team
     User.sort_teams_by_roles(case_teams).first
   end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe MessagesController, type: :controller do
       end
 
       it 'allows them to post on a closed case' do
-
         params[:case_id] = closed_case.id
         post :create , params: params
         expect(response).to redirect_to(case_path(closed_case, anchor: 'messages-section'))
@@ -129,7 +128,7 @@ RSpec.describe MessagesController, type: :controller do
     end
 
     context "overturned_sar case" do
-      let(:overturned_sar)     { create :overturned_ico_sar }
+      let(:overturned_sar)     { create :sar_case, :flagged_accepted }
       let(:params) do
         {
           case: {
@@ -144,6 +143,17 @@ RSpec.describe MessagesController, type: :controller do
 
         it "redirects to case detail page and contains a hash" do
           post :create , params: params
+          expect(response).to redirect_to(case_path(overturned_sar, anchor: 'messages-section'))
+        end
+      end
+
+      context 'as a multi-role person' do
+        let(:approver_manager)  { create :sar_approver_responder_manager }
+
+        before { sign_in approver_manager }
+
+        it "works" do
+          post :create, params: params
           expect(response).to redirect_to(case_path(overturned_sar, anchor: 'messages-section'))
         end
       end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -127,34 +127,38 @@ RSpec.describe MessagesController, type: :controller do
       end
     end
 
-    context "overturned_sar case" do
-      let(:overturned_sar)     { create :sar_case, :flagged_accepted }
+    context "sar case" do
       let(:params) do
         {
           case: {
             message_text: 'This is a new message'
           },
-          case_id: overturned_sar.id
+          case_id: sar_case.id
         }
       end
 
       context "as a manager" do
+        let(:sar_case)     { create :sar_case }
+
         before { sign_in manager }
 
         it "redirects to case detail page and contains a hash" do
           post :create , params: params
-          expect(response).to redirect_to(case_path(overturned_sar, anchor: 'messages-section'))
+          expect(response).to redirect_to(case_path(sar_case, anchor: 'messages-section'))
         end
       end
 
       context 'as a multi-role person' do
-        let(:approver_manager)  { create :sar_approver_responder_manager }
+        let(:sar_case)     { create :awaiting_responder_sar }
+
+        let(:approver_manager)  { create :sar_multi_role_user }
 
         before { sign_in approver_manager }
 
-        it "works" do
+        it "creates using the manager role" do
           post :create, params: params
-          expect(response).to redirect_to(case_path(overturned_sar, anchor: 'messages-section'))
+          expect(response).to be_redirect
+          expect(sar_case.message_transitions.last.acting_team).to eq(approver_manager.managing_teams.first)
         end
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -154,6 +154,17 @@ FactoryBot.define do
       managing_teams    { [ find_or_create(:team_dacu) ] }
     end
 
+    factory :sar_approver_responder_manager do
+      transient do
+        identifier { 'sar-approving-responding-managing user' }
+      end
+
+      full_name         { generate(:approver_responder_manager_name) }
+      approving_team    { find_or_create(:approving_team) }
+      responding_teams  { [ find_or_create(:sar_responding_team) ] }
+      managing_teams    { [ find_or_create(:team_disclosure_bmt) ] }
+    end
+
     factory :disclosure_specialist do
       transient do
         identifier { 'disclosure-specialist approving user' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -154,15 +154,15 @@ FactoryBot.define do
       managing_teams    { [ find_or_create(:team_dacu) ] }
     end
 
-    factory :sar_approver_responder_manager do
+    factory :sar_multi_role_user do
       transient do
-        identifier { 'sar-approving-responding-managing user' }
+        identifier { 'approving-responding-managing user' }
       end
 
       full_name         { generate(:approver_responder_manager_name) }
       approving_team    { find_or_create(:approving_team) }
       responding_teams  { [ find_or_create(:sar_responding_team) ] }
-      managing_teams    { [ find_or_create(:team_disclosure_bmt) ] }
+      managing_teams    { [ find_or_create(:team_dacu) ] }
     end
 
     factory :disclosure_specialist do


### PR DESCRIPTION
When a user has both a manager and a lesser role, when adding messages to a case it needs to be actioned as the manager role