### PR TITLE
CT-2323 log in as branston user

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -1190,10 +1190,7 @@ class CasesController < ApplicationController
     types = current_user.managing_teams.first.correspondence_types.menu_visible.order(:name).to_a
     types.delete(CorrespondenceType.sar) unless FeatureSet.sars.enabled?
     types.delete(CorrespondenceType.ico) unless FeatureSet.ico.enabled?
-
-    # TO-DO - This is here for development testing only
-    # Remove when there is a proper user with the right team/roles for Offender SARs
-    types << CorrespondenceType.offender_sar if FeatureSet.offender_sars.enabled?
+    types.delete(CorrespondenceType.offender_sar) unless FeatureSet.offender_sars.enabled?
     @permitted_correspondence_types = types
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,6 +183,7 @@ class User < ApplicationRecord
               .uniq
     types.delete(CorrespondenceType.sar) unless FeatureSet.sars.enabled?
     types.delete(CorrespondenceType.ico) unless FeatureSet.ico.enabled?
+    types.delete(CorrespondenceType.offender_sar) unless FeatureSet.offender_sars.enabled?
     types << CorrespondenceType.overturned_foi if types.include?(CorrespondenceType.foi)
     types << CorrespondenceType.overturned_sar if types.include?(CorrespondenceType.sar)
     types

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -1,5 +1,6 @@
 class CorrespondenceTypeSeeder
 
+  #rubocop:disable Metrics/MethodLength
   def seed!
     puts "----Seeding Correspondence Types----"
 
@@ -42,6 +43,6 @@ class CorrespondenceTypeSeeder
                 internal_time_limit: 10,
                 external_time_limit: 20,
                 deadline_calculator_class: 'CalendarDays')
-
   end
+  #rubocop:enable Metrics/MethodLength
 end

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -34,5 +34,14 @@ class CorrespondenceTypeSeeder
                 external_time_limit: 30,
                 deadline_calculator_class: 'CalendarDays')
 
+    rec = CorrespondenceType.find_by(abbreviation: 'OFFENDER')
+    rec = CorrespondenceType.new if rec.nil?
+    rec.update!(name: 'Offender SAR (OFFENDER)',
+                abbreviation: 'OFFENDER',
+                escalation_time_limit: 3,
+                internal_time_limit: 10,
+                external_time_limit: 20,
+                deadline_calculator_class: 'CalendarDays')
+
   end
 end

--- a/db/seeders/dev_team_seeder.rb
+++ b/db/seeders/dev_team_seeder.rb
@@ -40,9 +40,11 @@ class DevTeamSeeder
 
   #rubocop:disable Metrics/MethodLength
   def add_business_units
-    @foi = CorrespondenceType.foi
-    @sar = CorrespondenceType.sar
-    @ico = CorrespondenceType.ico
+    @foi      = CorrespondenceType.foi
+    @sar      = CorrespondenceType.sar
+    @ico      = CorrespondenceType.ico
+    @offender = CorrespondenceType.offender_sar
+
     @bu_dacu_bmt  = find_or_create_business_unit(parent: @dir_dacu,
                                                  name: 'Disclosure BMT',
                                                  code: Settings.foi_cases.default_managing_team,
@@ -95,6 +97,10 @@ class DevTeamSeeder
                                                  name: 'Communications and Information',
                                                  role: 'responder',
                                                  correspondence_type_ids: [@foi.id, @sar.id, @ico.id])
+    @bu_branston  = find_or_create_business_unit(parent: @dir_dacu,
+                                                 name: 'Branston Registry',
+                                                 role: 'manager',
+                                                 correspondence_type_ids: [@offender.id])
   end
   #rubocop:enable Metrics/MethodLength
 
@@ -119,6 +125,7 @@ class DevTeamSeeder
     TeamProperty.find_or_create_by!(team_id: @bu_utl.id,       key: 'lead', value: 'Farmer Jones')
     TeamProperty.find_or_create_by!(team_id: @bu_uttc.id,      key: 'lead', value: 'Gideon Osborne')
     TeamProperty.find_or_create_by!(team_id: @bu_candi.id,     key: 'lead', value: 'Candi Floss')
