### PR TITLE
CT-2180 Calculate num days late using case.external_deadline value

### DIFF
--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -574,10 +574,8 @@ class Case::Base < ApplicationRecord
     Date.today > external_deadline
   end
 
-  def num_days_draft_deadline_late
-    return unless date_draft_compliant.present? && internal_deadline.present?
-
-    days = (date_draft_compliant - internal_deadline).to_i
+  def num_days_late
+    days = (Date.today - external_deadline).to_i
     days > 0 ? days : nil
   end
 

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -100,7 +100,7 @@ class CSVExporter
         # Draft Timliness related information
         humanize_boolean(@kase.within_draft_deadline?), # Draft in time
         humanize_boolean(@kase.response_in_target?), # In Target
-        @kase.num_days_draft_deadline_late, # Number of days late
+        @kase.num_days_late, # Number of days late
       ]
     rescue => err
       raise CSVExporterError.new("Error encountered formatting case id #{@kase.id} as CSV:\nOriginal error: #{err.class} #{err.message}")

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -1466,40 +1466,20 @@ RSpec.describe Case::Base, type: :model do
     end
   end
 
-  describe '#num_days_draft_deadline_late' do
-    it 'is nil when date_draft_compliant is not present' do
-      kase.date_draft_compliant = nil
-      kase.internal_deadline = Date.today
-
-      expect(kase.num_days_draft_deadline_late).to be nil
-    end
-
-    it 'is nil when internal_deadline is not present' do
-      kase.date_draft_compliant = Date.today
-      kase.internal_deadline = nil
-
-      expect(kase.num_days_draft_deadline_late).to be nil
-    end
-
+  describe '#num_days_late' do
     it 'is nil when 0 days late' do
-      kase.date_draft_compliant = Date.today
-      kase.internal_deadline = Date.today
-
-      expect(kase.num_days_draft_deadline_late).to be nil
+      kase.external_deadline = Date.today
+      expect(kase.num_days_late).to be nil
     end
 
     it 'is nil when not yet late' do
-      kase.date_draft_compliant = Date.today
-      kase.internal_deadline = Date.tomorrow
-
-      expect(kase.num_days_draft_deadline_late).to be nil
+      kase.external_deadline = Date.tomorrow
+      expect(kase.num_days_late).to be nil
     end
 
     it 'returns correct number of days late' do
-      kase.date_draft_compliant = Date.today
-      kase.internal_deadline = Date.yesterday
-
-      expect(kase.num_days_draft_deadline_late).to eq 1
+      kase.external_deadline = Date.yesterday
+      expect(kase.num_days_late).to eq 1
     end
   end
 

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -116,7 +116,7 @@ describe CSVExporter do
           'Directorate name' => 'Responder Directorate',
           'Draft in time' => nil,
           'In target' => 'Yes',
-          'Number of days late' => 25,
+          'Number of days late' => 14,
         })
       end
     end
@@ -249,7 +249,7 @@ describe CSVExporter do
           'Directorate name' => 'Responder Directorate',
           'Draft in time' => nil,
           'In target' => 'Yes',
-          'Number of days late' => nil,
+          'Number of days late' => 2,
         })
       end
     end


### PR DESCRIPTION
### Summary
Case downloads report has a new column 'number of days late' implemented in #708. The implementation has been amended so that `case.num_days_late` calculates the number of days between `case.external_deadline` and _today_.

### Ticket
https://dsdmoj.atlassian.net/browse/CT-2180