### PR TITLE
CT-2342 assign new case to branston

### DIFF
--- a/app/models/business_unit.rb
+++ b/app/models/business_unit.rb
@@ -110,6 +110,10 @@ class BusinessUnit < Team
     code == Settings.foi_cases.default_managing_team
   end
 
+  def self.dacu_branston
+    find_by!(code: Settings.offender_sar_cases.default_managing_team)
+  end
+
   def self.press_office
     find_by!(code: Settings.press_office_team_code)
   end

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -759,6 +759,10 @@ class Case::Base < ApplicationRecord
   def overturned_ico_sar?;  false;  end
   def overturned_ico_foi?;  false;  end
 
+  def default_managing_team
+    BusinessUnit.dacu_bmt
+  end
+
   private
 
   def identifier
@@ -847,7 +851,7 @@ class Case::Base < ApplicationRecord
 
   def set_managing_team
     # For now, we just automatically assign cases to DACU.
-    self.managing_team = BusinessUnit.dacu_bmt
+    self.managing_team = self.default_managing_team
     self.managing_assignment.state = 'accepted'
   end
 

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -80,4 +80,8 @@ class Case::SAR::Offender < Case::Base
     end
     errors[:date_of_birth].any?
   end
+
+  def default_managing_team
+    BusinessUnit.find_by!(code: Settings.offender_sar_cases.default_managing_team)
+  end
 end

--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -1,6 +1,2 @@
 class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
-  # @todo (mseedat-moj): Allow all users to view Offender SAR during MVP dev
-  def show?
-    clear_failed_checks
-  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -53,6 +53,9 @@ overturned_foi_cases:
 overturned_sar_cases:
   default_managing_team: DISCLOSURE-BMT
   default_clearance_team: DISCLOSURE
+offender_sar_cases:
+  default_managing_team: BRANSTON
+  default_clearance_team: BRANSTON
 
 pit_extension_limit: 20
 sar_extension_limit: 60

--- a/db/seeders/dev_team_seeder.rb
+++ b/db/seeders/dev_team_seeder.rb
@@ -100,7 +100,8 @@ class DevTeamSeeder
     @bu_branston  = find_or_create_business_unit(parent: @dir_dacu,
                                                  name: 'Branston Registry',
                                                  role: 'manager',
-                                                 correspondence_type_ids: [@offender.id])
+                                                 correspondence_type_ids: [@offender.id],
+                                                 code: 'BRANSTON')
   end
   #rubocop:enable Metrics/MethodLength
 

--- a/spec/factories/business_units.rb
+++ b/spec/factories/business_units.rb
@@ -114,6 +114,7 @@ FactoryBot.define do
   factory :team_branston, parent: :managing_team do
     name { 'Branston Registry' }
     email { 'branston@localhost' }
+    code { 'BRANSTON' }
     directorate { find_or_create :dacu_directorate }
     managers { [find_or_create(:branston_user, :orphan)] }
   end

--- a/spec/models/business_unit_spec.rb
+++ b/spec/models/business_unit_spec.rb
@@ -104,12 +104,14 @@ RSpec.describe BusinessUnit, type: :model do
 
   context 'multiple teams created' do
     let(:managing_team)       { find_or_create :team_dacu }
+    let(:branston_team)       { find_or_create :team_branston }
     let(:approving_team)      { find_or_create :approving_team }
 
     describe 'managing scope' do
       it 'returns only managing teams' do
         expect(BusinessUnit.managing).to match_array [
-                                           managing_team
+                                           managing_team,
+                                           branston_team
                                          ]
       end
     end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Team, type: :model do
 
   context 'multiple teams created' do
     let!(:managing_team)       { find_or_create :team_disclosure_bmt }
+    let!(:branston_team)       { find_or_create :team_branston }
     let!(:responding_team)     { find_or_create :foi_responding_team }
     let!(:sar_responding_team) { find_or_create :sar_responding_team }
     let!(:approving_team)      { find_or_create :team_disclosure }
@@ -60,7 +61,8 @@ RSpec.describe Team, type: :model do
     describe 'managing scope' do
       it 'returns managing teams' do
         expect(BusinessUnit.managing).to match_array [
-                                           managing_team
+                                           managing_team,
+                                           branston_team
                                          ]
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -198,6 +198,7 @@ def seed_database_for_tests
   FactoryBot.find_or_create :sar_correspondence_type
   FactoryBot.find_or_create :offender_sar_correspondence_type
   FactoryBot.find_or_create :team_dacu
