### PR TITLE
CT-2238 workflow states

### DIFF
--- a/app/controllers/cases/case_transitions_controller.rb
+++ b/app/controllers/cases/case_transitions_controller.rb
@@ -4,26 +4,40 @@ module Cases
     before_action :set_date_of_birth_instance_var, except: []
 
     def mark_as_waiting_for_data
-      @case.state_machine.mark_as_waiting_for_data!(acting_user: current_user, acting_team: current_user.managing_teams.first)
+      @case.state_machine.mark_as_waiting_for_data!(params_for_transition)
       reload_case_page_on_success
     end
 
     def mark_as_ready_for_vetting
+      @case.state_machine.mark_as_ready_for_vetting!(params_for_transition)
+      reload_case_page_on_success
     end
 
     def mark_as_vetting_in_progress
+      @case.state_machine.mark_as_vetting_in_progress!(params_for_transition)
+      reload_case_page_on_success
     end
 
     def mark_as_ready_to_dispatch
+      @case.state_machine.mark_as_ready_to_dispatch!(params_for_transition)
+      reload_case_page_on_success
     end
 
     def mark_as_ready_to_close
+      @case.state_machine.mark_as_ready_to_close!(params_for_transition)
+      reload_case_page_on_success
     end
 
     def mark_as_closed
+      @case.state_machine.mark_as_closed!(params_for_transition)
+      reload_case_page_on_success
     end
 
     private
+
+    def params_for_transition
+      {acting_user: current_user, acting_team: current_user.managing_teams.first}
+    end
 
     def set_case
       @case = Case::Base.find(params[:id])

--- a/app/controllers/cases/case_transitions_controller.rb
+++ b/app/controllers/cases/case_transitions_controller.rb
@@ -4,7 +4,7 @@ module Cases
       @case = Case::Base.find(params[:case_id])
       authorize @case
 
-      if @case.state_machine.mark_as_next_state!(acting_user: current_user, acting_team: current_user.managing_teams.first)
+      if @case.state_machine.mark_as_waiting_for_data!(acting_user: current_user, acting_team: current_user.managing_teams.first)
         redirect_to(case_path(@case))
       end
     end

--- a/app/controllers/cases/case_transitions_controller.rb
+++ b/app/controllers/cases/case_transitions_controller.rb
@@ -1,12 +1,45 @@
 module Cases
   class CaseTransitionsController < CasesController
-    def create
-      @case = Case::Base.find(params[:case_id])
-      authorize @case
+    before_action :set_case, except: []
+    before_action :set_date_of_birth_instance_var, except: []
 
-      if @case.state_machine.mark_as_waiting_for_data!(acting_user: current_user, acting_team: current_user.managing_teams.first)
-        redirect_to(case_path(@case))
-      end
+    def mark_as_waiting_for_data
+      @case.state_machine.mark_as_waiting_for_data!(acting_user: current_user, acting_team: current_user.managing_teams.first)
+      reload_case_page_on_success
+    end
+
+    def mark_as_ready_for_vetting
+    end
+
+    def mark_as_vetting_in_progress
+    end
+
+    def mark_as_ready_to_dispatch
+    end
+
+    def mark_as_ready_to_close
+    end
+
+    def mark_as_closed
+    end
+
+    private
+
+    def set_case
+      @case = Case::Base.find(params[:id])
+      authorize @case
+    end
+
+    def reload_case_page_on_success
+      flash[:notice] = t('cases.update.case_updated')
+      redirect_to case_path(@case)
+    end
+
+    # this method is here to fix an issue with the gov_uk_date_fields
+    # where the validation fails since the internal list of instance
+    # variables lacks the date_of_birth field from the json properties
+    def set_date_of_birth_instance_var
+      @case.date_of_birth = @case.date_of_birth
     end
   end
 end

--- a/app/controllers/cases/case_transitions_controller.rb
+++ b/app/controllers/cases/case_transitions_controller.rb
@@ -2,8 +2,9 @@ module Cases
   class CaseTransitionsController < CasesController
     def create
       @case = Case::Base.find(params[:case_id])
-      # authorize @case
+      authorize @case
 
+      @case.state_machine.mark_as_waiting_for_data!(acting_user: current_user, acting_team: current_user.managing_teams.first)
     end
   end
 end

--- a/app/controllers/cases/case_transitions_controller.rb
+++ b/app/controllers/cases/case_transitions_controller.rb
@@ -18,13 +18,13 @@ module Cases
       reload_case_page_on_success
     end
 
-    def mark_as_ready_to_dispatch
-      @case.state_machine.mark_as_ready_to_dispatch!(params_for_transition)
+    def mark_as_ready_to_copy
+      @case.state_machine.mark_as_ready_to_copy!(params_for_transition)
       reload_case_page_on_success
     end
 
-    def mark_as_ready_to_close
-      @case.state_machine.mark_as_ready_to_close!(params_for_transition)
+    def mark_as_ready_to_dispatch
+      @case.state_machine.mark_as_ready_to_dispatch!(params_for_transition)
       reload_case_page_on_success
     end
 

--- a/app/controllers/cases/case_transitions_controller.rb
+++ b/app/controllers/cases/case_transitions_controller.rb
@@ -52,6 +52,8 @@ module Cases
     # this method is here to fix an issue with the gov_uk_date_fields
     # where the validation fails since the internal list of instance
     # variables lacks the date_of_birth field from the json properties
+    #     NoMethodError: undefined method `valid?' for nil:NilClass
+    #     ./app/state_machines/configurable_state_machine/machine.rb:256
     def set_date_of_birth_instance_var
       @case.date_of_birth = @case.date_of_birth
     end

--- a/app/controllers/cases/case_transitions_controller.rb
+++ b/app/controllers/cases/case_transitions_controller.rb
@@ -1,0 +1,9 @@
+module Cases
+  class CaseTransitionsController < CasesController
+    def create
+      @case = Case::Base.find(params[:case_id])
+      # authorize @case
+
+    end
+  end
+end

--- a/app/controllers/cases/case_transitions_controller.rb
+++ b/app/controllers/cases/case_transitions_controller.rb
@@ -4,7 +4,9 @@ module Cases
       @case = Case::Base.find(params[:case_id])
       authorize @case
 
-      @case.state_machine.mark_as_waiting_for_data!(acting_user: current_user, acting_team: current_user.managing_teams.first)
+      if @case.state_machine.mark_as_next_state!(acting_user: current_user, acting_team: current_user.managing_teams.first)
+        redirect_to(case_path(@case))
+      end
     end
   end
 end

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -32,34 +32,40 @@ module CasesHelper
     case event
     when :mark_as_waiting_for_data
       link_to "Mark as waiting for data",
-              new_case_assignment_path(@case),
+              case_case_transitions_path(@case),
               id: 'action--mark-as-waiting-for-data',
-              class: 'button'
+              class: 'button',
+              method: 'post'
     when :mark_as_ready_for_vetting
       link_to "Mark as ready for vetting",
-              new_case_assignment_path(@case),
+              case_case_transitions_path(@case),
               id: 'action--mark-as-ready-for-vetting',
-              class: 'button'
+              class: 'button',
+              method: 'post'
     when :mark_as_vetting_in_progress
       link_to "Mark as vetting in progress",
-              new_case_assignment_path(@case),
+              case_case_transitions_path(@case),
               id: 'action--mark-as-vetting-in-progress',
-              class: 'button'
+              class: 'button',
+              method: 'post'
     when :mark_as_ready_to_dispatch
       link_to "Mark as ready to dispatch",
-              new_case_assignment_path(@case),
+              case_case_transitions_path(@case),
               id: 'action--mark-as-ready-to-dispatch',
-              class: 'button'
+              class: 'button',
+              method: 'post'
     when :mark_as_ready_to_close
       link_to "Mark as ready to close",
-              new_case_assignment_path(@case),
+              case_case_transitions_path(@case),
               id: 'action--mark-as-ready-to-close',
-              class: 'button'
+              class: 'button',
+              method: 'post'
     when :mark_as_closed
       link_to "Mark as closed",
-              new_case_assignment_path(@case),
+              case_case_transitions_path(@case),
               id: 'action--mark-as-closed',
-              class: 'button'
+              class: 'button',
+              method: 'post'
     when :assign_responder
       link_to I18n.t('common.case.assign'),
               new_case_assignment_path(@case),

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -32,37 +32,37 @@ module CasesHelper
     case event
     when :mark_as_waiting_for_data
       link_to "Mark as waiting for data",
-              case_case_transitions_path(@case),
+              mark_as_waiting_for_data_case_path(@case),
               id: 'action--mark-as-waiting-for-data',
               class: 'button',
-              method: 'post'
-    when :mark_as_ready_for_vetting
+              method: 'patch'
+    when :waiting_for_data
       link_to "Mark as ready for vetting",
-              case_case_transitions_path(@case),
+              mark_as_ready_for_vetting_path(@case),
               id: 'action--mark-as-ready-for-vetting',
               class: 'button',
               method: 'post'
-    when :mark_as_vetting_in_progress
+    when :ready_for_vetting
       link_to "Mark as vetting in progress",
-              case_case_transitions_path(@case),
+              mark_as_vetting_in_progress_path(@case),
               id: 'action--mark-as-vetting-in-progress',
               class: 'button',
               method: 'post'
-    when :mark_as_ready_to_dispatch
+    when :vetting_in_progress
       link_to "Mark as ready to dispatch",
-              case_case_transitions_path(@case),
+              mark_as_ready_to_dispatch_path(@case),
               id: 'action--mark-as-ready-to-dispatch',
               class: 'button',
               method: 'post'
-    when :mark_as_ready_to_close
+    when :ready_to_dispatch
       link_to "Mark as ready to close",
-              case_case_transitions_path(@case),
+              mark_as_ready_to_close_path(@case),
               id: 'action--mark-as-ready-to-close',
               class: 'button',
               method: 'post'
