### PR TITLE
Upgrade to Webdrivers gem and fix feature specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ group :test do
   gem 'codeclimate-test-reporter', '~> 1.0'
   gem 'i18n-tasks', '~> 0.9.29'
   gem 'rails-controller-testing', require: false
-  gem 'selenium-webdriver'
+  gem 'webdrivers', '~> 3.0'
   gem 'shoulda-matchers', '~> 4.0'
   gem 'site_prism'
   gem 'webdrivers', '~> 3.0'
@@ -97,6 +97,7 @@ group :development, :test do
   gem 'rubocop', '~> 0.67.2', require: false
   gem 'rubocop-rspec', require: false
   gem 'ruby-progressbar'
+  gem 'spring-commands-rspec'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -488,7 +488,7 @@ GEM
       activerecord (>= 4.2, < 5.3)
       its-it (~> 1.2)
       schema_plus_core
-    selenium-webdriver (3.141.5926)
+    selenium-webdriver (3.142.1)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.9.0)
@@ -524,6 +524,8 @@ GEM
       ffi
     spring (2.0.2)
       activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -564,7 +566,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (3.8.0)
+    webdrivers (3.9.1)
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (~> 3.0)
@@ -650,7 +652,6 @@ DEPENDENCIES
   rubyzip (>= 1.2.1)
   sass-rails (~> 5.0)
   schema_plus_enums (~> 0.1)
-  selenium-webdriver
   sentry-raven (~> 2.9.0)
   shell-spinner
   shoulda-matchers (~> 4.0)
@@ -659,6 +660,7 @@ DEPENDENCIES
   site_prism
   slim-rails (~> 3.2)
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.1)
   table_print
   thor-rails

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -7,9 +7,11 @@ unless defined?(Spring)
   require 'rubygems'
   require 'bundler'
 
-  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(Gem.path_separator) }
-    gem 'spring', match[1]
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
     require 'spring/binstub'
   end
 end

--- a/spec/features/cases/foi/case_viewing/removing_response_spec.rb
+++ b/spec/features/cases/foi/case_viewing/removing_response_spec.rb
@@ -64,6 +64,7 @@ feature 'removing a response from response details' do
           expect(uploaded_file.first.actions.remove['data-confirm'])
             .to eq "Are you sure you want to remove #{attached_response.filename}?"
           accept_alert do
+            scroll_to uploaded_file.first.actions.remove
             uploaded_file.first.actions.remove.click
           end
           sleep 0.25
@@ -156,6 +157,7 @@ feature 'removing a response from response details' do
           expect(uploaded_file.first.actions.remove['data-confirm'])
             .to eq "Are you sure you want to remove #{attached_response.filename}?"
           accept_alert do
+            scroll_to uploaded_file.first.actions.remove
             uploaded_file.first.actions.remove.click
           end
           cases_show_page.wait_until_case_attachments_visible count: 0

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,12 @@ require 'rspec/rails'
 require 'capybara/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'capybara/rspec'
+
+# Webdrivers - Moved from deprecated chrome-helpers gem. Behaviour changed to require you to
+# explicitly issue a scroll command to bring off-screen elements below the fold up into view
+# before you click on them in feature specs
+# See https://stackoverflow.com/questions/55406656
+# and https://www.rubydoc.info/gems/capybara/Capybara/Node/Element#scroll_to-instance_method
 require 'webdrivers'
 
 require 'rails-controller-testing'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,10 +20,11 @@ require 'rspec/rails'
 require 'capybara/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'capybara/rspec'
-require 'selenium-webdriver'
+require 'webdrivers'
 
 require 'rails-controller-testing'
 require 'paper_trail/frameworks/rspec'
+Webdrivers.cache_time = 86_400
 
 Capybara.default_max_wait_time = 4
 
@@ -37,7 +38,8 @@ Capybara.register_driver :headless_chrome do |app|
   if ENV['CHROME_DEBUG'].present?
     configurationSetting = {}
   else
-    configurationSetting = { args: %w(headless disable-gpu) }
+    configurationSetting = { args: %w(headless disable-gpu no-sandbox --start-maximized
+                                      --window-size=1980,2080 --enable-features=NetworkService,NetworkServiceInProcess) }
   end
 
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
@@ -52,7 +54,6 @@ end
 Capybara.javascript_driver = :headless_chrome
 
 Capybara.server = :puma, { Silent: true }
-
 # Set these env variables to push screenshots for failed tests to S3.
 # if ENV['S3_TEST_SCREENSHOT_ACCESS_KEY_ID'].present? &&
 #    ENV['S3_TEST_SCREENSHOT_SECRET_ACCESS_KEY'].present?
@@ -81,6 +82,10 @@ Timecop.safe_mode = true
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 $LOAD_PATH.unshift(File.join(File.expand_path('..', __FILE__), 'site_prism'))
 require 'site_prism/page_objects/pages/application.rb'
+
+# include linked_cases_section specifically to avoid machine-specific load order issues
+require "site_prism/page_objects/sections/cases/linked_cases_section.rb"
+
 Dir[Rails.root.join("spec/site_prism/support/**/*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec/site_prism/page_objects/sections/shared/**/*.rb")].each { |f| require f }
 Dir[Rails.root.join("spec/site_prism/page_objects/sections/**/*.rb")].each { |f| require f }

--- a/spec/support/features/steps/cases/edit_steps.rb
+++ b/spec/support/features/steps/cases/edit_steps.rb
@@ -26,6 +26,7 @@ def edit_ico_case_step(kase:, original_case:)
   expect(cases_show_page).to be_displayed(id: kase.id)
   expect(cases_show_page.case_details).to have_edit_case
 
+  scroll_to cases_show_page.case_details.edit_case
   cases_show_page.case_details.edit_case.click
 
   expect(cases_edit_ico_page).to be_displayed(id: kase.id)
@@ -49,6 +50,7 @@ def edit_foi_case_closure_step(kase:, # rubocop:disable Metrics/MethodLength, Me
   expect(cases_show_page).to be_displayed(id: kase.id)
   expect(cases_show_page.case_details).to have_edit_closure
 
+  scroll_to cases_show_page.case_details.edit_closure
   cases_show_page.case_details.edit_closure.click
 
   expect(cases_edit_closure_page).to be_displayed
@@ -166,6 +168,7 @@ def edit_ico_case_closure_step(kase:, decision_received_date: Date.today, ico_de
   expect(cases_show_page).to be_displayed(id: kase.id)
   expect(cases_show_page.case_details).to have_edit_closure
 
+  scroll_to cases_show_page.case_details.edit_closure
   cases_show_page.case_details.edit_closure.click
 
   expect(cases_edit_closure_page).to be_displayed


### PR DESCRIPTION
Attempting to get the feature specs working - particularly the JS ones - following the retiral of the chrome driver helper gem and move to webdrivers gem. 

Specs needing the view to be scrolled to find an element in order to click on it were failing. 

After much effort expended trying to figure out why this was no longer working as it had done previously (possibly a bug in the chromedriver or Chrome itself, or a change in behaviour) a solution was finally found, which is to use a relatively recently introduced method in Capybara to scroll the required element into the viewport before clicking on it

See https://stackoverflow.com/questions/55406656/why-is-there-no-scroll-down-up-functionality-with-selenium-webdriver
and
https://www.rubydoc.info/gems/capybara/Capybara/Node/Element#scroll_to-instance_method