### PR TITLE
CT-2112 remove default deletion reason from migration

### DIFF
--- a/db/migrate/20190325082640_fix_reason_for_deletion.rb
+++ b/db/migrate/20190325082640_fix_reason_for_deletion.rb
@@ -2,7 +2,5 @@ class FixReasonForDeletion < ActiveRecord::Migration[5.0]
   def change
     change_column_null(:cases, :reason_for_deletion, true)
     change_column_default(:cases, :reason_for_deletion, to: nil, from: 'Unspecified')
-
-    Case::Base.unscoped.soft_deleted.each { |kase| kase.update!(reason_for_deletion: 'Unspecified') }
   end
 end


### PR DESCRIPTION
Default deletion reasons are just not needed, and cause more problems than they solve