-    when :mark_as_closed
+    when :ready_to_close
       link_to "Mark as closed",
-              case_case_transitions_path(@case),
+              mark_as_closed_path(@case),
               id: 'action--mark-as-closed',
               class: 'button',
               method: 'post'

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -48,16 +48,16 @@ module CasesHelper
               id: 'action--mark-as-vetting-in-progress',
               class: 'button',
               method: 'patch'
+    when :mark_as_ready_to_copy
+      link_to "Mark as ready to copy",
+              mark_as_ready_to_copy_case_path(@case),
+              id: 'action--mark-as-ready-to-copy',
+              class: 'button',
+              method: 'patch'
     when :mark_as_ready_to_dispatch
       link_to "Mark as ready to dispatch",
               mark_as_ready_to_dispatch_case_path(@case),
               id: 'action--mark-as-ready-to-dispatch',
-              class: 'button',
-              method: 'patch'
-    when :mark_as_ready_to_close
-      link_to "Mark as ready to close",
-              mark_as_ready_to_close_case_path(@case),
-              id: 'action--mark-as-ready-to-close',
               class: 'button',
               method: 'patch'
     when :mark_as_closed

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -36,36 +36,36 @@ module CasesHelper
               id: 'action--mark-as-waiting-for-data',
               class: 'button',
               method: 'patch'
-    when :waiting_for_data
+    when :mark_as_ready_for_vetting
       link_to "Mark as ready for vetting",
-              mark_as_ready_for_vetting_path(@case),
+              mark_as_ready_for_vetting_case_path(@case),
               id: 'action--mark-as-ready-for-vetting',
               class: 'button',
-              method: 'post'
-    when :ready_for_vetting
+              method: 'patch'
+    when :mark_as_vetting_in_progress
       link_to "Mark as vetting in progress",
-              mark_as_vetting_in_progress_path(@case),
+              mark_as_vetting_in_progress_case_path(@case),
               id: 'action--mark-as-vetting-in-progress',
               class: 'button',
-              method: 'post'
-    when :vetting_in_progress
+              method: 'patch'
+    when :mark_as_ready_to_dispatch
       link_to "Mark as ready to dispatch",
-              mark_as_ready_to_dispatch_path(@case),
+              mark_as_ready_to_dispatch_case_path(@case),
               id: 'action--mark-as-ready-to-dispatch',
               class: 'button',
-              method: 'post'
-    when :ready_to_dispatch
+              method: 'patch'
+    when :mark_as_ready_to_close
       link_to "Mark as ready to close",
-              mark_as_ready_to_close_path(@case),
+              mark_as_ready_to_close_case_path(@case),
               id: 'action--mark-as-ready-to-close',
               class: 'button',
-              method: 'post'
-    when :ready_to_close
+              method: 'patch'
+    when :mark_as_closed
       link_to "Mark as closed",
-              mark_as_closed_path(@case),
+              mark_as_closed_case_path(@case),
               id: 'action--mark-as-closed',
               class: 'button',
-              method: 'post'
+              method: 'patch'
     when :assign_responder
       link_to I18n.t('common.case.assign'),
               new_case_assignment_path(@case),

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -30,6 +30,36 @@ module CasesHelper
   #rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
   def action_button_for(event)
     case event
+    when :mark_as_waiting_for_data
+      link_to "Mark as waiting for data",
+              new_case_assignment_path(@case),
+              id: 'action--mark-as-waiting-for-data',
+              class: 'button'
+    when :mark_as_ready_for_vetting
+      link_to "Mark as ready for vetting",
+              new_case_assignment_path(@case),
+              id: 'action--mark-as-ready-for-vetting',
+              class: 'button'
+    when :mark_as_vetting_in_progress
+      link_to "Mark as vetting in progress",
+              new_case_assignment_path(@case),
+              id: 'action--mark-as-vetting-in-progress',
+              class: 'button'
+    when :mark_as_ready_to_dispatch
+      link_to "Mark as ready to dispatch",
+              new_case_assignment_path(@case),
+              id: 'action--mark-as-ready-to-dispatch',
+              class: 'button'
+    when :mark_as_ready_to_close
+      link_to "Mark as ready to close",
+              new_case_assignment_path(@case),
+              id: 'action--mark-as-ready-to-close',
+              class: 'button'
+    when :mark_as_closed
+      link_to "Mark as closed",
+              new_case_assignment_path(@case),
+              id: 'action--mark-as-closed',
+              class: 'button'
     when :assign_responder
       link_to I18n.t('common.case.assign'),
               new_case_assignment_path(@case),

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -1,6 +1,6 @@
 require './lib/translate_for_case'
 
-module CasesHelper
+module CasesHelper #rubocop:disable Metrics/ModuleLength
 
   def download_csv_link(full_path)
     uri = URI(full_path)

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -84,4 +84,8 @@ class Case::SAR::Offender < Case::Base
   def default_managing_team
     BusinessUnit.find_by!(code: Settings.offender_sar_cases.default_managing_team)
   end
+
+  def current_team_and_user_resolver
+    CurrentTeamAndUser::SAR::Offender.new(self)
+  end
 end

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -5,7 +5,13 @@ class Case::SAR::Offender < Case::Base
     end
 
     def searchable_fields_and_ranks
-      super.merge({ subject_full_name: 'B'})
+      super.merge({
+        subject_full_name: 'A',
+        prison_number: 'B',
+        previous_case_numbers: 'B',
+        subject_aliases: 'B',
+        other_subject_ids: 'B'
+      })
     end
   end
 

--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -1,2 +1,7 @@
 class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
+  def create?
+    clear_failed_checks
+    check_can_trigger_event(:mark_as_waiting_for_data) &&
+      check_user_is_a_manager_for_case
+  end
 end

--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -19,12 +19,12 @@ class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
     check_user_is_a_manager
   end
 
-  def mark_as_ready_to_dispatch?
+  def mark_as_ready_to_copy?
     clear_failed_checks
     check_user_is_a_manager
   end
 
-  def mark_as_ready_to_close?
+  def mark_as_ready_to_dispatch?
     clear_failed_checks
     check_user_is_a_manager
   end

--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -1,7 +1,6 @@
 class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
   def create?
     clear_failed_checks
-    check_can_trigger_event(:mark_as_waiting_for_data) &&
-      check_user_is_a_manager_for_case
+    check_user_is_a_manager
   end
 end

--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -3,4 +3,8 @@ class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
     clear_failed_checks
     check_user_is_a_manager
   end
+
+  def mark_as_waiting_for_data?
+    true
+  end
 end

--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -5,6 +5,32 @@ class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
   end
 
   def mark_as_waiting_for_data?
-    true
+    clear_failed_checks
+    check_user_is_a_manager
+  end
+
+  def mark_as_ready_for_vetting?
+    clear_failed_checks
+    check_user_is_a_manager
+  end
+
+  def mark_as_vetting_in_progress?
+    clear_failed_checks
+    check_user_is_a_manager
+  end
+
+  def mark_as_ready_to_dispatch?
+    clear_failed_checks
+    check_user_is_a_manager
+  end
+
+  def mark_as_ready_to_close?
+    clear_failed_checks
+    check_user_is_a_manager
+  end
+
+  def mark_as_closed?
+    clear_failed_checks
+    check_user_is_a_manager
   end
 end

--- a/app/services/current_team_and_user/sar/offender.rb
+++ b/app/services/current_team_and_user/sar/offender.rb
@@ -28,17 +28,12 @@ module CurrentTeamAndUser
         @user = nil
       end
 
+      def ready_to_copy
+        @team = @case.managing_team
+        @user = nil
+      end
+
       def ready_to_dispatch
-        @team = @case.managing_team
-        @user = nil
-      end
-
-      def ready_to_close
-        @team = @case.managing_team
-        @user = nil
-      end
-
-      def wibble
         @team = @case.managing_team
         @user = nil
       end

--- a/app/services/current_team_and_user/sar/offender.rb
+++ b/app/services/current_team_and_user/sar/offender.rb
@@ -1,0 +1,52 @@
+module CurrentTeamAndUser
+  module SAR
+    class Offender
+      attr_reader :team, :user
+
+      def initialize(kase)
+        @case = kase
+        @dts = DefaultTeamService.new(@case)
+      end
+
+      def data_to_be_requested
+        @team = @case.managing_team
+        @user = nil
+      end
+
+      def waiting_for_data
+        @team = @case.managing_team
+        @user = nil
+      end
+
+      def ready_for_vetting
+        @team = @case.managing_team
+        @user = nil
+      end
+
+      def vetting_in_progress
+        @team = @case.managing_team
+        @user = nil
+      end
+
+      def ready_to_dispatch
+        @team = @case.managing_team
+        @user = nil
+      end
+
+      def ready_to_close
+        @team = @case.managing_team
+        @user = nil
+      end
+
+      def wibble
+        @team = @case.managing_team
+        @user = nil
+      end
+
+      def closed
+        @team = @case.managing_team
+        @user = nil
+      end
+    end
+  end
+end

--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -248,7 +248,6 @@ module ConfigurableStateMachine
       event_config = state_config[event]
       if can_trigger_event?(event_name: event, metadata: params)
         ActiveRecord::Base.transaction do
-          # binding.pry()
           to_state = find_destination_state(event_config: event_config, user: user)
           to_workflow = find_destination_workflow(event_config: event_config, user: user)
           CaseTransition.unset_most_recent(@kase)

--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -248,6 +248,7 @@ module ConfigurableStateMachine
       event_config = state_config[event]
       if can_trigger_event?(event_name: event, metadata: params)
         ActiveRecord::Base.transaction do
+          # binding.pry()
           to_state = find_destination_state(event_config: event_config, user: user)
           to_workflow = find_destination_workflow(event_config: event_config, user: user)
           CaseTransition.unset_most_recent(@kase)

