### PR TITLE
CT-2257 add note to offender sar

### DIFF
--- a/app/controllers/cases/messages_controller.rb
+++ b/app/controllers/cases/messages_controller.rb
@@ -1,39 +1,16 @@
 module Cases
   class MessagesController < ApplicationController
+    include Notable
+
+    before_action :set_case
 
     def create
-      @case = Case::Base.find params[:case_id]
       authorize(@case, :can_add_message_to_case?)
 
-      begin
-        @case.state_machine.add_message_to_case!(
-          acting_user: current_user,
-          acting_team: case_team,
-          message: params[:case][:message_text]
-        )
-      rescue ActiveRecord::RecordInvalid => err
-        if err.record.errors.include?(:message)
-          flash[:case_errors] = { message_text: err.record.errors[:message] }
-        end
-      ensure
-        redirect_to case_path(@case, anchor: 'messages-section')
-      end
-    end
-
-    private
-
-    # need to sort with manager first so that if we are both manager and something else, we don't
-    # try to execute the action with our lower authority (which might fail)
-    def case_team
-      User.sort_teams_by_roles(case_teams).first
-    end
-
-    def case_teams
-      if current_user.teams_for_case(@case).any?
-        current_user.teams_for_case(@case)
-      else
-        current_user.teams
-      end
+      add_message(
+        event_name: 'add_message_to_case!',
+        on_success: case_path(@case, anchor: 'messages-section')
+      )
     end
   end
 end

--- a/app/controllers/cases/notes_controller.rb
+++ b/app/controllers/cases/notes_controller.rb
@@ -1,0 +1,52 @@
+module Cases
+  class NotesController < ApplicationController
+    before_action :set_case, except: []
+    before_action :set_date_of_birth_instance_var, except: []
+
+    def create
+      begin
+        @case.state_machine.add_note_to_case!(
+          acting_user: current_user,
+          acting_team: case_team,
+          message: params[:case][:message_text]
+        )
+      rescue ActiveRecord::RecordInvalid => err
+        if err.record.errors.include?(:message)
+          flash[:case_errors] = { message_text: err.record.errors[:message] }
+        end
+      ensure
+        redirect_to case_path(@case, anchor: 'case-history')
+      end
+    end
+
+    private
+
+    # need to sort with manager first so that if we are both manager and something else, we don't
+    # try to execute the action with our lower authority (which might fail)
+    def case_team
+      User.sort_teams_by_roles(case_teams).first
+    end
+
+    def case_teams
+      if current_user.teams_for_case(@case).any?
+        current_user.teams_for_case(@case)
+      else
+        current_user.teams
+      end
+    end
+
+    def set_case
+      @case = Case::Base.find(params[:case_id])
+      authorize(@case, :can_add_note_to_case?)
+    end
+
+    # this method is here to fix an issue with the gov_uk_date_fields
+    # where the validation fails since the internal list of instance
+    # variables lacks the date_of_birth field from the json properties
+    #     NoMethodError: undefined method `valid?' for nil:NilClass
+    #     ./app/state_machines/configurable_state_machine/machine.rb:256
+    def set_date_of_birth_instance_var
+      @case.date_of_birth = @case.date_of_birth
+    end
+  end
+end

--- a/app/controllers/cases/notes_controller.rb
+++ b/app/controllers/cases/notes_controller.rb
@@ -1,44 +1,17 @@
 module Cases
   class NotesController < ApplicationController
+    include Notable
     include GovUKDateFixes
 
     before_action :set_case, :set_date_of_birth
 
     def create
-      begin
-        @case.state_machine.add_note_to_case!(
-          acting_user: current_user,
-          acting_team: case_team,
-          message: params[:case][:message_text]
-        )
-      rescue ActiveRecord::RecordInvalid => err
-        if err.record.errors.include?(:message)
-          flash[:case_errors] = { message_text: err.record.errors[:message] }
-        end
-      ensure
-        redirect_to case_path(@case, anchor: 'case-history')
-      end
-    end
-
-    private
-
-    # need to sort with manager first so that if we are both manager and something else, we don't
-    # try to execute the action with our lower authority (which might fail)
-    def case_team
-      User.sort_teams_by_roles(case_teams).first
-    end
-
-    def case_teams
-      if current_user.teams_for_case(@case).any?
-        current_user.teams_for_case(@case)
-      else
-        current_user.teams
-      end
-    end
-
-    def set_case
-      @case = Case::Base.find(params[:case_id])
       authorize(@case, :can_add_note_to_case?)
+
+      add_message(
+        event_name: 'add_note_to_case!',
+        on_success: case_path(@case, anchor: 'case-history')
+      )
     end
   end
 end

