### PR TITLE
CT-2207 Use date received in search where clause

### DIFF
--- a/app/services/stats/base_cases_report.rb
+++ b/app/services/stats/base_cases_report.rb
@@ -23,8 +23,8 @@ module Stats
 
     def run
       case_scope
-        .where(date_responded: [@period_start..@period_end])
-        .by_last_transitioned_date
+        .where(received_date: [@period_start..@period_end])
+        .order(received_date: :asc)
         .each { |kase| @stats.add(kase) }
     end
 

--- a/spec/services/stats/r007_closed_cases_report_spec.rb
+++ b/spec/services/stats/r007_closed_cases_report_spec.rb
@@ -27,23 +27,23 @@ module Stats
         @cases = {
           closed_sar: {
             type: :closed_sar,
-            responded: @period_end - 1.hours,
+            received: @period_end - 1.hours,
           },
           closed_foi: {
             type: :closed_case,
-            responded: @period_start,
+            received: @period_start,
           },
           outside_period_foi: {
             type: :closed_case,
-            responded: @period_end + 1.days
+            received: @period_end + 1.days
           },
           responded_foi: {
             type: :responded_case,
-            responded: @period_start + 1.hour,
+            received: @period_start + 1.hour,
           },
           open_foi: {
             type: :accepted_case,
-            responded: @period_start + 1.days,
+            received: @period_start + 1.days,
             state: 'totally-not-accepted-really'
           },
         }
@@ -52,7 +52,7 @@ module Stats
           kase = build(
             options[:type],
             name: key,
-            date_responded: options[:responded],
+            received_date: options[:received],
             current_state: options[:state] || 'closed'
           )
 


### PR DESCRIPTION
### Summary
After discussion with users, determined report should be generated by filtering against the `cases.date_received` field as originally implemented in #768 

### Ticket
https://dsdmoj.atlassian.net/browse/CT-2091