+  FactoryBot.find_or_create :team_branston
   FactoryBot.find_or_create :ico_correspondence_type
   FactoryBot.find_or_create :overturned_sar_correspondence_type
   FactoryBot.find_or_create :overturned_foi_correspondence_type

--- a/spec/services/stats/r006_kilo_map_spec.rb
+++ b/spec/services/stats/r006_kilo_map_spec.rb
@@ -10,19 +10,24 @@ module Stats
       dacu_disclosure = BusinessUnit.dacu_disclosure
       dacu_disclosure.users.map(&:destroy)
       dacu_disclosure.team_lead = 'Jeremy Corbyn'
+      dacu_branston = BusinessUnit.dacu_branston
+      dacu_branston.users.map(&:destroy)
+      dacu_disclosure.team_lead = 'David Gauke'
+
 
       create :manager, full_name: 'Theresa May', email: 'tm@pm.gov.uk', managing_teams: [dacu_disclosure]
       create :manager, full_name: 'David Cameron', email: 'dc@pm.gov.uk', managing_teams: [dacu_disclosure]
       create :manager, full_name: 'Gordon Brown', email: 'gb@pm.gov.uk', managing_teams: [dacu_disclosure]
+      create :manager, full_name: 'David Gauke', email: 'dg@pm.gov.uk', managing_teams: [dacu_branston]
 
       map = R006KiloMap.new
       map.run
 
       csv_lines = map.to_csv.map { |row| row.map(&:value) }
-
       expect(csv_lines.shift).to eq header_line.split(',')
       expect(CSV.generate_line(csv_lines.shift).chomp).to match operations_line
       expect(CSV.generate_line(csv_lines.shift).chomp).to match dacu_directorate_line
+      expect(CSV.generate_line(csv_lines.shift).chomp).to match disclosure_line_0
       expect(CSV.generate_line(csv_lines.shift).chomp).to eq disclosure_line_1
       expect(CSV.generate_line(csv_lines.shift).chomp).to eq disclosure_line_2
       expect(CSV.generate_line(csv_lines.shift).chomp).to eq disclosure_line_3
@@ -46,8 +51,12 @@ module Stats
       /"",DACU Directorate,"",Director \d{1,5}/
     end
 
+    def disclosure_line_0
+      /"","",Branston Registry,Deputy Director \d{1,5},Hammersmith,branston@localhost/
+    end
+
     def disclosure_line_1
-      %{"","",Disclosure,Jeremy Corbyn,Hammersmith,dacu.disclosure@localhost,David Cameron,dc@pm.gov.uk}
+      %{"","",Disclosure,David Gauke,Hammersmith,dacu.disclosure@localhost,David Cameron,dc@pm.gov.uk}
     end
 
     def disclosure_line_2

--- a/spec/support/features/steps/cases/create_steps.rb
+++ b/spec/support/features/steps/cases/create_steps.rb
@@ -103,9 +103,13 @@ def create_offender_sar_case_step(params = {})
   cases_new_offender_sar_date_received_page.fill_in_case_details(params)
 
   click_on "Continue"
-  # commented out next expectation while team assignment issue is getting fixed
-  # expect(cases_show_page).to be_displayed
-  # expect(cases_show_page).to have_content "Case created successfully"
+
+  expect(cases_show_page).to be_displayed
+  expect(cases_show_page).to have_content "Case created successfully"
+  click_on "All open cases"
+
+  expect(cases_page).to be_displayed
+  expect(cases_page).to have_content "Branston Registry"
 end
 
 

--- a/spec/support/features/steps/cases/create_steps.rb
+++ b/spec/support/features/steps/cases/create_steps.rb
@@ -101,14 +101,13 @@ def create_offender_sar_case_step(params = {})
   expect(cases_new_offender_sar_date_received_page).to be_displayed
 
   cases_new_offender_sar_date_received_page.fill_in_case_details(params)
-
   click_on "Continue"
 
   expect(cases_show_page).to be_displayed
   expect(cases_show_page).to have_content "Case created successfully"
   click_on "All open cases"
 
-  expect(cases_page).to be_displayed
+  expect(open_cases_page).to be_displayed
   expect(cases_page).to have_content "Branston Registry"
 end
 


### PR DESCRIPTION
New Offender SAR cases got wired up to Disclosure BMT to start with, like every other case type. Which distressingly meant that you couldn't view a case you'd just created when logged in as a Branston user. Now amended so that everything else still defaults to the normal way, but giving cases the ability to specify an alternative default. 

## Deployment note
We need to add a code to the Branston team for this to work - probably need to add a data migration to ensure the Branston team is there and set the `code` field to BRANSTON