--- a/config/locales/event.en.yml
+++ b/config/locales/event.en.yml
@@ -38,3 +38,9 @@ en:
     upload_response_approve_and_bypass: Response uploaded and cleared - further clearance not required
     case/ico:
       respond: Response sent to ICO
+    mark_as_waiting_for_data: Marked as waiting for data
+    mark_as_ready_for_vetting: Marked as ready for vetting
+    mark_as_vetting_in_progress: Marked as vetting in progress
+    mark_as_ready_to_dispatch: Marked as ready to dispatch
+    mark_as_ready_to_close: Marked as ready to close
+    mark_as_closed:  Marked as closed

--- a/config/locales/event.en.yml
+++ b/config/locales/event.en.yml
@@ -41,6 +41,6 @@ en:
     mark_as_waiting_for_data: Marked as waiting for data
     mark_as_ready_for_vetting: Marked as ready for vetting
     mark_as_vetting_in_progress: Marked as vetting in progress
+    mark_as_ready_to_copy: Marked as ready to copy
     mark_as_ready_to_dispatch: Marked as ready to dispatch
-    mark_as_ready_to_close: Marked as ready to close
     mark_as_closed:  Marked as closed

--- a/config/locales/state.en.yml
+++ b/config/locales/state.en.yml
@@ -19,6 +19,6 @@ en:
       waiting_for_data: Waiting for data
       ready_for_vetting: Ready for vetting
       vetting_in_progress: Vetting in progress
+      ready_to_copy: Ready to copy
       ready_to_dispatch: Ready to dispatch
-      ready_to_close: Ready to close
       closed: Closed

--- a/config/locales/state.en.yml
+++ b/config/locales/state.en.yml
@@ -14,3 +14,11 @@ en:
       awaiting_dispatch: Ready to send to ICO
       responded: Closed - awaiting ICO decision
       closed: "Closed - %{ico_decision} by ICO"
+    case/sar/offender:
+      data_to_be_requested: Data to be requested
+      waiting_for_data: Waiting for data
+      ready_for_vetting: Ready for vetting
+      vetting_in_progress: Vetting in progress
+      ready_to_dispatch: Ready to dispatch
+      ready_to_close: Ready to close
+      closed: Closed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,8 @@ Rails.application.routes.draw do
       patch :progress_for_clearance
       patch :flag_for_clearance
     end
+
+    resources :case_transitions, only: [:create]
   end
 
   # Case Behaviours (awaiting move to module Cases)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,8 +155,8 @@ Rails.application.routes.draw do
       patch :mark_as_waiting_for_data, to: 'case_transitions#mark_as_waiting_for_data', as: 'mark_as_waiting_for_data'
       patch :mark_as_ready_for_vetting, to: 'case_transitions#mark_as_ready_for_vetting', as: 'mark_as_ready_for_vetting'
       patch :mark_as_vetting_in_progress, to: 'case_transitions#mark_as_vetting_in_progress', as: 'mark_as_vetting_in_progress'
+      patch :mark_as_ready_to_copy, to: 'case_transitions#mark_as_ready_to_copy', as: 'mark_as_ready_to_copy'
       patch :mark_as_ready_to_dispatch, to: 'case_transitions#mark_as_ready_to_dispatch', as: 'mark_as_ready_to_dispatch'
-      patch :mark_as_ready_to_close, to: 'case_transitions#mark_as_ready_to_close', as: 'mark_as_ready_to_close'
       patch :mark_as_closed, to: 'case_transitions#mark_as_closed', as: 'mark_as_closed'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -151,7 +151,14 @@ Rails.application.routes.draw do
       patch :flag_for_clearance
     end
 
-    resources :case_transitions, only: [:create]
+    member do
+      patch :mark_as_waiting_for_data, to: 'case_transitions#mark_as_waiting_for_data', as: 'mark_as_waiting_for_data'
+      patch :mark_as_ready_for_vetting
+      patch :mark_as_vetting_in_progress
+      patch :mark_as_ready_to_dispatch
+      patch :mark_as_ready_to_close
+      patch :mark_as_closed
+    end
   end
 
   # Case Behaviours (awaiting move to module Cases)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,11 +153,11 @@ Rails.application.routes.draw do
 
     member do
       patch :mark_as_waiting_for_data, to: 'case_transitions#mark_as_waiting_for_data', as: 'mark_as_waiting_for_data'
-      patch :mark_as_ready_for_vetting
-      patch :mark_as_vetting_in_progress
-      patch :mark_as_ready_to_dispatch
-      patch :mark_as_ready_to_close
-      patch :mark_as_closed
+      patch :mark_as_ready_for_vetting, to: 'case_transitions#mark_as_ready_for_vetting', as: 'mark_as_ready_for_vetting'
+      patch :mark_as_vetting_in_progress, to: 'case_transitions#mark_as_vetting_in_progress', as: 'mark_as_vetting_in_progress'
+      patch :mark_as_ready_to_dispatch, to: 'case_transitions#mark_as_ready_to_dispatch', as: 'mark_as_ready_to_dispatch'
+      patch :mark_as_ready_to_close, to: 'case_transitions#mark_as_ready_to_close', as: 'mark_as_ready_to_close'
+      patch :mark_as_closed, to: 'case_transitions#mark_as_closed', as: 'mark_as_closed'
     end
   end
 

--- a/config/state_machine/configs/00_moj/40_offender_sar/10_offender_sar_preamble.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/10_offender_sar_preamble.yml
@@ -15,12 +15,10 @@
       - approver
 
     permitted_states:
-      - unassigned
       - data_to_be_requested
       - waiting_for_data
       - ready_for_vetting
       - vetting_in_progress
-      - ready_to_copy
       - ready_to_dispatch
-      - case_closed
-      - case_destroyed
+      - ready_to_close
+      - closed

--- a/config/state_machine/configs/00_moj/40_offender_sar/10_offender_sar_preamble.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/10_offender_sar_preamble.yml
@@ -19,6 +19,6 @@
       - waiting_for_data
       - ready_for_vetting
       - vetting_in_progress
+      - ready_to_copy
       - ready_to_dispatch
-      - ready_to_close
       - closed

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -6,27 +6,27 @@
           manager:
             states:
               data_to_be_requested:
-                mark_as_waiting_for_data:
+                mark_as_next_state:
                   transition_to: waiting_for_data
                 add_message_to_case:
               waiting_for_data:
-                mark_as_ready_for_vetting:
+                mark_as_next_state:
                   transition_to: ready_for_vetting
                 add_message_to_case:
               ready_for_vetting:
-                mark_as_vetting_in_progress:
+                mark_as_next_state:
                   transition_to: vetting_in_progress
                 add_message_to_case:
               vetting_in_progress:
-                mark_as_ready_to_dispatch:
+                mark_as_next_state:
                   transition_to: ready_to_dispatch
                 add_message_to_case:
               ready_to_dispatch:
-                mark_as_ready_to_close:
+                mark_as_next_state:
                   transition_to: ready_to_close
                 add_message_to_case:
               ready_to_close:
-                mark_as_closed:
+                mark_as_next_state:
                   transition_to: closed
                 add_message_to_case:
               closed:

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -1,12 +1,31 @@
       standard:
-        initial_state: unassigned
+        initial_state: data_to_be_requested
         user_roles:
 
         ########################### SAR :: STANDARD WORKFLOW :: MANAGER ########################
           manager:
             states:
-              unassigned:
+              data_to_be_requested:
+                mark_as_waiting_for_data:
                 add_message_to_case:
+              waiting_for_data:
+                mark_as_ready_for_vetting:
+                add_message_to_case:
+              ready_for_vetting:
+                mark_as_vetting_in_progress:
+                add_message_to_case:
+              vetting_in_progress:
+                mark_as_ready_to_dispatch:
+                add_message_to_case:
+              ready_to_dispatch:
+                mark_as_ready_to_close:
+                add_message_to_case:
+              ready_to_close:
+                mark_as_closed:
+                add_message_to_case:
+              closed:
+                add_message_to_case:
+
           #       assign_responder:
           #         transition_to: awaiting_responder
           #         after_transition: Workflows::Hooks#assign_responder_email

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -7,21 +7,27 @@
             states:
               data_to_be_requested:
                 mark_as_waiting_for_data:
+                  transition_to: waiting_for_data
                 add_message_to_case:
               waiting_for_data:
                 mark_as_ready_for_vetting:
+                  transition_to: ready_for_vetting
                 add_message_to_case:
               ready_for_vetting:
                 mark_as_vetting_in_progress:
+                  transition_to: vetting_in_progress
                 add_message_to_case:
               vetting_in_progress:
                 mark_as_ready_to_dispatch:
+                  transition_to: ready_to_dispatch
                 add_message_to_case:
               ready_to_dispatch:
                 mark_as_ready_to_close:
+                  transition_to: ready_to_close
                 add_message_to_case:
               ready_to_close:
                 mark_as_closed:
+                  transition_to: closed
                 add_message_to_case:
               closed:
                 add_message_to_case:

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -18,145 +18,17 @@
                   transition_to: vetting_in_progress
                 add_message_to_case:
               vetting_in_progress:
+                mark_as_ready_to_copy:
+                  transition_to: ready_to_copy
+                add_message_to_case:
+              ready_to_copy:
                 mark_as_ready_to_dispatch:
                   transition_to: ready_to_dispatch
                 add_message_to_case:
               ready_to_dispatch:
-                mark_as_ready_to_close:
-                  transition_to: ready_to_close
-                add_message_to_case:
-              ready_to_close:
                 mark_as_closed:
                   transition_to: closed
                 add_message_to_case:
               closed:
                 add_message_to_case:
 