--- a/app/controllers/cases/notes_controller.rb
+++ b/app/controllers/cases/notes_controller.rb
@@ -1,5 +1,7 @@
 module Cases
   class NotesController < ApplicationController
+    include GovUKDateFixes
+
     before_action :set_case, :set_date_of_birth
 
     def create
@@ -37,15 +39,6 @@ module Cases
     def set_case
       @case = Case::Base.find(params[:case_id])
       authorize(@case, :can_add_note_to_case?)
-    end
-
-    # this method is here to fix an issue with the gov_uk_date_fields
-    # where the validation fails since the internal list of instance
-    # variables lacks the date_of_birth field from the json properties
-    #     NoMethodError: undefined method `valid?' for nil:NilClass
-    #     ./app/state_machines/configurable_state_machine/machine.rb:256
-    def set_date_of_birth
-      @case.date_of_birth = @case.date_of_birth
     end
   end
 end

--- a/app/controllers/cases/notes_controller.rb
+++ b/app/controllers/cases/notes_controller.rb
@@ -1,7 +1,6 @@
 module Cases
   class NotesController < ApplicationController
-    before_action :set_case, except: []
-    before_action :set_date_of_birth_instance_var, except: []
+    before_action :set_case, :set_date_of_birth
 
     def create
       begin
@@ -45,7 +44,7 @@ module Cases
     # variables lacks the date_of_birth field from the json properties
     #     NoMethodError: undefined method `valid?' for nil:NilClass
     #     ./app/state_machines/configurable_state_machine/machine.rb:256
-    def set_date_of_birth_instance_var
+    def set_date_of_birth
       @case.date_of_birth = @case.date_of_birth
     end
   end

--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -2,6 +2,7 @@ module Cases
   class OffenderSarController < CasesController
     include NewCase
     include OffenderSARCasesParams
+    include GovUKDateFixes
 
     before_action :set_case_types, only: [:new, :create]
     before_action :set_case, except: [:new, :create]
@@ -113,15 +114,6 @@ module Cases
     def reload_case_page_on_success
       flash[:notice] = t('cases.update.case_updated')
       redirect_to case_path(@case)
-    end
-
-    # This method is here to fix an issue with the gov_uk_date_fields
-    # where the validation fails since the internal list of instance
-    # variables lacks the date_of_birth field from the json properties
-    #     NoMethodError: undefined method `valid?' for nil:NilClass
-    #     ./app/state_machines/configurable_state_machine/machine.rb:256
-    def set_date_of_birth
-      @case.date_of_birth = @case.date_of_birth
     end
 
     # @todo: Should this be in Steppable?

--- a/app/controllers/concerns/gov_uk_date_fixes.rb
+++ b/app/controllers/concerns/gov_uk_date_fixes.rb
@@ -1,0 +1,13 @@
+module GovUKDateFixes
+  extend ActiveSupport::Concern
+
+  # This method is here to fix an issue with the gov_uk_date_fields
+  # where the validation fails since the internal list of instance
+  # variables lacks the date_of_birth field from the json properties
+  #     NoMethodError: undefined method `valid?' for nil:NilClass
+  #     ./app/state_machines/configurable_state_machine/machine.rb:256
+  def set_date_of_birth
+    @case.date_of_birth = @case.date_of_birth
+  end
+
+end

--- a/app/controllers/concerns/notable.rb
+++ b/app/controllers/concerns/notable.rb
@@ -1,0 +1,42 @@
+# @note: Case Closure and Respond methods require refactoring as per
+# other case behaviours
+module Notable
+  extend ActiveSupport::Concern
+  include SetupCase
+
+  def add_message(event_name: '', on_success: '')
+    begin
+      @case.state_machine.send(event_name,
+        acting_user: current_user,
+        acting_team: case_team,
+        message: params[:case][:message_text]
+      )
+    rescue ActiveRecord::RecordInvalid => err
+      if err.record.errors.include?(:message)
+        flash[:case_errors] = { message_text: err.record.errors[:message] }
+      end
+    ensure
+      redirect_to on_success
+    end
+  end
+
+  private
+
+  # need to sort with manager first so that if we are both manager and something else, we don't
+  # try to execute the action with our lower authority (which might fail)
+  def case_team
+    User.sort_teams_by_roles(case_teams).first
+  end
+
+  def case_teams
+    if current_user.teams_for_case(@case).any?
+      current_user.teams_for_case(@case)
+    else
+      current_user.teams
+    end
+  end
+
+  def set_case
+    @case = Case::Base.find(params[:case_id])
+  end
+end