+    TeamProperty.find_or_create_by!(team_id: @bu_branston.id,  key: 'lead', value: 'Brian Rix')
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/db/seeders/dev_user_seeder.rb
+++ b/db/seeders/dev_user_seeder.rb
@@ -11,6 +11,7 @@ class DevUserSeeder
       'pressoffice'   => BusinessUnit.press_office,
       'privateoffice' => BusinessUnit.private_office,
       'commsandinfo'  => BusinessUnit.find_by!(name: 'Communications and Information'),
+      'branston'  => BusinessUnit.find_by!(name: 'Branston Registry'),
     }
 
     @users = {
@@ -37,6 +38,7 @@ class DevUserSeeder
       'Prescilla Offenberg'=> [{ team: 'pressoffice',    role: 'approver' }],
       'Primrose Offord'    => [{ team: 'privateoffice',  role: 'approver' }],
       'Princeton Office'   => [{ team: 'privateoffice',  role: 'approver' }],
+      'Brian Rix'          => [{ team: 'branston',  role: 'manager' }],
     }
   end
   # rubocop:enable Metrics/MethodLength

--- a/spec/factories/business_units.rb
+++ b/spec/factories/business_units.rb
@@ -40,6 +40,7 @@ FactoryBot.define do
                              find_or_create(:foi_correspondence_type),
                              find_or_create(:sar_correspondence_type),
                              find_or_create(:ico_correspondence_type),
+                             find_or_create(:offender_sar_correspondence_type),
                            ] }
     directorate         { find_or_create :directorate }
     properties          { [find_or_create(:team_property, :area)] }
@@ -108,6 +109,13 @@ FactoryBot.define do
     code { Settings.foi_cases.default_managing_team }
     directorate { find_or_create :dacu_directorate }
     managers { [find_or_create(:disclosure_bmt_user, :orphan)] }
+  end
+
+  factory :team_branston, parent: :managing_team do
+    name { 'Branston Registry' }
+    email { 'branston@localhost' }
+    directorate { find_or_create :dacu_directorate }
+    managers { [find_or_create(:branston_user, :orphan)] }
   end
 
   factory :team_disclosure, aliases: [:team_dacu_disclosure], parent: :approving_team do

--- a/spec/factories/team_correspondence_type_roles.rb
+++ b/spec/factories/team_correspondence_type_roles.rb
@@ -50,6 +50,10 @@ FactoryBot.define do
       # category_id   { find_or_create(:category, :sar).id }
     end
 
+    trait :offender_sar do
+      correspondence_type   { find_or_create :offender_sar_correspondence_type }
+    end
+
 
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -88,6 +88,16 @@ FactoryBot.define do
       managing_teams { [find_or_create(:team_dacu, :empty)] }
     end
 
+    factory :branston_user, parent: :manager do
+      transient do
+        identifier { 'branston registry managing user' }
+      end
+
+      full_name      { identifier }
+      email          { email_from_name(full_name) }
+      managing_teams { [find_or_create(:team_branston, :empty)] }
+    end
+
     trait :orphan do
       approving_team { nil }
       managing_teams { [] }

--- a/spec/factory_specs/business_unit_factory_spec.rb
+++ b/spec/factory_specs/business_unit_factory_spec.rb
@@ -9,7 +9,7 @@ describe 'Business Unit factories' do
       it 'creates responding team with responding team correspondence_type role for FOI' do
         bu = create :business_unit
         expect(bu.role).to eq 'responder'
-        expect(bu.correspondence_type_roles.size).to eq 3
+        expect(bu.correspondence_type_roles.size).to eq 4
         tcr = bu.correspondence_type_roles.first
         expect(tcr).to match_tcr_attrs(:foi, :view, :respond)
       end