-          #       assign_responder:
-          #         transition_to: awaiting_responder
-          #         after_transition: Workflows::Hooks#assign_responder_email
-          #       destroy_case:
-          #       edit_case:
-          #         if: Workflows::Predicates#overturned_editing_enabled?
-          #       flag_for_clearance:
-          #         switch_workflow: trigger
-          #       link_a_case:
-          #       remove_linked_case:
-          #       request_further_clearance:
-          #         if: Case::SARPolicy#can_request_further_clearance?
-          #         switch_workflow: trigger
-
-          #     awaiting_responder:
-          #       add_message_to_case:
-          #       assign_to_new_team:
-          #         transition_to: awaiting_responder
-          #         after_transition: Workflows::Hooks#assign_responder_email
-          #       destroy_case:
-          #       edit_case:
-          #         if: Workflows::Predicates#overturned_editing_enabled?
-          #       flag_for_clearance:
-          #         switch_workflow: trigger
-          #       link_a_case:
-          #       remove_linked_case:
-          #       request_further_clearance:
-          #         if: Case::SARPolicy#can_request_further_clearance?
-          #         switch_workflow: trigger
-
-          #     drafting:
-          #       add_message_to_case:
-          #         after_transition: Workflows::Hooks#notify_responder_message_received
-          #       assign_to_new_team:
-          #         transition_to: awaiting_responder
-          #         after_transition: Workflows::Hooks#assign_responder_email
-          #       destroy_case:
-          #       edit_case:
-          #         if: Workflows::Predicates#overturned_editing_enabled?
-          #       extend_sar_deadline:
-          #         if: Workflows::Predicates#deadline_does_not_exceed_max_deadline?
-          #       flag_for_clearance:
-          #         switch_workflow: trigger
-          #       link_a_case:
-          #       remove_linked_case:
-          #       remove_sar_deadline_extension:
-          #         if: Workflows::Predicates#has_sar_deadline_extension?
-          #       request_further_clearance:
-          #         if: Case::SARPolicy#can_request_further_clearance?
-          #         switch_workflow: trigger
-          #       unassign_from_user:
-          #         transition_to: awaiting_responder
-
-          #     closed:
-          #       add_message_to_case:
-          #       assign_to_new_team:
-          #       destroy_case:
-          #       edit_case:
-          #         if: Workflows::Predicates#overturned_editing_enabled?
-          #       update_closure:
-          #         if: Workflows::Predicates#overturned_editing_enabled?
-          #       link_a_case:
-          #       remove_linked_case:
-
-          ########################### SAR :: STANDARD WORKFLOW :: RESPONDER ########################
-          # responder:
-          #   states:
-          #     data_to_be_requested:
-          #       # add_message_to_case:
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-
-          #     waiting_for_data:
-          #       # accept_responder_assignment:
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-          #       #   transition_to: drafting
-          #       # add_message_to_case:
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-          #       # reject_responder_assignment:
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-          #       #   transition_to: unassigned
-
-          #     ready_for_vetting:
-          #       # add_message_to_case:
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-          #       #   after_transition: Workflows::Hooks#notify_responder_message_received
-          #       # respond_and_close:
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-          #       #   transition_to: closed
-          #       # respond:
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-          #       # close:
-          #       #   after_transition: Workflows::Hooks#notify_managing_team_case_closed
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-          #       #   transition_to: closed
-          #       # reassign_user:
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-          #       #   after_transition: Workflows::Hooks#reassign_user_email
-
-          #     vetting_in_progress:
-          #       # add_message_to_case:
-          #       #   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-          #       # update_closure:
-          #       #   if: Workflows::Predicates#overturned_editing_enabled_and_responder_in_assigned_team?
-          #     ready_to_dispatch:
-          #     ready_to_close:
-          #     closed:
-
-
-          ########################### SAR :: STANDARD WORKFLOW :: APPROVER ########################
-          # approver:
-          #   states:
-          #     unassigned:
-          #       add_message_to_case:
-          #         if: Workflows::Predicates#user_is_approver_on_case?
-          #       flag_for_clearance:
-          #         switch_workflow: trigger
-
-          #     awaiting_responder:
-          #       flag_for_clearance:
-          #         switch_workflow: trigger
-
-          #     drafting:
-          #       extend_sar_deadline:
-          #         if: Workflows::Predicates#user_is_in_approving_team_for_case?
-          #       flag_for_clearance:
-          #         switch_workflow: trigger
-          #       remove_sar_deadline_extension:
-          #         if: Workflows::Predicates#case_extended_and_user_in_approving_team?

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -6,27 +6,27 @@
           manager:
             states:
               data_to_be_requested:
-                mark_as_next_state:
+                mark_as_waiting_for_data:
                   transition_to: waiting_for_data
                 add_message_to_case:
               waiting_for_data:
-                mark_as_next_state:
+                mark_as_ready_for_vetting:
                   transition_to: ready_for_vetting
                 add_message_to_case:
               ready_for_vetting:
-                mark_as_next_state:
+                mark_as_vetting_in_progress:
                   transition_to: vetting_in_progress
                 add_message_to_case:
               vetting_in_progress:
-                mark_as_next_state:
+                mark_as_ready_to_dispatch:
                   transition_to: ready_to_dispatch
                 add_message_to_case:
               ready_to_dispatch:
-                mark_as_next_state:
+                mark_as_ready_to_close:
                   transition_to: ready_to_close
                 add_message_to_case:
               ready_to_close:
-                mark_as_next_state:
+                mark_as_closed:
                   transition_to: closed
                 add_message_to_case:
               closed:

--- a/spec/controllers/cases/case_transitions_controller_spec.rb
+++ b/spec/controllers/cases/case_transitions_controller_spec.rb
@@ -1,36 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Cases::CaseTransitionsController, type: :controller do
-  describe "#mark_as_waiting_for_data" do
-    before do
-      sign_in manager
-    end
-    let(:manager) { find_or_create :branston_user }
-    let(:offender_sar) { create(:offender_sar_case).decorate }
-    let(:params) {{ id: offender_sar.id }}
-
-    it 'sets @case' do
-      patch :mark_as_waiting_for_data, params: params
-
-      expect(assigns(:case)).to eq offender_sar
-    end
-
-    it 'authorizes' do
-      expect {
-        patch :mark_as_waiting_for_data, params: params
-      }.to require_permission(:mark_as_waiting_for_data?)
-        .with_args(manager, offender_sar)
-    end
-
-    it 'flashes a notification' do
-      patch :mark_as_waiting_for_data, params: params
-      expect(flash[:notice])
-        .to eq 'Case updated'
-    end
-
-    it 'redirects to case details page' do
-      patch :mark_as_waiting_for_data, params: params
-      expect(response).to redirect_to(case_path(offender_sar))
-    end
-  end
+  it_behaves_like 'edit offender sar spec', :offender_sar_case, :mark_as_waiting_for_data
+  it_behaves_like 'edit offender sar spec', :waiting_for_data_offender_sar, :mark_as_ready_for_vetting
+  it_behaves_like 'edit offender sar spec', :ready_for_vetting_offender_sar, :mark_as_vetting_in_progress
+  it_behaves_like 'edit offender sar spec', :vetting_in_progress_offender_sar, :mark_as_ready_to_copy
+  it_behaves_like 'edit offender sar spec', :ready_to_copy_offender_sar, :mark_as_ready_to_dispatch
+  # it_behaves_like 'edit offender sar spec', :ready_to_dispatch_offender_sar, :mark_as_closed
 end

--- a/spec/controllers/cases/case_transitions_controller_spec.rb
+++ b/spec/controllers/cases/case_transitions_controller_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe Cases::CaseTransitionsController, type: :controller do
+  describe "#create" do
+    before do
+      sign_in manager
+    end
+    let(:manager) { find_or_create :branston_user }
+    let(:offender_sar) { create(:offender_sar_case).decorate }
+    let(:params) {{ case_id: offender_sar.id }}
+
+    it 'sets @case' do
+      post :create, params: params
+
+      expect(assigns(:case)).to eq offender_sar
+    end
+
+      # it 'authorizes' do
+      #   expect {
+      #     patch :progress_for_clearance, params: params
+      #   }.to require_permission(:progress_for_clearance?)
+      #     .with_args(responder, accepted_sar)
+      # end
+
+      # it 'sets @case' do
+      #   patch :progress_for_clearance, params: params
+      #   expect(assigns(:case)).to eq accepted_sar
+      # end
+
+      # it 'flashes a notification' do
+      #   patch :progress_for_clearance, params: params
+      #   expect(flash[:notice])
+      #     .to eq 'The Disclosure team has been notified this case is ready for clearance'
+      # end
+
+      # it 'redirects to case details page' do
+      #   patch :progress_for_clearance, params: params
+      #   expect(response).to redirect_to(case_path(accepted_sar))
+      # end
+
+      # it 'calls the state_machine method' do
+
+      #   patch :progress_for_clearance, params: params
+
+      #   stub_find_case(accepted_sar.id) do |kase|
+      #     expect(kase.state_machine).to have_received(:progress_for_clearance!)
+      #       .with(
+      #         acting_user: responder,
+      #         acting_team: responding_team,
+      #         target_team: disclosure_team
+      #       )
+      #   end
+      # end
+
+  end
+end

--- a/spec/controllers/cases/case_transitions_controller_spec.rb
+++ b/spec/controllers/cases/case_transitions_controller_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe Cases::CaseTransitionsController, type: :controller do
       expect(assigns(:case)).to eq offender_sar
     end
 
-    # it 'authorizes' do
-    #   expect {
-    #     post :create, params: params
-    #   }.to require_permission(:create_case_transition?)
-    #     .with_args(manager, offender_sar)
-    # end
+    it 'authorizes' do
+      expect {
+        post :create, params: params
+      }.to require_permission(:create?)
+        .with_args(manager, offender_sar)
+    end
 
     # it 'flashes a notification' do
     #   patch :progress_for_clearance, params: params

