### PR TITLE
CT-2359 Hide date received legend but keep for accessibility only

### DIFF
--- a/app/views/cases/offender_sar/_date_received_step.html.slim
+++ b/app/views/cases/offender_sar/_date_received_step.html.slim
@@ -9,9 +9,11 @@
 = form_for @case, url: case_create_action(@case.object), as: :offender_sar do |f|
 
   .form-group
-    = f.gov_uk_date_field :received_date, { legend_text: '',
-      form_hint_text: t('cases.new.date_sar_received_copy'),
-      today_button: {class: ''}}
+    = f.gov_uk_date_field :received_date, {
+        legend_text: '',
+        form_hint_text: t('cases.new.date_sar_received_copy'),
+        today_button: true
+      }
   p
     = link_to "Previous", "/cases/new/offender/requested-info"
   input name="current_step" type="hidden" value=@case.current_step

--- a/app/views/cases/offender_sar/_date_received_step.html.slim
+++ b/app/views/cases/offender_sar/_date_received_step.html.slim
@@ -10,8 +10,9 @@
 
   .form-group
     = f.gov_uk_date_field :received_date, { legend_text: t('cases.new.date_sar_received'),
-        form_hint_text: t('cases.new.date_sar_received_copy'),
-        today_button: {class: ''}}
+      legend_class: 'visually-hidden',
+      form_hint_text: t('cases.new.date_sar_received_copy'),
+      today_button: {class: ''}}
   p
     = link_to "Previous", "/cases/new/offender/requested-info"
   input name="current_step" type="hidden" value=@case.current_step

--- a/app/views/cases/offender_sar/_date_received_step.html.slim
+++ b/app/views/cases/offender_sar/_date_received_step.html.slim
@@ -9,8 +9,7 @@
 = form_for @case, url: case_create_action(@case.object), as: :offender_sar do |f|
 
   .form-group
-    = f.gov_uk_date_field :received_date, { legend_text: t('cases.new.date_sar_received'),
-      legend_class: 'visually-hidden',
+    = f.gov_uk_date_field :received_date, { legend_text: '',
       form_hint_text: t('cases.new.date_sar_received_copy'),
       today_button: {class: ''}}
   p

--- a/app/views/cases/offender_sar/_date_received_step.html.slim
+++ b/app/views/cases/offender_sar/_date_received_step.html.slim
@@ -9,10 +9,10 @@
 = form_for @case, url: case_create_action(@case.object), as: :offender_sar do |f|
 
   .form-group
-    = f.gov_uk_date_field :received_date, {
+    = f.gov_uk_date_field :received_date, { \
         legend_text: '',
         form_hint_text: t('cases.new.date_sar_received_copy'),
-        today_button: true
+        today_button: { class: '' } \
       }
   p
     = link_to "Previous", "/cases/new/offender/requested-info"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -755,7 +755,6 @@ en:
       correspondence_type_errors:
         unknown: "Unknown correspondence type \"%{type}\""
         not_authorised: "You are not authorised to create \"%{type}\" correspondences"
-      date_sar_received: "When was the SAR received?"
       date_sar_received_copy: "For example, 12 11 2007"
       date_of_birth: "Date of birth"
       date_of_birth_copy: "For example, 24 11 1992"


### PR DESCRIPTION
## Description
Hide text for legend of date recieved because it's already in heading, but keep the legend for accessibility.
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
NEW

![image](https://user-images.githubusercontent.com/22935203/62283702-0ec6cd00-b44a-11e9-96f2-660f659cca02.png)


OLD

![image](https://user-images.githubusercontent.com/22935203/62283624-d7f0b700-b449-11e9-9a6c-989401175ad2.png)

 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2359
 
### Deployment
N/a
 
### Manual testing instructions
GO through offender sar journey then page 4 should have no legend text