--- a/app/decorators/case_transition_decorator.rb
+++ b/app/decorators/case_transition_decorator.rb
@@ -47,6 +47,8 @@ class CaseTransitionDecorator < Draper::Decorator
       target_user = User.find(object.target_user_id)
       acting_user = User.find(object.acting_user_id)
       "#{ acting_user.full_name } re-assigned this case to <strong>#{ target_user.full_name }</strong>"
+    else
+      object&.message
     end
   end
 end

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -758,7 +758,7 @@ class Case::Base < ApplicationRecord
   def overturned_ico?;      false;  end
   def overturned_ico_sar?;  false;  end
   def overturned_ico_foi?;  false;  end
-  def is_offender_sar?;        false;  end
+  def is_offender_sar?;     false;  end
 
   def default_managing_team
     BusinessUnit.dacu_bmt

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -758,6 +758,7 @@ class Case::Base < ApplicationRecord
   def overturned_ico?;      false;  end
   def overturned_ico_sar?;  false;  end
   def overturned_ico_foi?;  false;  end
+  def is_offender_sar?;        false;  end
 
   def default_managing_team
     BusinessUnit.dacu_bmt

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -94,4 +94,8 @@ class Case::SAR::Offender < Case::Base
   def current_team_and_user_resolver
     CurrentTeamAndUser::SAR::Offender.new(self)
   end
+
+  def is_offender_sar?
+    true
+  end
 end

--- a/app/models/case_transition.rb
+++ b/app/models/case_transition.rb
@@ -32,10 +32,13 @@ class CaseTransition < ApplicationRecord
   EXTEND_SAR_DEADLINE_EVENT = 'extend_sar_deadline'
   REMOVE_SAR_EXTENSION_EVENT = 'remove_sar_deadline_extension'
   ADD_MESSAGE_TO_CASE_EVENT = 'add_message_to_case'
+  ADD_NOTE_TO_CASE_EVENT = 'add_note_to_case'
 
   after_destroy :update_most_recent, if: :most_recent?
 
-  validates :message, presence: true, if: -> { event == ADD_MESSAGE_TO_CASE_EVENT }
+  validates :message, presence: true, if: -> {
+    [ADD_MESSAGE_TO_CASE_EVENT, ADD_NOTE_TO_CASE_EVENT].include? event
+  }
 
   jsonb_accessor :metadata,
                  message:                    :text,

--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -294,6 +294,10 @@ class Case::BasePolicy < ApplicationPolicy
     raise Pundit::NotDefinedError.new("Please define 'show?' method in #{self.class}")
   end
 
+  def can_add_note_to_case?
+    false
+  end
+
   private
 
   check :user_in_responding_team do

--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -3,4 +3,8 @@ class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
     clear_failed_checks
     check_user_is_a_manager
   end
+
+  def can_add_note_to_case?
+    true
+  end
 end

--- a/app/views/cases/offender_sar/_case_notes.html.slim
+++ b/app/views/cases/offender_sar/_case_notes.html.slim
@@ -2,6 +2,8 @@
   = form_for case_details, as: :case, url: case_notes_path(case_details), method: :post, class: "message-form" do |f|
     .message-form data-ws-case-id="#{case_details.id}"
       h2.request--heading Add a note to this case:
+      = GovukElementsErrorsHelper.error_summary @case.object,
+              "#{pluralize(@case.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""
       p For instance call notes or important changes to the status of the case
       = f.text_area :message_text, required: true
-      = f.submit "Add to case history", class: 'button-secondary'
+      = f.submit "Add to case history", class: 'button'

--- a/app/views/cases/offender_sar/_case_notes.html.slim
+++ b/app/views/cases/offender_sar/_case_notes.html.slim
@@ -1,0 +1,7 @@
+- if policy(case_details).can_add_note_to_case?
+  = form_for case_details, as: :case, url: case_notes_path(case_details), method: :post, class: "message-form" do |f|
+    .message-form data-ws-case-id="#{case_details.id}"
+      h2.request--heading Add a note to this case:
+      p For instance call notes or important changes to the status of the case
+      = f.text_area :message_text, required: true
+      = f.submit "Add to case history", class: 'button-secondary'

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -74,12 +74,17 @@ div id="case-#{@correspondence_type_key}" class="case"
     section.case-info
       = render partial: 'cases/case_attachments', locals: {case_details: @case}
 
-  section#messages-section.case-info
-    = render partial: 'cases/case_messages', locals: { case_details: @case }
+  - unless @case.is_offender_sar?
+    section#messages-section.case-info
+      = render partial: 'cases/case_messages', locals: { case_details: @case }
 
   - if @case_transitions.any?
     section.case-info.has-page-break
       = render partial: 'cases/case_history', locals: { case_transitions: @case_transitions }