--- a/spec/controllers/cases/case_transitions_controller_spec.rb
+++ b/spec/controllers/cases/case_transitions_controller_spec.rb
@@ -1,51 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe Cases::CaseTransitionsController, type: :controller do
-  describe "#create" do
+  describe "#mark_as_waiting_for_data" do
     before do
       sign_in manager
     end
     let(:manager) { find_or_create :branston_user }
     let(:offender_sar) { create(:offender_sar_case).decorate }
-    let(:params) {{ case_id: offender_sar.id }}
+    let(:params) {{ id: offender_sar.id }}
 
     it 'sets @case' do
-      post :create, params: params
+      patch :mark_as_waiting_for_data, params: params
 
       expect(assigns(:case)).to eq offender_sar
     end
 
     it 'authorizes' do
       expect {
-        post :create, params: params
-      }.to require_permission(:create?)
+        patch :mark_as_waiting_for_data, params: params
+      }.to require_permission(:mark_as_waiting_for_data?)
         .with_args(manager, offender_sar)
     end
 
-    # it 'flashes a notification' do
-    #   patch :progress_for_clearance, params: params
-    #   expect(flash[:notice])
-    #     .to eq 'The Disclosure team has been notified this case is ready for clearance'
-    # end
+    it 'flashes a notification' do
+      patch :mark_as_waiting_for_data, params: params
+      expect(flash[:notice])
+        .to eq 'Case updated'
+    end
 
-    # it 'redirects to case details page' do
-    #   patch :progress_for_clearance, params: params
-    #   expect(response).to redirect_to(case_path(accepted_sar))
-    # end
-
-    # it 'calls the state_machine method' do
-
-    #   patch :progress_for_clearance, params: params
-
-    #   stub_find_case(accepted_sar.id) do |kase|
-    #     expect(kase.state_machine).to have_received(:progress_for_clearance!)
-    #       .with(
-    #         acting_user: responder,
-    #         acting_team: responding_team,
-    #         target_team: disclosure_team
-    #       )
-    #   end
-    # end
-
+    it 'redirects to case details page' do
+      patch :mark_as_waiting_for_data, params: params
+      expect(response).to redirect_to(case_path(offender_sar))
+    end
   end
 end

--- a/spec/controllers/cases/case_transitions_controller_spec.rb
+++ b/spec/controllers/cases/case_transitions_controller_spec.rb
@@ -6,5 +6,6 @@ RSpec.describe Cases::CaseTransitionsController, type: :controller do
   it_behaves_like 'edit offender sar spec', :ready_for_vetting_offender_sar, :mark_as_vetting_in_progress
   it_behaves_like 'edit offender sar spec', :vetting_in_progress_offender_sar, :mark_as_ready_to_copy
   it_behaves_like 'edit offender sar spec', :ready_to_copy_offender_sar, :mark_as_ready_to_dispatch
+  # todo - fix this in https://dsdmoj.atlassian.net/browse/CT-2266
   # it_behaves_like 'edit offender sar spec', :ready_to_dispatch_offender_sar, :mark_as_closed
 end

--- a/spec/controllers/cases/case_transitions_controller_spec.rb
+++ b/spec/controllers/cases/case_transitions_controller_spec.rb
@@ -15,42 +15,37 @@ RSpec.describe Cases::CaseTransitionsController, type: :controller do
       expect(assigns(:case)).to eq offender_sar
     end
 
-      # it 'authorizes' do
-      #   expect {
-      #     patch :progress_for_clearance, params: params
-      #   }.to require_permission(:progress_for_clearance?)
-      #     .with_args(responder, accepted_sar)
-      # end
+    # it 'authorizes' do
+    #   expect {
+    #     post :create, params: params
+    #   }.to require_permission(:create_case_transition?)
+    #     .with_args(manager, offender_sar)
+    # end
 
-      # it 'sets @case' do
-      #   patch :progress_for_clearance, params: params
-      #   expect(assigns(:case)).to eq accepted_sar
-      # end
+    # it 'flashes a notification' do
+    #   patch :progress_for_clearance, params: params
+    #   expect(flash[:notice])
+    #     .to eq 'The Disclosure team has been notified this case is ready for clearance'
+    # end
 
-      # it 'flashes a notification' do
-      #   patch :progress_for_clearance, params: params
-      #   expect(flash[:notice])
-      #     .to eq 'The Disclosure team has been notified this case is ready for clearance'
-      # end
+    # it 'redirects to case details page' do
+    #   patch :progress_for_clearance, params: params
+    #   expect(response).to redirect_to(case_path(accepted_sar))
+    # end
 
-      # it 'redirects to case details page' do
-      #   patch :progress_for_clearance, params: params
-      #   expect(response).to redirect_to(case_path(accepted_sar))
-      # end
+    # it 'calls the state_machine method' do
 
-      # it 'calls the state_machine method' do
+    #   patch :progress_for_clearance, params: params
 
-      #   patch :progress_for_clearance, params: params
-
-      #   stub_find_case(accepted_sar.id) do |kase|
-      #     expect(kase.state_machine).to have_received(:progress_for_clearance!)
-      #       .with(
-      #         acting_user: responder,
-      #         acting_team: responding_team,
-      #         target_team: disclosure_team
-      #       )
-      #   end
-      # end
+    #   stub_find_case(accepted_sar.id) do |kase|
+    #     expect(kase.state_machine).to have_received(:progress_for_clearance!)
+    #       .with(
+    #         acting_user: responder,
+    #         acting_team: responding_team,
+    #         target_team: disclosure_team
+    #       )
+    #   end
+    # end
 
   end
 end

--- a/spec/factories/case/offender_sars.rb
+++ b/spec/factories/case/offender_sars.rb
@@ -84,6 +84,21 @@ FactoryBot.define do
     end
   end
 
+  factory :ready_to_copy_offender_sar, parent: :offender_sar_case, class: Case::SAR::Offender do
+    transient do
+      identifier { "Ready to close offender sar" }
+    end
+
+    created_at      { creation_time }
+    received_date   { creation_time }
+
+    after(:create) do |kase, evaluator|
+      create :case_transition_ready_to_copy,
+             case: kase
+      kase.reload
+    end
+  end
+
   factory :ready_to_dispatch_offender_sar, parent: :offender_sar_case, class: Case::SAR::Offender do
     transient do
       identifier { "Ready to dispatch offender sar" }
@@ -94,21 +109,6 @@ FactoryBot.define do
 
     after(:create) do |kase, evaluator|
       create :case_transition_ready_to_dispatch,
-             case: kase
-      kase.reload
-    end
-  end
-
-  factory :ready_to_close_offender_sar, parent: :offender_sar_case, class: Case::SAR::Offender do
-    transient do
-      identifier { "Ready to close offender sar" }
-    end
-
-    created_at      { creation_time }
-    received_date   { creation_time }
-
-    after(:create) do |kase, evaluator|
-      create :case_transition_ready_to_close,
              case: kase
       kase.reload
     end

--- a/spec/factories/case/offender_sars.rb
+++ b/spec/factories/case/offender_sars.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
     created_at      { creation_time }
     received_date   { creation_time }
 
-    after(:create) do |kase, evaluator|
+    after(:create) do |kase|
       create :case_transition_waiting_for_data,
              case: kase
       kase.reload
@@ -62,7 +62,7 @@ FactoryBot.define do
     created_at      { creation_time }
     received_date   { creation_time }
 
-    after(:create) do |kase, evaluator|
+    after(:create) do |kase|
       create :case_transition_ready_for_vetting,
              case: kase
       kase.reload
@@ -77,7 +77,7 @@ FactoryBot.define do
     created_at      { creation_time }
     received_date   { creation_time }
 
-    after(:create) do |kase, evaluator|
+    after(:create) do |kase|
       create :case_transition_vetting_in_progress,
              case: kase
       kase.reload
@@ -92,7 +92,7 @@ FactoryBot.define do
     created_at      { creation_time }
     received_date   { creation_time }
 
-    after(:create) do |kase, evaluator|
+    after(:create) do |kase|
       create :case_transition_ready_to_copy,
              case: kase
       kase.reload
@@ -107,7 +107,7 @@ FactoryBot.define do
     created_at      { creation_time }
     received_date   { creation_time }
 
-    after(:create) do |kase, evaluator|
+    after(:create) do |kase|
       create :case_transition_ready_to_dispatch,
              case: kase
       kase.reload
@@ -122,7 +122,7 @@ FactoryBot.define do
     created_at      { creation_time }
     received_date   { creation_time }
 
-    after(:create) do |kase, evaluator|
+    after(:create) do |kase|
       create :case_transition_closed,
              case: kase
       kase.reload

--- a/spec/factories/case/offender_sars.rb
+++ b/spec/factories/case/offender_sars.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
       third_party_relationship { 'Aunt' }
     end
 
-    current_state                   { 'unassigned' }
+    current_state                   { 'data_to_be_requested' }
     sequence(:name)                 { |n| "#{identifier} name #{n}" }
     email                           { Faker::Internet.email(identifier) }
     reply_method                    { 'send_by_email' }
@@ -37,5 +37,95 @@ FactoryBot.define do
     flag_as_high_profile            { false }
     created_at                      { creation_time }
     creator                         { create(:user, :orphan) }