@@ -52,7 +52,7 @@ describe 'Business Unit factories' do
         bu = create :responding_team
 
         expect(bu.role).to eq 'responder'
-        expect(bu.correspondence_type_roles.size).to eq 5
+        expect(bu.correspondence_type_roles.size).to eq 6
         foi_tcr = bu.correspondence_type_roles.detect do |r|
           r.correspondence_type_id == CorrespondenceType.foi.id
         end
@@ -62,6 +62,11 @@ describe 'Business Unit factories' do
           r.correspondence_type_id == CorrespondenceType.sar.id
         end
         expect(sar_tcr).to match_tcr_attrs(:sar, :view, :respond)
+
+        osar_tcr = bu.correspondence_type_roles.detect do |r|
+          r.correspondence_type_id == CorrespondenceType.offender_sar.id
+        end
+        expect(osar_tcr).to match_tcr_attrs(:offender_sar, :view, :respond)
 
         ico_tcr = bu.correspondence_type_roles.detect do |r|
           r.correspondence_type_id == CorrespondenceType.ico.id

--- a/spec/features/cases/osar/case_creating_spec.rb
+++ b/spec/features/cases/osar/case_creating_spec.rb
@@ -4,12 +4,12 @@ feature 'Offender SAR Case creation by a manager' do
 
   given(:responder)       { find_or_create(:foi_responder) }
   given(:responding_team) { create :responding_team, responders: [responder] }
-  given(:manager)         { find_or_create :disclosure_bmt_user }
+  given(:manager)         { find_or_create :branston_user }
   given(:managing_team)   { create :managing_team, managers: [manager] }
 
   background do
     responding_team
-    find_or_create :team_dacu_disclosure
+    find_or_create :team_branston
     login_as manager
     cases_page.load
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe User, type: :model do
   let(:sar)             { create(:sar_correspondence_type) }
   let(:overturned_sar)  { create(:overturned_sar_correspondence_type) }
   let(:overturned_foi)  { create(:overturned_foi_correspondence_type) }
+  let(:offender_sar)    { create(:offender_sar_correspondence_type) }
 
   describe '#manager?' do
     it 'returns true for a manager' do
@@ -238,21 +239,28 @@ RSpec.describe User, type: :model do
   describe '#permitted_correspondence_types' do
     it 'returns any correspondence types associated with users teams' do
       expect(manager.permitted_correspondence_types)
-        .to match_array([foi, ico, sar, overturned_foi, overturned_sar])
+        .to match_array([foi, ico, sar, overturned_foi, overturned_sar, offender_sar])
     end
 
     it 'does not include SAR if that feature is disabled' do
       disable_feature(:sars)
 
       expect(manager.permitted_correspondence_types)
-        .to match_array([foi, ico, overturned_foi])
+        .to match_array([foi, ico, overturned_foi, offender_sar])
     end
 
     it 'does not include ICO if that feature is disabled' do
       disable_feature(:ico)
 
       expect(manager.permitted_correspondence_types)
-        .to match_array([foi, sar, overturned_foi, overturned_sar])
+        .to match_array([foi, sar, overturned_foi, overturned_sar, offender_sar])
+    end
+
+    it 'does not include Offender SAR if that feature is disabled' do
+      disable_feature(:offender_sars)
+
+      expect(manager.permitted_correspondence_types)
+        .to match_array([foi, ico, sar, overturned_foi, overturned_sar])
     end
   end
 


### PR DESCRIPTION
In the previous work, I'd added in a Correspondence Type for Offender SAR and manually added it to the list of new case types for every user, provided the feature flag was turned on. 

Now we're still respecting the feature flag, but I've also set up a basic team and user in the developer seeds so that we can log in as a Branston user. 

Credentials are for Brian Rix (i.e. Branston Registry user)
correspondence-staff-dev+brian.rix@digital.justice.gov.uk

## Jira Ticket
https://dsdmoj.atlassian.net/browse/CT-2323