### PR TITLE
Fix date-dependent spec failure

### DIFF
--- a/spec/controllers/cases_controller/update_case_spec.rb
+++ b/spec/controllers/cases_controller/update_case_spec.rb
@@ -76,9 +76,11 @@ describe CasesController, type: :controller do
           before(:each) { params['case_foi']['received_date_yyyy'] = '2017' }
 
           it 'does not update the record' do
-            original_kase = kase.clone
-            patch :update, params: params
-            expect(kase.reload).to eq original_kase
+            Timecop.freeze(now) do
+              original_kase = kase.clone
+              patch :update, params: params
+              expect(kase.reload).to eq original_kase
+            end
           end
 
           it 'has error details on the record' do
@@ -94,26 +96,32 @@ describe CasesController, type: :controller do
 
         context 'date draft compliant before received date' do
           it 'has error details on the record' do
-            kase.date_responded = 3.business_days.after(kase.received_date)
-            params['case_foi']['date_draft_compliant_yyyy'] = '2016'
-            patch :update, params: params
-            expect(assigns(:case).errors.full_messages).to eq ["Date compliant draft uploaded can't be before date received"]
+            Timecop.freeze(now) do
+              kase.date_responded = 3.business_days.after(kase.received_date)
+              params['case_foi']['date_draft_compliant_yyyy'] = '2016'
+              patch :update, params: params
+              expect(assigns(:case).errors.full_messages).to eq ["Date compliant draft uploaded can't be before date received"]
+            end
           end
         end
 
         context 'date draft compliant in future' do
           it 'has error details on the record' do
-            params['case_foi']['date_draft_compliant_yyyy'] = '2020'
-            patch :update, params: params
-            expect(assigns(:case).errors.full_messages).to eq ['Date compliant draft uploaded can\'t be in the future.']
+            Timecop.freeze(now) do
+              params['case_foi']['date_draft_compliant_yyyy'] = '2020'
+              patch :update, params: params
+              expect(assigns(:case).errors.full_messages).to eq ['Date compliant draft uploaded can\'t be in the future.']
+            end
           end
         end
 
         context 'date draft compliant before received date' do
           it 'has error details on the record' do
-            params['case_foi']['date_draft_compliant_yyyy'] = '2016'
-            patch :update, params: params
-            expect(assigns(:case).errors.full_messages).to eq ["Date compliant draft uploaded can't be before date received"]
+            Timecop.freeze(now) do
+              params['case_foi']['date_draft_compliant_yyyy'] = '2016'
+              patch :update, params: params
+              expect(assigns(:case).errors.full_messages).to eq ["Date compliant draft uploaded can't be before date received"]
+            end
           end
         end
       end

--- a/spec/controllers/cases_controller/update_case_spec.rb
+++ b/spec/controllers/cases_controller/update_case_spec.rb
@@ -11,15 +11,17 @@ describe CasesController, type: :controller do
 
     context 'foi case' do
       let(:kase)  do
-        create :accepted_case,
-               name: 'Original Name',
-               email: 'original_email@moj.com',
-               message: 'Original message',
-               received_date: now.to_date,
-               postal_address: 'Original Postal Address',
-               subject: 'Original subject',
-               requester_type: 'member_of_the_public',
-               delivery_method: 'sent_by_email'
+        Timecop.freeze(now) do
+          create :accepted_case,
+                 name: 'Original Name',
+                 email: 'original_email@moj.com',
+                 message: 'Original message',
+                 received_date: now.to_date,
+                 postal_address: 'Original Postal Address',
+                 subject: 'Original subject',
+                 requester_type: 'member_of_the_public',
+                 delivery_method: 'sent_by_email'
+        end
       end
       let(:params) do
           {
@@ -119,17 +121,19 @@ describe CasesController, type: :controller do
 
     context 'sar case' do
       let(:kase)  do
-        create :accepted_sar,
-               name: 'Original Name',
-               email: 'original_email@moj.com',
-               message: 'origninal full case',
-               received_date: now.to_date,
-               postal_address: '',
-               subject: 'Original summary',
-               third_party: false,
-               reply_method: 'send_by_email',
-               subject_type: 'offender',
-               subject_full_name: 'original subject'
+        Timecop.freeze(now) do
+          create :accepted_sar,
+                 name: 'Original Name',
+                 email: 'original_email@moj.com',
+                 message: 'origninal full case',
+                 received_date: now.to_date,
+                 postal_address: '',
+                 subject: 'Original summary',
+                 third_party: false,
+                 reply_method: 'send_by_email',
+                 subject_type: 'offender',
+                 subject_full_name: 'original subject'
+        end
       end
       let(:params) do
         {

--- a/spec/services/team_deletion_service_spec.rb
+++ b/spec/services/team_deletion_service_spec.rb
@@ -91,6 +91,7 @@ describe TeamDeletionService do
 
         context 'has closed cases but no open' do
           it 'returns :ok and soft deletes the team' do
+            DbHousekeeping.clean(seed: true)
             closed_case = create :closed_case
             bu = closed_case.responding_team
             bu.responders.destroy_all


### PR DESCRIPTION
The specs hard-code a date of May 30, 2018 - the app prevents you from creating a case that's more than a year old! So apply time cop freeze to allow specs to pass 

Subsequently had some parallel and order-dependent test failures