+  end
+
+  factory :waiting_for_data_offender_sar, parent: :offender_sar_case, class: Case::SAR::Offender do
+    transient do
+      identifier { "waiting for data offender sar" }
+    end
+
+    created_at      { creation_time }
+    received_date   { creation_time }
+
+    after(:create) do |kase, evaluator|
+      create :case_transition_waiting_for_data,
+             case: kase
+      kase.reload
+    end
+  end
+
+  factory :ready_for_vetting_offender_sar, parent: :offender_sar_case, class: Case::SAR::Offender do
+    transient do
+      identifier { "Ready for vetting offender sar" }
+    end
+
+    created_at      { creation_time }
+    received_date   { creation_time }
+
+    after(:create) do |kase, evaluator|
+      create :case_transition_ready_for_vetting,
+             case: kase
+      kase.reload
+    end
+  end
+
+  factory :vetting_in_progress_offender_sar, parent: :offender_sar_case, class: Case::SAR::Offender do
+    transient do
+      identifier { "Vetting in progress offender sar" }
+    end
+
+    created_at      { creation_time }
+    received_date   { creation_time }
+
+    after(:create) do |kase, evaluator|
+      create :case_transition_vetting_in_progress,
+             case: kase
+      kase.reload
+    end
+  end
+
+  factory :ready_to_dispatch_offender_sar, parent: :offender_sar_case, class: Case::SAR::Offender do
+    transient do
+      identifier { "Ready to dispatch offender sar" }
+    end
+
+    created_at      { creation_time }
+    received_date   { creation_time }
+
+    after(:create) do |kase, evaluator|
+      create :case_transition_ready_to_dispatch,
+             case: kase
+      kase.reload
+    end
+  end
+
+  factory :ready_to_close_offender_sar, parent: :offender_sar_case, class: Case::SAR::Offender do
+    transient do
+      identifier { "Ready to close offender sar" }
+    end
+
+    created_at      { creation_time }
+    received_date   { creation_time }
+
+    after(:create) do |kase, evaluator|
+      create :case_transition_ready_to_close,
+             case: kase
+      kase.reload
+    end
+  end
+
+  factory :closed_offender_sar, parent: :offender_sar_case, class: Case::SAR::Offender do
+    transient do
+      identifier { "Closed offender sar" }
+    end
+
+    created_at      { creation_time }
+    received_date   { creation_time }
+
+    after(:create) do |kase, evaluator|
+      create :case_transition_closed,
+             case: kase
+      kase.reload
+    end
   end
 end

--- a/spec/factories/case/sars.rb
+++ b/spec/factories/case/sars.rb
@@ -121,10 +121,7 @@ FactoryBot.define do
     end
   end
 
-  factory :awaiting_responder_sar,
-          parent: :sar_case,
-          aliases: [:assigned_sar],
-          class: Case::SAR::Standard do
+  factory :awaiting_responder_sar, parent: :sar_case, aliases: [:assigned_sar], class: Case::SAR::Standard do
     transient do
       identifier { "assigned sar" }
     end

--- a/spec/factories/case_transitions.rb
+++ b/spec/factories/case_transitions.rb
@@ -315,4 +315,52 @@ FactoryBot.define do
     final_deadline          { self.case.external_deadline + 30.days }
     original_final_deadline { self.case.external_deadline }
   end
+
+  factory :case_transition_waiting_for_data, parent: :case_transition do
+    to_state { 'waiting_for_data' }
+    event { 'mark_as_waiting_for_data' }
+
+    acting_team { self.case.managing_team }
+    acting_user { acting_team.managers.first }
+  end
+
+  factory :case_transition_ready_for_vetting, parent: :case_transition do
+    to_state { 'ready_for_vetting' }
+    event { 'mark_as_ready_for_vetting' }
+
+    acting_team { self.case.managing_team }
+    acting_user { acting_team.managers.first }
+  end
+
+  factory :case_transition_vetting_in_progress, parent: :case_transition do
+    to_state { 'vetting_in_progress' }
+    event { 'mark_as_vetting_in_progress' }
+
+    acting_team { self.case.managing_team }
+    acting_user { acting_team.managers.first }
+  end
+
+  factory :case_transition_ready_to_dispatch, parent: :case_transition do
+    to_state { 'ready_to_dispatch' }
+    event { 'mark_as_ready_to_dispatch' }
+
+    acting_team { self.case.managing_team }
+    acting_user { acting_team.managers.first }
+  end
+
+  factory :case_transition_ready_to_close, parent: :case_transition do
+    to_state { 'ready_to_close' }
+    event { 'mark_as_ready_to_close' }
+
+    acting_team { self.case.managing_team }
+    acting_user { acting_team.managers.first }
+  end
+
+  # factory :case_transition_close, parent: :case_transition do
+  #   to_state { 'closed' }
+  #   event { 'mark_as_closed' }
+
+  #   acting_team { self.case.managing_team }
+  #   acting_user { acting_team.managers.first }
+  # end
 end

--- a/spec/factories/case_transitions.rb
+++ b/spec/factories/case_transitions.rb
@@ -340,17 +340,17 @@ FactoryBot.define do
     acting_user { acting_team.managers.first }
   end
 
-  factory :case_transition_ready_to_dispatch, parent: :case_transition do
-    to_state { 'ready_to_dispatch' }
-    event { 'mark_as_ready_to_dispatch' }
+  factory :case_transition_ready_to_copy, parent: :case_transition do
+    to_state { 'ready_to_copy' }
+    event { 'mark_as_ready_to_copy' }
 
     acting_team { self.case.managing_team }
     acting_user { acting_team.managers.first }
   end
 
-  factory :case_transition_ready_to_close, parent: :case_transition do
-    to_state { 'ready_to_close' }
-    event { 'mark_as_ready_to_close' }
+  factory :case_transition_ready_to_dispatch, parent: :case_transition do
+    to_state { 'ready_to_dispatch' }
+    event { 'mark_as_ready_to_dispatch' }
 
     acting_team { self.case.managing_team }
     acting_user { acting_team.managers.first }

--- a/spec/features/cases/offender_sar/case_progressing_spec.rb
+++ b/spec/features/cases/offender_sar/case_progressing_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 feature 'Offender SAR Case creation by a manager' do
   given(:manager)         { find_or_create :branston_user }
   given(:managing_team)   { create :managing_team, managers: [manager] }
+  given(:offender_sar_case) { create(:offender_sar_case).decorate }
 
   background do
     find_or_create :team_branston
@@ -11,6 +12,13 @@ feature 'Offender SAR Case creation by a manager' do
   end
 
   scenario 'creating a case that does not need clearance', js: true do
-    create_offender_sar_case_step
+    # create_offender_sar_case_step
+    cases_show_page.load(id: offender_sar_case.id)
+
+    expect(cases_show_page).to have_content "Mark as waiting for data"
+    click_on "Mark as waiting for data"
+
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content "Mark as ready for vetting"
   end
 end

--- a/spec/features/cases/offender_sar/case_progressing_spec.rb
+++ b/spec/features/cases/offender_sar/case_progressing_spec.rb
@@ -11,8 +11,7 @@ feature 'Offender SAR Case creation by a manager' do
     cases_page.load
   end
 
-  scenario 'creating a case that does not need clearance', js: true do
-    # create_offender_sar_case_step
+  scenario 'creating a case that does not need clearance' do
     cases_show_page.load(id: offender_sar_case.id)
 
     expect(cases_show_page).to have_content "Mark as waiting for data"
@@ -20,5 +19,22 @@ feature 'Offender SAR Case creation by a manager' do
 
     expect(cases_show_page).to be_displayed
     expect(cases_show_page).to have_content "Mark as ready for vetting"
+    click_on "Mark as ready for vetting"
+
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content "Mark as vetting in progress"
+    click_on "Mark as vetting in progress"
+
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content "Mark as ready to dispatch"
+    click_on "Mark as ready to dispatch"
+
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content "Mark as ready to close"
+    click_on "Mark as ready to close"
+
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content "Mark as closed"
+    click_on "Mark as closed"
   end
 end

--- a/spec/features/cases/offender_sar/case_progressing_spec.rb
+++ b/spec/features/cases/offender_sar/case_progressing_spec.rb
@@ -15,6 +15,7 @@ feature 'Offender SAR Case creation by a manager' do
     cases_show_page.load(id: offender_sar_case.id)
 
     expect(cases_show_page).to have_content "Mark as waiting for data"
+    expect(cases_show_page).to have_content "Data to be requested"
     click_on "Mark as waiting for data"
 
     expect(cases_show_page).to be_displayed
@@ -26,12 +27,12 @@ feature 'Offender SAR Case creation by a manager' do
     click_on "Mark as vetting in progress"
 
     expect(cases_show_page).to be_displayed
-    expect(cases_show_page).to have_content "Mark as ready to dispatch"
-    click_on "Mark as ready to dispatch"
+    expect(cases_show_page).to have_content "Mark as ready to copy"
+    click_on "Mark as ready to copy"
 
     expect(cases_show_page).to be_displayed
-    expect(cases_show_page).to have_content "Mark as ready to close"
-    click_on "Mark as ready to close"
+    expect(cases_show_page).to have_content "Mark as ready to dispatch"
+    click_on "Mark as ready to dispatch"
 
     expect(cases_show_page).to be_displayed
     expect(cases_show_page).to have_content "Mark as closed"

--- a/spec/models/case/sar/offender_spec.rb
+++ b/spec/models/case/sar/offender_spec.rb
@@ -334,7 +334,18 @@ describe Case::SAR::Offender do
 
   describe '.searchable_fields_and_ranks' do
     it 'includes subject full name' do
-      expect(Case::SAR::Offender.searchable_fields_and_ranks).to include({subject_full_name: 'B'})
+      expect(Case::SAR::Offender.searchable_fields_and_ranks).to include({
+        message: 'D',
+        name: 'A',
+        number: 'A',
+        other_subject_ids: 'B',
+        previous_case_numbers: 'B',
+        prison_number: 'B',
+        responding_team_name: 'B',
+        subject: 'C',
+        subject_aliases: 'B',
+        subject_full_name: 'A',
+      })
     end
   end
 