+
+  - if @case.is_offender_sar?
+    section.notes-section
+      = render partial: 'cases/offender_sar/case_notes',locals: { case_details: @case }
 
   = render partial: 'shared/components/case_page_original_case_details'
 

--- a/config/locales/event.en.yml
+++ b/config/locales/event.en.yml
@@ -3,6 +3,7 @@ en:
     accept_approver_assignment: Clearance level added
     accept_responder_assignment: Accepted by Business unit
     add_message_to_case: Message added - see messages section above
+    add_note_to_case: "Note added:"
     add_response_to_flagged_case: Response uploaded
     add_response_to_flagged_case_and_approve: Response uploaded and cleared
     add_responses: Response uploaded

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,7 @@ Rails.application.routes.draw do
     resources :amendments, only: [:new, :create]
 
     resources :messages, only: [:create]
+    resources :notes, only: [:create]
 
     resources :attachments, only: [:show, :destroy] do
       get 'download', on: :member

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -8,27 +8,27 @@
               data_to_be_requested:
                 mark_as_waiting_for_data:
                   transition_to: waiting_for_data
-                add_message_to_case:
+                add_note_to_case:
               waiting_for_data:
                 mark_as_ready_for_vetting:
                   transition_to: ready_for_vetting
-                add_message_to_case:
+                add_note_to_case:
               ready_for_vetting:
                 mark_as_vetting_in_progress:
                   transition_to: vetting_in_progress
-                add_message_to_case:
+                add_note_to_case:
               vetting_in_progress:
                 mark_as_ready_to_copy:
                   transition_to: ready_to_copy
-                add_message_to_case:
+                add_note_to_case:
               ready_to_copy:
                 mark_as_ready_to_dispatch:
                   transition_to: ready_to_dispatch
-                add_message_to_case:
+                add_note_to_case:
               ready_to_dispatch:
                 mark_as_closed:
                   transition_to: closed
-                add_message_to_case:
+                add_note_to_case:
               closed:
-                add_message_to_case:
+                add_note_to_case:
 

--- a/spec/controllers/cases/notes_controller_spec.rb
+++ b/spec/controllers/cases/notes_controller_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Cases::NotesController, type: :controller do
+  let!(:team_branston)         { find_or_create :team_branston }
+  let!(:manager)           { team_branston.users.first }
+  let!(:offender_sar_case) { create(:offender_sar_case) }
+
+  describe 'POST #create' do
+
+    let(:params) do
+      {
+        case: {
+          message_text: 'This is a new message'
+        },
+        case_id: offender_sar_case.id
+      }
+    end
+
+    context "as an anonymous user" do
+      it "be redirected to signin if trying to start a new case" do
+        post :create , params: params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "offender sar case" do
+      let(:params) do
+        {
+          case: {
+            message_text: 'This is a new message'
+          },
+          case_id: offender_sar_case.id
+        }
+      end
+
+      context "as a manager" do
+        before { sign_in manager }
+
+        it "redirects to case detail page and contains a hash" do
+          post :create , params: params
+          expect(response).to redirect_to(case_path(offender_sar_case, anchor: 'case-history'))
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/cases/notes_controller_spec.rb
+++ b/spec/controllers/cases/notes_controller_spec.rb
@@ -42,5 +42,28 @@ RSpec.describe Cases::NotesController, type: :controller do
         end
       end
     end
+
+    context "message is blank, (user type doesn't matter)" do
+      let(:params) do
+        {
+          case: { message_text: '' },
+          case_id: offender_sar_case.id
+        }
+      end
+      before do
+        sign_in manager
+        post :create, params: params
+      end
+
+      it "copies the error to the flash" do
+        expect(flash[:case_errors][:message_text]).to eq ["can't be blank"]
+      end
+
+      it 'redirects to case detail page and contains a anchor' do
+        expect(response)
+            .to redirect_to(case_path(offender_sar_case,
+                                      anchor: 'case-history'))
+      end
+    end
   end
 end

--- a/spec/features/cases/offender_sar/adding_note_to_case_history_spec.rb
+++ b/spec/features/cases/offender_sar/adding_note_to_case_history_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+feature 'When viewing an offender sar case' do
+  given(:manager)         { find_or_create :branston_user }
+  given(:managing_team)   { create :managing_team, managers: [manager] }
+  given(:offender_sar_case) { create(:offender_sar_case).decorate }
+
+  background do
+    find_or_create :team_branston
+    login_as manager
+    cases_page.load
+  end
+
+  scenario 'adding a note' do
+    cases_show_page.load(id: offender_sar_case.id)
+
+    expect(cases_show_page).to have_content "Add a note to this case"
+    cases_show_page.new_message.input.set "Hi this is nice"
+    click_on "Add to case history"
+
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content "Hi this is nice"
+  end
+end

