### PR TITLE
CT-2366 Amend FoiController to allow non-selection of FOI Type

### DIFF
--- a/app/controllers/cases/foi_controller.rb
+++ b/app/controllers/cases/foi_controller.rb
@@ -16,7 +16,9 @@ module Cases
     end
 
     def case_type
-      Case::FOI::Standard.factory(params.dig(@correspondence_type_key, 'type'))
+      foi_type = params.dig(@correspondence_type_key, 'type')
+      return Case::FOI::Standard if foi_type.blank?
+      Case::FOI::Standard.factory(foi_type)
     end
 
     def create_params

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -285,7 +285,12 @@ module CasesHelper
     user.manager? && kase.closed? && !kase.allow_event?(user, :update_closure)
   end
 
+  # Note use of Case::FOI::Standard for Timeliness/ComplianceReview FOI cases
   def case_create_action(kase)
-    self.send("#{kase.model_name.singular}_index_path")
+    if kase.foi?
+      self.send("case_foi_standard_index_path")
+    else
+      self.send("#{kase.model_name.singular}_index_path")
+    end
   end
 end

--- a/app/models/case/foi/standard.rb
+++ b/app/models/case/foi/standard.rb
@@ -127,7 +127,7 @@ class Case::FOI::Standard < Case::Base
   end
 
   def self.factory(type)
-    case type&.downcase
+    case type&.demodulize&.downcase
     when 'standard'
       self
     when 'timelinessreview'

--- a/app/models/case/foi/standard.rb
+++ b/app/models/case/foi/standard.rb
@@ -127,7 +127,7 @@ class Case::FOI::Standard < Case::Base
   end
 
   def self.factory(type)
-    case type&.demodulize&.downcase
+    case type&.downcase
     when 'standard'
       self
     when 'timelinessreview'

--- a/app/views/cases/foi/_new.html.slim
+++ b/app/views/cases/foi/_new.html.slim
@@ -1,7 +1,7 @@
 = render partial: 'layouts/header'
 
 = form_for kase, as: :foi, url: case_create_action(kase.object) do |f|
-  = f.radio_button_fieldset(:type, choices: @case_types, value_method: :to_s)
+  = f.radio_button_fieldset(:type, choices: @case_types, value_method: :demodulize)
 
   = render partial: 'cases/foi/new_form_common', locals: { f: f }
   = render partial: 'cases/foi/new_form_details', locals: { f: f }

--- a/app/views/cases/foi/_new.html.slim
+++ b/app/views/cases/foi/_new.html.slim
@@ -1,9 +1,8 @@
 = render partial: 'layouts/header'
 
 = form_for kase, as: :foi, url: case_create_action(kase.object) do |f|
-  = f.radio_button_fieldset :type,
-                            choices: @case_types,
-                            value_method: :demodulize
+  = f.radio_button_fieldset(:type, choices: @case_types, value_method: :to_s)
+
   = render partial: 'cases/foi/new_form_common', locals: { f: f }
   = render partial: 'cases/foi/new_form_details', locals: { f: f }
 

--- a/spec/controllers/cases/foi_controller_spec.rb
+++ b/spec/controllers/cases/foi_controller_spec.rb
@@ -148,6 +148,20 @@ RSpec.describe Cases::FoiController, type: :controller do
           assert_raises { post :create, params: invalid_foi_params }
         end
       end
+
+      context 'with missing FOI type' do
+        let(:invalid_foi_params) {
+          foi_params.tap do |p|
+            p[:foi][:type] = ''
+            p[:foi][:name] = 'A Standard FOI'
+          end
+        }
+
+        it 'defaults to FOI Standard' do
+          post :create, params: invalid_foi_params
+          expect(Case::FOI::Standard.last.name).to eq 'A Standard FOI'
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Description
Fixes 3 bugs/issues:
1. If during FOI creation, user does not select an FOI type and presses 'Save', the page will refresh without throwing an exception
3. Issue with ComplianceReview/TimelinessReview type creation resolved
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2366
 
### Manual testing instructions
1. Log in as any user
2. Click 'Create Case' and select 'FOI'
3. Try saving without entering any details at all