--- a/spec/services/current_team_and_user/sar/offender_spec.rb
+++ b/spec/services/current_team_and_user/sar/offender_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'CurrentTeamAndUserSAROffenderService' do
+
+  let(:team_branston)             { find_or_create :team_branston }
+  let(:service)               { CurrentTeamAndUserService.new(kase) }
+
+  context 'data to be requested state' do
+    let(:kase)  { create :offender_sar_case }
+    it 'returns the correct team and user' do
+      expect(kase.current_state).to eq 'data_to_be_requested'
+      expect(service.team).to eq team_branston
+      expect(service.user).to be_nil
+    end
+  end
+
+  context 'data to be requested state' do
+    let(:kase)  { create :waiting_for_data_offender_sar }
+    it 'returns the correct team and user' do
+      expect(kase.current_state).to eq 'waiting_for_data'
+      expect(service.team).to eq team_branston
+      expect(service.user).to be_nil
+    end
+  end
+
+  context 'unknown_state' do
+    let(:kase)  { create :offender_sar_case }
+    it 'raises' do
+      allow(kase).to receive(:current_state).and_return('of_disbelief')
+      expect{
+        service
+      }.to raise_error(
+             RuntimeError,
+             'State of_disbelief unrecognised by CurrentTeamAndUser::SAR::Offender'
+           )
+    end
+  end
+end

--- a/spec/site_prism/page_objects/pages/cases/show_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/show_page.rb
@@ -35,8 +35,8 @@ module PageObjects
           element :mark_as_waiting_for_data, '#action--mark-as-waiting-for-data'
           element :mark_as_ready_for_vetting, '#action--mark-as-ready-for-vetting'
           element :mark_as_vetting_in_progress, '#action--mark-as-vetting-in-progress'
+          element :mark_as_ready_to_copy, '#action--mark-as-ready-to-copy'
           element :mark_as_ready_to_dispatch, '#action--mark-as-ready-to-dispatch'
-          element :mark_as_ready_to_close, '#action--mark-as-ready-to-close'
           element :mark_as_closed, '#action--mark-as-closed'
         end
         element :extend_for_pit_action, '#action--extend-for-pit'

--- a/spec/site_prism/page_objects/pages/cases/show_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/show_page.rb
@@ -32,6 +32,12 @@ module PageObjects
           element :progress_to_disclosure, '#action--progress-for-clearance'
           element :extend_sar_deadline, '#action--extend-deadline-for-sar'
           element :remove_sar_deadline_extension, '#action--remove-extended-deadline-for-sar'
+          element :mark_as_waiting_for_data, '#action--mark-as-waiting-for-data'
+          element :mark_as_ready_for_vetting, '#action--mark-as-ready-for-vetting'
+          element :mark_as_vetting_in_progress, '#action--mark-as-vetting-in-progress'
+          element :mark_as_ready_to_dispatch, '#action--mark-as-ready-to-dispatch'
+          element :mark_as_ready_to_close, '#action--mark-as-ready-to-close'
+          element :mark_as_closed, '#action--mark-as-closed'
         end
         element :extend_for_pit_action, '#action--extend-for-pit'
         element :remove_pit_extension_action, '#action--remove-pit-extension'

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -16,7 +16,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'data_to_be_requested'
           expect(k.state_machine.permitted_events(manager)).to eq [:add_message_to_case,
-                                                                   :mark_as_waiting_for_data]
+                                                                   :mark_as_next_state]
         end
       end
 
@@ -27,72 +27,52 @@ describe ConfigurableStateMachine::Machine do
           expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'waiting_for_data'
-          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case]
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+                                                                      :mark_as_next_state]
         end
       end
 
       context 'ready for vetting state' do
         it 'shows events' do
-          k = create :accepted_ot_ico_foi
-          expect(k.class).to eq Case::OverturnedICO::FOI
+          k = create :ready_for_vetting_offender_sar
+          expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
-          expect(k.current_state).to eq 'drafting'
+          expect(k.current_state).to eq 'ready_for_vetting'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :assign_to_new_team,
-                                                                      :destroy_case,
-                                                                      :extend_for_pit,
-                                                                      :flag_for_clearance,
-                                                                      :link_a_case,
-                                                                      :remove_linked_case,
-                                                                      :request_further_clearance,
-                                                                      :unassign_from_user]
+                                                                      :mark_as_next_state]
         end
       end
 
       context 'vetting in progress state' do
         it 'shows events' do
-          k = create :with_response_ot_ico_foi
-          expect(k.class).to eq Case::OverturnedICO::FOI
+          k = create :vetting_in_progress_offender_sar
+          expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
-          expect(k.current_state).to eq 'awaiting_dispatch'
+          expect(k.current_state).to eq 'vetting_in_progress'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :destroy_case,
-                                                                      :extend_for_pit,
-                                                                      :flag_for_clearance,
-                                                                      :link_a_case,
-                                                                      :remove_linked_case,
-                                                                      :request_further_clearance,
-                                                                      :unassign_from_user]
+                                                                      :mark_as_next_state]
         end
       end
 
       context 'ready to dispatch state' do
         it 'shows events' do
-          k = create :responded_ot_ico_foi
-          expect(k.class).to eq Case::OverturnedICO::FOI
+          k = create :ready_to_dispatch_offender_sar
+          expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
-          expect(k.current_state).to eq 'responded'
+          expect(k.current_state).to eq 'ready_to_dispatch'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :close,
-                                                                      :destroy_case,
-                                                                      :link_a_case,
-                                                                      :remove_linked_case,
-                                                                      :unassign_from_user]
+                                                                      :mark_as_next_state]
         end
       end
 
       context 'ready to close state' do
         it 'shows events' do
-          k = create :closed_ot_ico_foi
-          expect(k.class).to eq Case::OverturnedICO::FOI
+          k = create :ready_to_close_offender_sar
+          expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
-          expect(k.current_state).to eq 'closed'
+          expect(k.current_state).to eq 'ready_to_close'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :assign_to_new_team,
-                                                                      :destroy_case,
-                                                                      :link_a_case,
-                                                                      :remove_linked_case,
-                                                                      :update_closure]
+                                                                      :mark_as_next_state]
         end
       end
     end

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -50,6 +50,17 @@ describe ConfigurableStateMachine::Machine do
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'vetting_in_progress'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+                                                                      :mark_as_ready_to_copy]
+        end
+      end
+
+      context 'ready to copy state' do
+        it 'shows events' do
+          k = create :ready_to_copy_offender_sar
+          expect(k.class).to eq Case::SAR::Offender
+          expect(k.workflow).to eq 'standard'
+          expect(k.current_state).to eq 'ready_to_copy'
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
                                                                       :mark_as_ready_to_dispatch]
         end
       end
@@ -60,17 +71,6 @@ describe ConfigurableStateMachine::Machine do
           expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'ready_to_dispatch'
-          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :mark_as_ready_to_close]
-        end
-      end
-
-      context 'ready to close state' do
-        it 'shows events' do
-          k = create :ready_to_close_offender_sar
-          expect(k.class).to eq Case::SAR::Offender
-          expect(k.workflow).to eq 'standard'
-          expect(k.current_state).to eq 'ready_to_close'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
                                                                       :mark_as_closed]
         end

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+describe ConfigurableStateMachine::Machine do
+  context 'standard workflow' do
+
+##################### MANAGER  ############################
+
+    context 'manager' do
+
+      let(:manager)   { find_or_create :disclosure_bmt_user}
+
+      context 'data to be requested state' do
+        it 'should show permitted events' do
+          k = create :offender_sar_case
+          expect(k.class).to eq Case::SAR::Offender
+          expect(k.workflow).to eq 'standard'
+          expect(k.current_state).to eq 'data_to_be_requested'
+          expect(k.state_machine.permitted_events(manager)).to eq [:add_message_to_case,
+                                                                   :mark_as_waiting_for_data]
+        end
+      end
+
+
+      context 'waiting for data state' do
+        it 'shows events' do
+          k = create :waiting_for_data_offender_sar
+          expect(k.class).to eq Case::SAR::Offender
+          expect(k.workflow).to eq 'standard'
+          expect(k.current_state).to eq 'waiting_for_data'
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case]
+        end
+      end
+
+      context 'ready for vetting state' do
+        it 'shows events' do
+          k = create :accepted_ot_ico_foi
+          expect(k.class).to eq Case::OverturnedICO::FOI
+          expect(k.workflow).to eq 'standard'
+          expect(k.current_state).to eq 'drafting'
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+                                                                      :assign_to_new_team,
+                                                                      :destroy_case,
+                                                                      :extend_for_pit,
+                                                                      :flag_for_clearance,
+                                                                      :link_a_case,
+                                                                      :remove_linked_case,
+                                                                      :request_further_clearance,
+                                                                      :unassign_from_user]
+        end
+      end
+
+      context 'vetting in progress state' do
+        it 'shows events' do
+          k = create :with_response_ot_ico_foi
+          expect(k.class).to eq Case::OverturnedICO::FOI
+          expect(k.workflow).to eq 'standard'
+          expect(k.current_state).to eq 'awaiting_dispatch'
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+                                                                      :destroy_case,
+                                                                      :extend_for_pit,
+                                                                      :flag_for_clearance,
+                                                                      :link_a_case,
+                                                                      :remove_linked_case,
+                                                                      :request_further_clearance,
+                                                                      :unassign_from_user]
+        end
+      end
+
+      context 'ready to dispatch state' do
+        it 'shows events' do
+          k = create :responded_ot_ico_foi
+          expect(k.class).to eq Case::OverturnedICO::FOI
+          expect(k.workflow).to eq 'standard'
+          expect(k.current_state).to eq 'responded'
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+                                                                      :close,
+                                                                      :destroy_case,
+                                                                      :link_a_case,
+                                                                      :remove_linked_case,
+                                                                      :unassign_from_user]
+        end
+      end
+
+      context 'ready to close state' do
+        it 'shows events' do
+          k = create :closed_ot_ico_foi
+          expect(k.class).to eq Case::OverturnedICO::FOI
+          expect(k.workflow).to eq 'standard'
+          expect(k.current_state).to eq 'closed'
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+                                                                      :assign_to_new_team,
+                                                                      :destroy_case,
+                                                                      :link_a_case,
+                                                                      :remove_linked_case,
+                                                                      :update_closure]
+        end
+      end
+    end
+  end
+end

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -16,7 +16,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'data_to_be_requested'
           expect(k.state_machine.permitted_events(manager)).to eq [:add_message_to_case,
-                                                                   :mark_as_next_state]
+                                                                   :mark_as_waiting_for_data]
         end
       end
 
