### PR TITLE
CT-2236 Allow Show Offender SAR for all users

### DIFF
--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -1,2 +1,6 @@
 class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
+  # @todo (mseedat-moj): Allow all users to view Offender SAR during MVP dev
+  def show?
+    clear_failed_checks
+  end
 end


### PR DESCRIPTION
### Summary
During testing all logged in users can see Offender SARS. This is necessary during the pre-workflow state and permissions stage of development.