### PR TITLE
CT-2280 Add data migration for offender-sar correspondence type

### DIFF
--- a/db/data_migrations/20190517132128_add_offender_sar_correspondence_type.rb
+++ b/db/data_migrations/20190517132128_add_offender_sar_correspondence_type.rb
@@ -1,0 +1,15 @@
+class AddOffenderSarCorrespondenceType < ActiveRecord::DataMigration
+  def up
+    CorrespondenceType.create!(
+      name:                       'Offender SAR',
+      abbreviation:               'OFFENDER_SAR',
+      internal_time_limit:        10,
+      external_time_limit:        30,
+      escalation_time_limit:      3,
+      deadline_calculator_class:  'CalendarDays',
+      default_private_officer:    "correspondence-staff-dev+primrose.offord@digital.justice.gov.uk",
+      default_press_officer:      "correspondence-staff-dev+preston.offman@digital.justice.gov.uk",
+      report_category_name:       'Offender SAR report'
+    )
+  end
+end

--- a/db/migrate/20190326113949_add_unique_index_to_user_case_transition_tracker.rb
+++ b/db/migrate/20190326113949_add_unique_index_to_user_case_transition_tracker.rb
@@ -4,7 +4,7 @@ class AddUniqueIndexToUserCaseTransitionTracker < ActiveRecord::Migration[5.0]
     # rather than repeatedly CT-2151
     change_table :cases_users_transitions_trackers do |t|
       # add timestamps late to the party - so they have to be nullable
-      t.timestamps null: false
+      t.timestamps null: true
       t.index [:case_id, :user_id], unique: true
     end
   end


### PR DESCRIPTION
Add data migration for offender-sar correspondence type 
Also, fix issue preventing migrations from proceeding