@@ -28,7 +28,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'waiting_for_data'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :mark_as_next_state]
+                                                                      :mark_as_ready_for_vetting]
         end
       end
 
@@ -39,7 +39,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'ready_for_vetting'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :mark_as_next_state]
+                                                                      :mark_as_vetting_in_progress]
         end
       end
 
@@ -50,7 +50,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'vetting_in_progress'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :mark_as_next_state]
+                                                                      :mark_as_ready_to_dispatch]
         end
       end
 
@@ -61,7 +61,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'ready_to_dispatch'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :mark_as_next_state]
+                                                                      :mark_as_ready_to_close]
         end
       end
 
@@ -72,7 +72,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'ready_to_close'
           expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
-                                                                      :mark_as_next_state]
+                                                                      :mark_as_closed]
         end
       end
     end

--- a/spec/support/shared_examples/cases/edit_offender_sar_spec.rb
+++ b/spec/support/shared_examples/cases/edit_offender_sar_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.shared_examples 'edit offender sar spec' do |offender_sar_case, method|
+  describe "mark methods" do
+    before do
+      sign_in manager
+    end
+    let(:manager) { find_or_create :branston_user }
+    let(:offender_sar) { create(offender_sar_case).decorate }
+    let(:params) {{ id: offender_sar.id }}
+
+    it 'sets @case' do
+      patch method, params: params
+
+      expect(assigns(:case)).to eq offender_sar
+    end
+
+    it 'authorizes' do
+      expect {
+        patch method, params: params
+      }.to require_permission("#{method}?")
+        .with_args(manager, offender_sar)
+    end
+
+    it 'flashes a notification' do
+      patch method, params: params
+      expect(flash[:notice])
+        .to eq 'Case updated'
+    end
+
+    it 'redirects to case details page' do
+      patch method, params: params
+      expect(response).to redirect_to(case_path(offender_sar))
+    end
+  end
+end

--- a/spec/views/cases/show_html_slim_spec.rb
+++ b/spec/views/cases/show_html_slim_spec.rb
@@ -33,8 +33,8 @@ describe 'cases/show.html.slim', type: :view do
       :mark_as_waiting_for_data,
       :mark_as_ready_for_vetting,
       :mark_as_vetting_in_progress,
+      :mark_as_ready_to_copy,
       :mark_as_ready_to_dispatch,
-      :mark_as_ready_to_close,
       :mark_as_closed
     ]
 
@@ -486,7 +486,7 @@ describe 'cases/show.html.slim', type: :view do
         mark_as_ready_for_vetting: true,
         mark_as_vetting_in_progress: true,
         mark_as_ready_to_dispatch: true,
-        mark_as_ready_to_close: true,
+        mark_as_ready_to_copy: true,
         mark_as_closed: true
       )
     end
@@ -542,13 +542,13 @@ describe 'cases/show.html.slim', type: :view do
 
       context 'when a case is ready to dispatch' do
         it 'shows mark as ready to close' do
-          assign(:permitted_events, [:mark_as_ready_to_close])
-          assign(:filtered_permitted_events, [:mark_as_ready_to_close])
+          assign(:permitted_events, [:mark_as_ready_to_copy])
+          assign(:filtered_permitted_events, [:mark_as_ready_to_copy])
           login_as manager
           render
           cases_show_page.load(rendered)
 
-          expect(cases_show_page.actions).to have_mark_as_ready_to_close
+          expect(cases_show_page.actions).to have_mark_as_ready_to_copy
         end
       end
     end

--- a/spec/views/cases/show_html_slim_spec.rb
+++ b/spec/views/cases/show_html_slim_spec.rb
@@ -30,7 +30,12 @@ describe 'cases/show.html.slim', type: :view do
       :upload_response_and_approve?,
       :upload_responses_for_flagged?,
       :upload_response_and_return_for_redraft?,
-      :mark_as_waiting_for_data
+      :mark_as_waiting_for_data,
+      :mark_as_ready_for_vetting,
+      :mark_as_vetting_in_progress,
+      :mark_as_ready_to_dispatch,
+      :mark_as_ready_to_close,
+      :mark_as_closed
     ]
 
 
@@ -471,35 +476,81 @@ describe 'cases/show.html.slim', type: :view do
     end
   end
 
-  fcontext 'with an offender sar case' do
+  context 'with an offender sar case' do
     let(:offender_sar_case) { create(:offender_sar_case).decorate }
 
     before do
       assign(:case, offender_sar_case)
       setup_policies(
-        mark_as_waiting_for_data: true
+        mark_as_waiting_for_data: true,
+        mark_as_ready_for_vetting: true,
+        mark_as_vetting_in_progress: true,
+        mark_as_ready_to_dispatch: true,
+        mark_as_ready_to_close: true,
+        mark_as_closed: true
       )
     end
 
     context 'as a manager' do
       context 'when a case just created' do
         it 'shows mark as waiting for data' do
+          assign(:permitted_events, [:mark_as_waiting_for_data])
+          assign(:filtered_permitted_events, [:mark_as_waiting_for_data])
           login_as manager
           render
           cases_show_page.load(rendered)
-byebug
+
           expect(cases_show_page.actions).to have_mark_as_waiting_for_data
         end
       end
-      # context 'when a case is waiting for data' do
-      #   it 'shows mark as ready for vetting' do
-      #     login_as manager
-      #     render
-      #     cases_show_page.load(rendered)
 
-      #     expect(cases_show_page.actions).to have_mark_as_waiting_for_data
-      #   end
-      # end
+      context 'when a case is waiting for data' do
+        it 'shows mark as ready for vetting' do
+          assign(:permitted_events, [:mark_as_ready_for_vetting])
+          assign(:filtered_permitted_events, [:mark_as_ready_for_vetting])
+          login_as manager
+          render
+          cases_show_page.load(rendered)
+
+          expect(cases_show_page.actions).to have_mark_as_ready_for_vetting
+        end
+      end
+
+      context 'when a case is ready for vetting' do
+        it 'shows mark as vetting in progress' do
+          assign(:permitted_events, [:mark_as_vetting_in_progress])
+          assign(:filtered_permitted_events, [:mark_as_vetting_in_progress])
+          login_as manager
+          render
+          cases_show_page.load(rendered)
+
+          expect(cases_show_page.actions).to have_mark_as_vetting_in_progress
+        end
+      end
+
+      context 'when a case is vetting in progress' do
+        it 'shows mark as ready to dispatch' do
+          assign(:permitted_events, [:mark_as_ready_to_dispatch])
+          assign(:filtered_permitted_events, [:mark_as_ready_to_dispatch])
+          login_as manager
+          render
+          cases_show_page.load(rendered)
+
+          expect(cases_show_page.actions).to have_mark_as_ready_to_dispatch
+        end
+      end
+
+      context 'when a case is ready to dispatch' do
+        it 'shows mark as ready to close' do
+          assign(:permitted_events, [:mark_as_ready_to_close])
+          assign(:filtered_permitted_events, [:mark_as_ready_to_close])
+          login_as manager
+          render
+          cases_show_page.load(rendered)
+
+          expect(cases_show_page.actions).to have_mark_as_ready_to_close
+        end
+      end
     end
   end
 end

--- a/spec/views/cases/show_html_slim_spec.rb
+++ b/spec/views/cases/show_html_slim_spec.rb
@@ -29,7 +29,8 @@ describe 'cases/show.html.slim', type: :view do
       :upload_responses?,
       :upload_response_and_approve?,
       :upload_responses_for_flagged?,
-      :upload_response_and_return_for_redraft?
+      :upload_response_and_return_for_redraft?,
+      :mark_as_waiting_for_data
     ]
 
 
@@ -467,6 +468,38 @@ describe 'cases/show.html.slim', type: :view do
           expect(cases_show_page.actions).to have_remove_sar_deadline_extension
         end
       end
+    end
+  end
+
+  fcontext 'with an offender sar case' do
+    let(:offender_sar_case) { create(:offender_sar_case).decorate }
+
+    before do
+      assign(:case, offender_sar_case)
+      setup_policies(
+        mark_as_waiting_for_data: true
+      )
+    end
+
+    context 'as a manager' do
+      context 'when a case just created' do
+        it 'shows mark as waiting for data' do
+          login_as manager
+          render
+          cases_show_page.load(rendered)
+byebug
+          expect(cases_show_page.actions).to have_mark_as_waiting_for_data
+        end
+      end
+      # context 'when a case is waiting for data' do
+      #   it 'shows mark as ready for vetting' do
+      #     login_as manager
+      #     render
+      #     cases_show_page.load(rendered)
+
+      #     expect(cases_show_page.actions).to have_mark_as_waiting_for_data
+      #   end
+      # end
     end
   end
 end


### PR DESCRIPTION
## Description
Implement support for the available states for Offender SARs and provide an interface to move it through the workflow states. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
![state transitions](https://user-images.githubusercontent.com/1161161/61964036-e0b63880-afc4-11e9-84d2-ab55e10ee665.gif)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2238
 
### Deployment
n/a
### Manual testing instructions
A newly created case should be able to be viewed and start off in "Data to be requested". You can then use the green button to move it through the states shown here. The current implementation throws an exception when you try to close the case - next ticket will get that working 

![image](https://user-images.githubusercontent.com/1161161/61964144-1c510280-afc5-11e9-8fe0-cf47428ab6e8.png)