--- a/spec/routing/cases_routes_spec.rb
+++ b/spec/routing/cases_routes_spec.rb
@@ -64,4 +64,8 @@ describe 'cases routes', type: :routing do
   describe post: '/cases/1/responses' do
     it { should route_to controller: 'cases/responses', action: 'create', case_id: '1' }
   end
+
+  describe post: '/cases/1/notes' do
+    it { should route_to controller: 'cases/notes', action: 'create', case_id: '1' }
+  end
 end

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -15,7 +15,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'data_to_be_requested'
-          expect(k.state_machine.permitted_events(manager)).to eq [:add_message_to_case,
+          expect(k.state_machine.permitted_events(manager)).to eq [:add_note_to_case,
                                                                    :mark_as_waiting_for_data]
         end
       end
@@ -27,7 +27,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'waiting_for_data'
-          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_note_to_case,
                                                                       :mark_as_ready_for_vetting]
         end
       end
@@ -38,7 +38,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'ready_for_vetting'
-          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_note_to_case,
                                                                       :mark_as_vetting_in_progress]
         end
       end
@@ -49,7 +49,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'vetting_in_progress'
-          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_note_to_case,
                                                                       :mark_as_ready_to_copy]
         end
       end
@@ -60,7 +60,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'ready_to_copy'
-          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_note_to_case,
                                                                       :mark_as_ready_to_dispatch]
         end
       end
@@ -71,7 +71,7 @@ describe ConfigurableStateMachine::Machine do
           expect(k.class).to eq Case::SAR::Offender
           expect(k.workflow).to eq 'standard'
           expect(k.current_state).to eq 'ready_to_dispatch'
-          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_message_to_case,
+          expect(k.state_machine.permitted_events(manager.id)).to eq [:add_note_to_case,
                                                                       :mark_as_closed]
         end
       end

--- a/spec/views/cases/show_html_slim_spec.rb
+++ b/spec/views/cases/show_html_slim_spec.rb
@@ -35,9 +35,9 @@ describe 'cases/show.html.slim', type: :view do
       :mark_as_vetting_in_progress,
       :mark_as_ready_to_copy,
       :mark_as_ready_to_dispatch,
-      :mark_as_closed
+      :mark_as_closed,
+      :can_add_note_to_case?
     ]
-
 
     if (policies.keys - policy_names).any?
       raise NameError,
@@ -487,11 +487,25 @@ describe 'cases/show.html.slim', type: :view do
         mark_as_vetting_in_progress: true,
         mark_as_ready_to_dispatch: true,
         mark_as_ready_to_copy: true,
-        mark_as_closed: true
+        mark_as_closed: true,
+        can_add_note_to_case?: true
       )
     end
 
     context 'as a manager' do
+      context 'partials' do
+        before do
+          assign(:permitted_events, [:add_note_to_case])
+          assign(:filtered_permitted_events, [:add_note_to_case])
+          login_as manager
+          render
+          cases_show_page.load(rendered)
+        end
+        it { should_not have_rendered 'cases/_case_messages'}
+        it { should have_rendered 'cases/offender_sar/_case_notes'}
+      end
+
+
       context 'when a case just created' do
         it 'shows mark as waiting for data' do
           assign(:permitted_events, [:mark_as_waiting_for_data])


### PR DESCRIPTION
## Description
Allow Branston users to add notes to cases that get displayed inline in the case history 

![image](https://user-images.githubusercontent.com/1161161/62366889-004ae500-b520-11e9-8169-4c39f0a3632c.png)

It validates for empty message using the HTML required attribute 

![image](https://user-images.githubusercontent.com/1161161/62366912-16f13c00-b520-11e9-9968-24ba454ebb68.png)

but shows a form validation error just like the conversation feature IF the browser doesn't respect the `, required: true` setting on the text field. 

![image](https://user-images.githubusercontent.com/1161161/62366946-2cfefc80-b520-11e9-9c40-fd247f492eac.png)


Notes are stored using the `message` property in the JSON field for the case, and get displayed as the details element when case transition items render in the case history. Normal conversation messages are still filtered out based on their different event name, so if we were to add the conversation feature back for offender SAR, it should still work. 
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
  
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2257
 
### Deployment
No database malarkey
 
### Manual testing instructions
The task is to hide the conversation feature when viewing an offender SAR and instead display the "add note to case" form below the case history section. This should not show up for any other case type. 
