### PR TITLE
[01] CT-2408 Intermittent ReportType spec fails (PR No. 1)

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,1 @@
+--format progress

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -2,7 +2,7 @@ module Searchable
   extend ActiveSupport::Concern
 
   included do
-    include PgSearch
+    include PgSearch::Model
 
     self.ignored_columns = self.ignored_columns + [searchable_document_tsvector]
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,4 @@
-if ENV['COVERAGE'].present?
+if !!ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start 'rails' do
     add_group "Services", "app/services"

--- a/spec/services/stats/base_report_spec.rb
+++ b/spec/services/stats/base_report_spec.rb
@@ -9,9 +9,8 @@ module Stats
   end
 
   describe BaseReport do
-
-    before(:all)  { create :report_type }
-    after(:all)   { ReportType.delete_all }
+    before(:all) { create_report_type(abbr: :r006) }
+    after(:all) { DbHousekeeping.clean(seed: true) }
 
     describe '.new' do
       it 'raises if BaseReport is instantiated' do

--- a/spec/services/stats/case_selector_spec.rb
+++ b/spec/services/stats/case_selector_spec.rb
@@ -48,8 +48,7 @@ module Stats
     end
 
     after(:all) { DbHousekeeping.clean }
-
-    let(:selector)    { CaseSelector.new(Case::Base.all) }
+    after(:all) { DbHousekeeping.clean(seed: true) }
 
     describe '.ids_for_cases_received_in_period' do
       it 'returns an array of all cases received in period' do

--- a/spec/services/stats/case_selector_spec.rb
+++ b/spec/services/stats/case_selector_spec.rb
@@ -46,9 +46,9 @@ module Stats
         @oap_cxx = create :accepted_case, name: '@oap_cxx', received_date: @period_end + 2.days
       end
     end
-
-    after(:all) { DbHousekeeping.clean }
     after(:all) { DbHousekeeping.clean(seed: true) }
+
+    let(:selector) { CaseSelector.new(Case::Base.all) }
 
     describe '.ids_for_cases_received_in_period' do
       it 'returns an array of all cases received in period' do
@@ -74,22 +74,26 @@ module Stats
     describe '.ids_for_period' do
       context 'using Class name' do
         it 'returns an array of case_ids that were received or open during period' do
-          expected_ids = [ @obs_cos, @obs_cdp, @obs_coe, @obs_cap,
-                           @oos_cdp, @oos_coe, @oos_cap,
-                           @odp_cdp, @odp_coe, @odp_cap,
-                           @ooe_cap,
-                           @obs_cxx, @oos_cxx, @odp_cxx, @ooe_cxx ].map(&:id)
+          expected_ids = [
+            @obs_cos, @obs_cdp, @obs_coe, @obs_cap,
+            @oos_cdp, @oos_coe, @oos_cap,
+            @odp_cdp, @odp_coe, @odp_cap,
+            @ooe_cap,
+            @obs_cxx, @oos_cxx, @odp_cxx, @ooe_cxx
+          ].map(&:id)
           expect(selector.ids_for_period(@period_start, @period_end)).to match_array expected_ids
         end
       end
 
       context 'using scope' do
         it 'returns an array of case_ids that were received or open during period' do
-          expected_ids = [ @obs_cos, @obs_cdp, @obs_coe, @obs_cap,
-                           @oos_cdp, @oos_coe, @oos_cap,
-                           @odp_cdp, @odp_coe, @odp_cap,
-                           @ooe_cap,
-                           @obs_cxx, @oos_cxx, @odp_cxx, @ooe_cxx ].map(&:id)
+          expected_ids = [
+            @obs_cos, @obs_cdp, @obs_coe, @obs_cap,
+            @oos_cdp, @oos_coe, @oos_cap,
+            @odp_cdp, @odp_coe, @odp_cap,
+            @ooe_cap,
+            @obs_cxx, @oos_cxx, @odp_cxx, @ooe_cxx
+          ].map(&:id)
           expect(CaseSelector.new(Case::Base.all).ids_for_period(@period_start, @period_end)).to match_array expected_ids
         end
       end

--- a/spec/services/stats/r002_appeals_performance_report_spec.rb
+++ b/spec/services/stats/r002_appeals_performance_report_spec.rb
@@ -4,9 +4,7 @@ module Stats # rubocop:disable Metrics/ModuleLength
   describe R002AppealsPerformanceReport do
 
     before(:all) do
-      DbHousekeeping.clean
-
-      create :report_type, :r002
+      create_report_type(abbr: :r002)
 
       Team.all.each(&:destroy)
       Timecop.freeze Time.new(2017, 6, 30, 12, 0, 0) do
@@ -88,10 +86,7 @@ module Stats # rubocop:disable Metrics/ModuleLength
       Team.where.not(id: required_teams.map(&:id)).destroy_all
     end
 
-    after(:all) do
-      ReportType.r002.destroy
-      DbHousekeeping.clean
-    end
+    after(:all) { DbHousekeeping.clean(seed: true) }
 
     describe '#title' do
       it 'returns the report title' do
@@ -121,67 +116,67 @@ module Stats # rubocop:disable Metrics/ModuleLength
       it 'adds up directorate stats in each business_group' do
         expect(@results[@bizgrp_ab.id])
           .to eq({
-                   business_group:                @bizgrp_ab.name,
-                   directorate:                   '',
-                   business_unit:                 '',
-                   responsible:                   @bizgrp_ab.team_lead,
-                   ir_appeal_performance:         28.6,
-                   ir_appeal_total:               9,
-                   ir_appeal_responded_in_time:   2,
-                   ir_appeal_responded_late:      2,
-                   ir_appeal_open_in_time:        2,
-                   ir_appeal_open_late:           3,
-                   ico_appeal_performance:        28.6,
-                   ico_appeal_total:              18,
-                   ico_appeal_responded_in_time:  4,
-                   ico_appeal_responded_late:     4,
-                   ico_appeal_open_in_time:       4,
-                   ico_appeal_open_late:          6,
-                 })
+            business_group:                @bizgrp_ab.name,
+            directorate:                   '',
+            business_unit:                 '',
+            responsible:                   @bizgrp_ab.team_lead,
+            ir_appeal_performance:         28.6,
+            ir_appeal_total:               9,
+            ir_appeal_responded_in_time:   2,
+            ir_appeal_responded_late:      2,
+            ir_appeal_open_in_time:        2,
+            ir_appeal_open_late:           3,
+            ico_appeal_performance:        28.6,
+            ico_appeal_total:              18,
+            ico_appeal_responded_in_time:  4,
+            ico_appeal_responded_late:     4,
+            ico_appeal_open_in_time:       4,
+            ico_appeal_open_late:          6,
+          })
       end
 
       it 'adds up business_unit stats in each directorate' do
         expect(@results[@bizgrp_cd.id])
           .to eq({
-                   business_group:                @bizgrp_cd.name,
-                   directorate:                   '',
-                   business_unit:                 '',
-                   responsible:                   @bizgrp_cd.team_lead,
-                   ir_appeal_performance:         50.0,
-                   ir_appeal_total:               3,
-                   ir_appeal_responded_in_time:   1,
-                   ir_appeal_responded_late:      1,
-                   ir_appeal_open_in_time:        1,
-                   ir_appeal_open_late:           0,
-                   ico_appeal_performance:        50.0,
-                   ico_appeal_total:              6,
-                   ico_appeal_responded_in_time:  2,
-                   ico_appeal_responded_late:     2,
-                   ico_appeal_open_in_time:       2,
-                   ico_appeal_open_late:          0,
-                 })
+            business_group:                @bizgrp_cd.name,
+            directorate:                   '',
+            business_unit:                 '',
+            responsible:                   @bizgrp_cd.team_lead,
+            ir_appeal_performance:         50.0,
+            ir_appeal_total:               3,
+            ir_appeal_responded_in_time:   1,
+            ir_appeal_responded_late:      1,
+            ir_appeal_open_in_time:        1,
+            ir_appeal_open_late:           0,
+            ico_appeal_performance:        50.0,
+            ico_appeal_total:              6,
+            ico_appeal_responded_in_time:  2,
+            ico_appeal_responded_late:     2,
+            ico_appeal_open_in_time:       2,
+            ico_appeal_open_late:          0,
+          })
       end
 
       it 'adds up individual business_unit stats' do
         expect(@results[@team_c.id])
           .to eq({
-                   business_group:                @bizgrp_cd.name,
-                   directorate:                   @dir_cd.name,
-                   business_unit:                 @team_c.name,
-                   responsible:                   @team_c.team_lead,
-                   ir_appeal_performance:         50.0,
-                   ir_appeal_total:               2,
-                   ir_appeal_responded_in_time:   1,
-                   ir_appeal_responded_late:      1,
-                   ir_appeal_open_in_time:        0,
-                   ir_appeal_open_late:           0,
-                   ico_appeal_performance:        50.0,
-                   ico_appeal_total:              4,
-                   ico_appeal_responded_in_time:  2,
-                   ico_appeal_responded_late:     2,
-                   ico_appeal_open_in_time:       0,
-                   ico_appeal_open_late:          0,
-                 })
+            business_group:                @bizgrp_cd.name,
+            directorate:                   @dir_cd.name,
+            business_unit:                 @team_c.name,
+            responsible:                   @team_c.team_lead,
+            ir_appeal_performance:         50.0,
+            ir_appeal_total:               2,
+            ir_appeal_responded_in_time:   1,
+            ir_appeal_responded_late:      1,
+            ir_appeal_open_in_time:        0,
+            ir_appeal_open_late:           0,
+            ico_appeal_performance:        50.0,
+            ico_appeal_total:              4,
+            ico_appeal_responded_in_time:  2,
+            ico_appeal_responded_late:     2,
+            ico_appeal_open_in_time:       0,
+            ico_appeal_open_late:          0,
+          })
       end
     end
 
@@ -225,20 +220,20 @@ module Stats # rubocop:disable Metrics/ModuleLength
         end
 
         expect(rag_ratings).to eq([
-                                    [],
-                                    (0..15).map { |x| [x, :blue] },
-                                    (0..15).map { |x| [x, :grey] },
-                                    [[4, :red], [10, :red]],
-                                    [[4, :red], [10, :red]],
-                                    [[4, :red], [10, :red]],
-                                    [[4, :red], [10, :red]],
-                                    [[4, :red], [10, :red]],
-                                    [[4, :red], [10, :red]],
-                                    [[4, :red], [10, :red]],
-                                    [[10, :red]],
-                                    [[4, :red], [10, :red]],
-                                    [[4, :red], [10, :red]],
-                                  ])
+          [],
+          (0..15).map { |x| [x, :blue] },
+          (0..15).map { |x| [x, :grey] },
+          [[4, :red], [10, :red]],
+          [[4, :red], [10, :red]],
+          [[4, :red], [10, :red]],
+          [[4, :red], [10, :red]],
+          [[4, :red], [10, :red]],
+          [[4, :red], [10, :red]],
+          [[4, :red], [10, :red]],
+          [[10, :red]],
+          [[4, :red], [10, :red]],
+          [[4, :red], [10, :red]],
+        ])
       end
     end
 
@@ -283,20 +278,20 @@ module Stats # rubocop:disable Metrics/ModuleLength
       if responded_date.nil?
         factory = "accepted_ico_#{type}_case".to_sym
         kase = create factory,
-                      creation_time: received_date,
-                      external_deadline: deadline_date,
-                      responding_team: team,
-                      responder: responder,
-                      identifier: ident
+          creation_time: received_date,
+          external_deadline: deadline_date,
+          responding_team: team,
+          responder: responder,
+          identifier: ident
       else
         factory = "responded_ico_#{type}_case".to_sym
         kase = create factory,
-                      creation_time: received_date,
-                      external_deadline: deadline_date,
-                      responding_team: team,
-                      responder: responder,
-                      date_responded: responded_date,
-                      identifier: ident
+          creation_time: received_date,
+          external_deadline: deadline_date,
+          responding_team: team,
+          responder: responder,
+          date_responded: responded_date,
+          identifier: ident
       end
       kase
     end

--- a/spec/services/stats/r003_business_unit_performance_report_spec.rb
+++ b/spec/services/stats/r003_business_unit_performance_report_spec.rb
@@ -445,15 +445,15 @@ module Stats
       responded_date = responded.nil? ? nil : Date.parse(responded)
       kase = nil
       Timecop.freeze(received_date + 10.hours) do
-        factory = case type
-        when 'std'
-          :case_with_response
-        when 'irt'
-          :accepted_timeliness_review
-        when 'irc'
-          :accepted_compliance_review
-        end
-
+        factory =
+          case type
+          when 'std'
+            :case_with_response
+          when 'irt'
+            :accepted_timeliness_review
+          when 'irc'
+            :accepted_compliance_review
+          end
 
         kase = create factory, responding_team: team, responder: responder, identifier: ident
         kase.external_deadline = Date.parse(deadline)
@@ -475,6 +475,5 @@ module Stats
     # rubocop:enable Metrics/CyclomaticComplexity
 
   end
-
 end
 # rubocop:enable Metrics/ModuleLength

--- a/spec/services/stats/r003_business_unit_performance_report_spec.rb
+++ b/spec/services/stats/r003_business_unit_performance_report_spec.rb
@@ -3,10 +3,8 @@ require 'rails_helper'
 # rubocop:disable Metrics/ModuleLength
 module Stats
   describe R003BusinessUnitPerformanceReport do
-
     before(:all) do
-      DbHousekeeping.clean
-      find_or_create :report_type, :r003
+      create_report_type(abbr: :r003)
 
       Team.all.map(&:destroy)
       Timecop.freeze Time.new(2017, 6, 30, 12, 0, 0) do
@@ -62,10 +60,7 @@ module Stats
       Team.where('id > ?', @team_d.id).destroy_all
     end
 
-    after(:all) do
-      DbHousekeeping.clean
-      ReportType.r003.destroy
-    end
+    after(:all) { DbHousekeeping.clean(seed: true) }
 
     context 'defining the period' do
       context 'no period parameters passsed in' do
@@ -111,86 +106,86 @@ module Stats
 
         it 'adds up directorate stats in each business_group' do
           expect(@results[@bizgrp_ab.id])
-              .to eq({
-                         business_group:                @bizgrp_ab.name,
-                         directorate:                   '',
-                         business_unit:                 '',
-                         responsible:                   @bizgrp_ab.team_lead,
-                         non_trigger_performance:       28.6,
-                         non_trigger_total:             9,
-                         non_trigger_responded_in_time: 2,
-                         non_trigger_responded_late:    2,
-                         non_trigger_open_in_time:      2,
-                         non_trigger_open_late:         3,
-                         trigger_performance:           33.3,
-                         trigger_total:                 5,
-                         trigger_responded_in_time:     1,
-                         trigger_responded_late:        1,
-                         trigger_open_in_time:          2,
-                         trigger_open_late:             1,
-                         overall_performance:           30.0,
-                         overall_total:                 14,
-                         overall_responded_in_time:     3,
-                         overall_responded_late:        3,
-                         overall_open_in_time:          4,
-                         overall_open_late:             4
-                     })
+            .to eq({
+              business_group:                @bizgrp_ab.name,
+              directorate:                   '',
+              business_unit:                 '',
+              responsible:                   @bizgrp_ab.team_lead,
+              non_trigger_performance:       28.6,
+              non_trigger_total:             9,
+              non_trigger_responded_in_time: 2,
+              non_trigger_responded_late:    2,
+              non_trigger_open_in_time:      2,
+              non_trigger_open_late:         3,
+              trigger_performance:           33.3,
+              trigger_total:                 5,
+              trigger_responded_in_time:     1,
+              trigger_responded_late:        1,
+              trigger_open_in_time:          2,
+              trigger_open_late:             1,
+              overall_performance:           30.0,
+              overall_total:                 14,
+              overall_responded_in_time:     3,
+              overall_responded_late:        3,
+              overall_open_in_time:          4,
+              overall_open_late:             4
+            })
         end
 
         it 'adds up business_unit stats in each directorate' do
           expect(@results[@bizgrp_cd.id])
-              .to eq({
-                         business_group:                @bizgrp_cd.name,
-                         directorate:                   '',
-                         business_unit:                 '',
-                         responsible:                   @bizgrp_cd.team_lead,
-                         non_trigger_performance:       50.0,
-                         non_trigger_total:             3,
-                         non_trigger_responded_in_time: 1,
-                         non_trigger_responded_late:    1,
-                         non_trigger_open_in_time:      1,
-                         non_trigger_open_late:         0,
-                         trigger_performance:           0.0,
-                         trigger_total:                 0,
-                         trigger_responded_in_time:     0,
-                         trigger_responded_late:        0,
-                         trigger_open_in_time:          0,
-                         trigger_open_late:             0,
-                         overall_performance:           50.0,
-                         overall_total:                 3,
-                         overall_responded_in_time:     1,
-                         overall_responded_late:        1,
-                         overall_open_in_time:          1,
-                         overall_open_late:             0
-                     })
+            .to eq({
+              business_group:                @bizgrp_cd.name,
+              directorate:                   '',
+              business_unit:                 '',
+              responsible:                   @bizgrp_cd.team_lead,
+              non_trigger_performance:       50.0,
+              non_trigger_total:             3,
+              non_trigger_responded_in_time: 1,
+              non_trigger_responded_late:    1,
+              non_trigger_open_in_time:      1,
+              non_trigger_open_late:         0,
+              trigger_performance:           0.0,
+              trigger_total:                 0,
+              trigger_responded_in_time:     0,
+              trigger_responded_late:        0,
+              trigger_open_in_time:          0,
+              trigger_open_late:             0,
+              overall_performance:           50.0,
+              overall_total:                 3,
+              overall_responded_in_time:     1,
+              overall_responded_late:        1,
+              overall_open_in_time:          1,
+              overall_open_late:             0
+            })
         end
 
         it 'adds up individual business_unit stats' do
           expect(@results[@team_c.id])
-              .to eq({
-                         business_group:                @bizgrp_cd.name,
-                         directorate:                   @dir_cd.name,
-                         business_unit:                 @team_c.name,
-                         responsible:                   @team_c.team_lead,
-                         non_trigger_performance:       50.0,
-                         non_trigger_total:             2,
-                         non_trigger_responded_in_time: 1,
-                         non_trigger_responded_late:    1,
-                         non_trigger_open_in_time:      0,
-                         non_trigger_open_late:         0,
-                         trigger_performance:           0.0,
-                         trigger_total:                 0,
-                         trigger_responded_in_time:     0,
-                         trigger_responded_late:        0,
-                         trigger_open_in_time:          0,
-                         trigger_open_late:             0,
-                         overall_performance:           50.0,
-                         overall_total:                 2,
-                         overall_responded_in_time:     1,
-                         overall_responded_late:        1,
-                         overall_open_in_time:          0,
-                         overall_open_late:             0
-                     })
+            .to eq({
+              business_group:                @bizgrp_cd.name,
+              directorate:                   @dir_cd.name,
+              business_unit:                 @team_c.name,
+              responsible:                   @team_c.team_lead,
+              non_trigger_performance:       50.0,
+              non_trigger_total:             2,
+              non_trigger_responded_in_time: 1,
+              non_trigger_responded_late:    1,
+              non_trigger_open_in_time:      0,
+              non_trigger_open_late:         0,
+              trigger_performance:           0.0,
+              trigger_total:                 0,
+              trigger_responded_in_time:     0,
+              trigger_responded_late:        0,
+              trigger_open_in_time:          0,
+              trigger_open_late:             0,
+              overall_performance:           50.0,
+              overall_total:                 2,
+              overall_responded_in_time:     1,
+              overall_responded_late:        1,
+              overall_open_in_time:          0,
+              overall_open_late:             0
+            })
         end
       end
 
@@ -207,31 +202,31 @@ module Stats
           end
 
           expect(rag_ratings).to eq([
-                                      [],
-                                      (0..21).map { |x| [x, :blue] },
-                                      (0..21).map { |x| [x, :grey] },
-                                      [[4, :red], [10, :red], [16, :red]],
-                                      [[4, :red], [10, :red], [16, :red]],
-                                      [[4, :red], [10, :red], [16, :red]],
-                                      [[4, :red], [10, :red], [16, :red]],
-                                      [[4, :red], [10, :red], [16, :red]],
-                                      [[4, :red], [16, :red]],
-                                      [[4, :red], [16, :red]],
-                                      [[4, :red], [16, :red]],
-                                      [[4, :red], [16, :red]],
-                                      [[4, :red], [10, :red], [16, :red]],
-                                    ])
+            [],
+            (0..21).map { |x| [x, :blue] },
+            (0..21).map { |x| [x, :grey] },
+            [[4, :red], [10, :red], [16, :red]],
+            [[4, :red], [10, :red], [16, :red]],
+            [[4, :red], [10, :red], [16, :red]],
+            [[4, :red], [10, :red], [16, :red]],
+            [[4, :red], [10, :red], [16, :red]],
+            [[4, :red], [16, :red]],
+            [[4, :red], [16, :red]],
+            [[4, :red], [16, :red]],
+            [[4, :red], [16, :red]],
+            [[4, :red], [10, :red], [16, :red]],
+          ])
         end
 
         it 'outputs results as a csv lines' do
           super_header = %q{"","","","",} +
-              %q{Non-trigger cases,Non-trigger cases,Non-trigger cases,Non-trigger cases,Non-trigger cases,Non-trigger cases,} +
-              %q{Trigger cases,Trigger cases,Trigger cases,Trigger cases,Trigger cases,Trigger cases,} +
-              %q{Overall,Overall,Overall,Overall,Overall,Overall}
+            %q{Non-trigger cases,Non-trigger cases,Non-trigger cases,Non-trigger cases,Non-trigger cases,Non-trigger cases,} +
+            %q{Trigger cases,Trigger cases,Trigger cases,Trigger cases,Trigger cases,Trigger cases,} +
+            %q{Overall,Overall,Overall,Overall,Overall,Overall}
           header = %q{Business group,Directorate,Business unit,Responsible,} +
-              %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late,} +
-              %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late,} +
-              %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late}
+            %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late,} +
+            %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late,} +
+            %q{Performance %,Total received,Responded - in time,Responded - late,Open - in time,Open - late}
           expected_text = <<~EOCSV
           Business unit report (FOIs) - 1 Jan 2017 to 30 Jun 2017
           #{super_header}
@@ -288,103 +283,103 @@ module Stats
         it 'adds up directorate stats in each business_group' do
           expect(@results[@bizgrp_ab.id])
             .to eq({
-                     business_group:                @bizgrp_ab.name,
-                     directorate:                   '',
-                     business_unit:                 '',
-                     responsible:                   @bizgrp_ab.team_lead,
-                     non_trigger_performance:       28.6,
-                     non_trigger_total:             9,
-                     non_trigger_responded_in_time: 2,
-                     non_trigger_responded_late:    2,
-                     non_trigger_open_in_time:      2,
-                     non_trigger_open_late:         3,
-                     trigger_performance:           33.3,
-                     trigger_total:                 5,
-                     trigger_responded_in_time:     1,
-                     trigger_responded_late:        1,
-                     trigger_open_in_time:          2,
-                     trigger_open_late:             1,
-                     overall_performance:           30.0,
-                     overall_total:                 14,
-                     overall_responded_in_time:     3,
-                     overall_responded_late:        3,
-                     overall_open_in_time:          4,
-                     overall_open_late:             4,
-                     bu_performance:                0.0,
-                     bu_total:                      14,
-                     bu_responded_in_time:          0,
-                     bu_responded_late:             6,
-                     bu_open_in_time:               0,
-                     bu_open_late:                  8
-                   })
+              business_group:                @bizgrp_ab.name,
+              directorate:                   '',
+              business_unit:                 '',
+              responsible:                   @bizgrp_ab.team_lead,
+              non_trigger_performance:       28.6,
+              non_trigger_total:             9,
+              non_trigger_responded_in_time: 2,
+              non_trigger_responded_late:    2,
+              non_trigger_open_in_time:      2,
+              non_trigger_open_late:         3,
+              trigger_performance:           33.3,
+              trigger_total:                 5,
+              trigger_responded_in_time:     1,
+              trigger_responded_late:        1,
+              trigger_open_in_time:          2,
+              trigger_open_late:             1,
+              overall_performance:           30.0,
+              overall_total:                 14,
+              overall_responded_in_time:     3,
+              overall_responded_late:        3,
+              overall_open_in_time:          4,
+              overall_open_late:             4,
+              bu_performance:                0.0,
+              bu_total:                      14,
+              bu_responded_in_time:          0,
+              bu_responded_late:             6,
+              bu_open_in_time:               0,
+              bu_open_late:                  8
+            })
         end
 
         it 'adds up business_unit stats in each directorate' do
           expect(@results[@bizgrp_cd.id])
             .to eq({
-                     business_group:                @bizgrp_cd.name,
-                     directorate:                   '',
-                     business_unit:                 '',
-                     responsible:                   @bizgrp_cd.team_lead,
-                     non_trigger_performance:       50.0,
-                     non_trigger_total:             3,
-                     non_trigger_responded_in_time: 1,
-                     non_trigger_responded_late:    1,
-                     non_trigger_open_in_time:      1,
-                     non_trigger_open_late:         0,
-                     trigger_performance:           0.0,
-                     trigger_total:                 0,
-                     trigger_responded_in_time:     0,
-                     trigger_responded_late:        0,
-                     trigger_open_in_time:          0,
-                     trigger_open_late:             0,
-                     overall_performance:           50.0,
-                     overall_total:                 3,
-                     overall_responded_in_time:     1,
-                     overall_responded_late:        1,
-                     overall_open_in_time:          1,
-                     overall_open_late:             0,
-                     bu_performance:                0.0,
-                     bu_total:                      3,
-                     bu_responded_in_time:          0,
-                     bu_responded_late:             2,
-                     bu_open_in_time:               0,
-                     bu_open_late:                  1
-                   })
+              business_group:                @bizgrp_cd.name,
+              directorate:                   '',
+              business_unit:                 '',
+              responsible:                   @bizgrp_cd.team_lead,
+              non_trigger_performance:       50.0,
+              non_trigger_total:             3,
+              non_trigger_responded_in_time: 1,
+              non_trigger_responded_late:    1,
+              non_trigger_open_in_time:      1,
+              non_trigger_open_late:         0,
+              trigger_performance:           0.0,
+              trigger_total:                 0,
+              trigger_responded_in_time:     0,
+              trigger_responded_late:        0,
+              trigger_open_in_time:          0,
+              trigger_open_late:             0,
+              overall_performance:           50.0,
+              overall_total:                 3,
+              overall_responded_in_time:     1,
+              overall_responded_late:        1,
+              overall_open_in_time:          1,
+              overall_open_late:             0,
+              bu_performance:                0.0,
+              bu_total:                      3,
+              bu_responded_in_time:          0,
+              bu_responded_late:             2,
+              bu_open_in_time:               0,
+              bu_open_late:                  1
+            })
         end
 
         it 'adds up individual business_unit stats' do
           expect(@results[@team_c.id])
             .to eq({
-                     business_group:                @bizgrp_cd.name,
-                     directorate:                   @dir_cd.name,
-                     business_unit:                 @team_c.name,
-                     responsible:                   @team_c.team_lead,
-                     non_trigger_performance:       50.0,
-                     non_trigger_total:             2,
-                     non_trigger_responded_in_time: 1,
-                     non_trigger_responded_late:    1,
-                     non_trigger_open_in_time:      0,
-                     non_trigger_open_late:         0,
-                     trigger_performance:           0.0,
-                     trigger_total:                 0,
-                     trigger_responded_in_time:     0,
-                     trigger_responded_late:        0,
-                     trigger_open_in_time:          0,
-                     trigger_open_late:             0,
-                     overall_performance:           50.0,
-                     overall_total:                 2,
-                     overall_responded_in_time:     1,
-                     overall_responded_late:        1,
-                     overall_open_in_time:          0,
-                     overall_open_late:             0,
-                     bu_performance:                0.0,
-                     bu_total:                      2,
-                     bu_responded_in_time:          0,
-                     bu_responded_late:             2,
-                     bu_open_in_time:               0,
-                     bu_open_late:                  0
-                   })
+              business_group:                @bizgrp_cd.name,
+              directorate:                   @dir_cd.name,
+              business_unit:                 @team_c.name,
+              responsible:                   @team_c.team_lead,
+              non_trigger_performance:       50.0,
+              non_trigger_total:             2,
+              non_trigger_responded_in_time: 1,
+              non_trigger_responded_late:    1,
+              non_trigger_open_in_time:      0,
+              non_trigger_open_late:         0,
+              trigger_performance:           0.0,
+              trigger_total:                 0,
+              trigger_responded_in_time:     0,
+              trigger_responded_late:        0,
+              trigger_open_in_time:          0,
+              trigger_open_late:             0,
+              overall_performance:           50.0,
+              overall_total:                 2,
+              overall_responded_in_time:     1,
+              overall_responded_late:        1,
+              overall_open_in_time:          0,
+              overall_open_late:             0,
+              bu_performance:                0.0,
+              bu_total:                      2,
+              bu_responded_in_time:          0,
+              bu_responded_late:             2,
+              bu_open_in_time:               0,
+              bu_open_late:                  0
+            })
         end
       end
 
@@ -451,13 +446,13 @@ module Stats
       kase = nil
       Timecop.freeze(received_date + 10.hours) do
         factory = case type
-                    when 'std'
-                      :case_with_response
-                    when 'irt'
-                      :accepted_timeliness_review
-                    when 'irc'
-                      :accepted_compliance_review
-                  end
+        when 'std'
+          :case_with_response
+        when 'irt'
+          :accepted_timeliness_review
+        when 'irc'
+          :accepted_compliance_review
+        end
 
 
         kase = create factory, responding_team: team, responder: responder, identifier: ident

--- a/spec/services/stats/r004_cabinet_office_report_spec.rb
+++ b/spec/services/stats/r004_cabinet_office_report_spec.rb
@@ -5,10 +5,8 @@ require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
 module Stats
   describe R004CabinetOfficeReport do
     context 'sections 1, 2, 3' do
-
       before(:all) do
-        ReportType.delete_all
-        create :report_type, :r004
+        create_report_type(abbr: :r004)
 
         @frozen_time = Time.new 2017, 6, 14, 11, 20, 45
 
@@ -85,9 +83,7 @@ module Stats
 
       end
 
-      after(:all) do
-        DbHousekeeping.clean
-      end
+      after(:all) { DbHousekeeping.clean(seed: true) }
 
       context '1.A' do
         it 'records the total number' do
@@ -384,10 +380,8 @@ module Stats
     end
 
     context 'section 4' do
-
       before(:all) do
-        ReportType.delete_all
-        create :report_type, :r004
+        create_report_type(abbr: :r004)
 
         @frozen_time = Time.new 2017, 6, 14, 11, 20, 45
         CaseClosure::MetadataSeeder.seed!
@@ -418,7 +412,7 @@ module Stats
         end
       end
 
-      after(:all) { DbHousekeeping.clean }
+      after(:all) { DbHousekeeping.clean(seed: true) }
 
       context '4.A' do
         it 'counts the number of cases with just one exception s21 including in time and out of time' do

--- a/spec/services/stats/r005_monthly_performance_report_spec.rb
+++ b/spec/services/stats/r005_monthly_performance_report_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 module Stats
   describe R005MonthlyPerformanceReport do
 
-    before(:all) { create :report_type, :r005 }
-    after(:all) { ReportType.delete_all }
+    before(:all) { create_report_type(abbr: :r005) }
+    after(:all) { DbHousekeeping.clean(seed: true) }
 
     describe '.title' do
       it 'returns the title' do
@@ -65,7 +65,7 @@ module Stats
           [[1, :red], [7, :red], [13, :red]],   # March
           [[1, :red], [7, :green], [13, :red]], # April
           [],
-          [[1, :red], [7, :red], [13, :red]],   # Totals
+          [[1, :red], [7, :amber], [13, :red]],   # Totals
         ]
 
         expect(rag_ratings).to eq(expected)

--- a/spec/services/stats/r006_kilo_map_spec.rb
+++ b/spec/services/stats/r006_kilo_map_spec.rb
@@ -1,12 +1,9 @@
 require 'rails_helper'
 
 module Stats
-
-
   describe R006KiloMap do
 
     it 'produces a kilo map as a csv' do
-
       dacu_disclosure = BusinessUnit.dacu_disclosure
       dacu_disclosure.users.map(&:destroy)
       dacu_disclosure.team_lead = 'Jeremy Corbyn'

--- a/spec/services/stats/r007_closed_cases_report_spec.rb
+++ b/spec/services/stats/r007_closed_cases_report_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 module Stats
   describe R007ClosedCasesReport do
-    before(:all) { create :report_type, :r007 }
-    after(:all) { ReportType.delete_all }
+    before(:all) { create_report_type(abbr: :r007)}
+    after(:all) { DbHousekeeping.clean(seed: true) }
 
     describe '.title' do
       it 'returns correct title' do

--- a/spec/services/stats/r102_sar_appeals_performance_report_spec.rb
+++ b/spec/services/stats/r102_sar_appeals_performance_report_spec.rb
@@ -2,12 +2,8 @@ require 'rails_helper'
 
 module Stats
   describe R102SarAppealsPerformanceReport do
-
-
     before(:all) do
-      DbHousekeeping.clean
-
-      create :report_type, :r102
+      create_report_type(abbr: :r102)
 
       Team.all.map(&:destroy)
       Timecop.freeze Time.new(2017, 6, 30, 12, 0, 0) do
@@ -84,10 +80,7 @@ module Stats
       Team.where.not(id: required_teams.map(&:id)).destroy_all
     end
 
-    after(:all) do
-      DbHousekeeping.clean
-      ReportType.r102.destroy
-    end
+    after(:all) { DbHousekeeping.clean(seed: true) }
 
     describe '#title' do
       it 'returns the report title' do
@@ -117,49 +110,49 @@ module Stats
       it 'adds up directorate stats in each business_group' do
         expect(@results[@bizgrp_ab.id])
           .to eq({
-                   business_group:                @bizgrp_ab.name,
-                   directorate:                   '',
-                   business_unit:                 '',
-                   responsible:                   @bizgrp_ab.team_lead,
-                   ico_appeal_performance:        28.6,
-                   ico_appeal_total:              9,
-                   ico_appeal_responded_in_time:  2,
-                   ico_appeal_responded_late:     2,
-                   ico_appeal_open_in_time:       2,
-                   ico_appeal_open_late:          3,
-                 })
+            business_group:                @bizgrp_ab.name,
+            directorate:                   '',
+            business_unit:                 '',
+            responsible:                   @bizgrp_ab.team_lead,
+            ico_appeal_performance:        28.6,
+            ico_appeal_total:              9,
+            ico_appeal_responded_in_time:  2,
+            ico_appeal_responded_late:     2,
+            ico_appeal_open_in_time:       2,
+            ico_appeal_open_late:          3,
+          })
       end
 
       it 'adds up business_unit stats in each directorate' do
         expect(@results[@bizgrp_cd.id])
           .to eq({
-                   business_group:                @bizgrp_cd.name,
-                   directorate:                   '',
-                   business_unit:                 '',
-                   responsible:                   @bizgrp_cd.team_lead,
-                   ico_appeal_performance:        50.0,
-                   ico_appeal_total:              3,
-                   ico_appeal_responded_in_time:  1,
-                   ico_appeal_responded_late:     1,
-                   ico_appeal_open_in_time:       1,
-                   ico_appeal_open_late:          0,
-                 })
+            business_group:                @bizgrp_cd.name,
+            directorate:                   '',
+            business_unit:                 '',
+            responsible:                   @bizgrp_cd.team_lead,
+            ico_appeal_performance:        50.0,
+            ico_appeal_total:              3,
+            ico_appeal_responded_in_time:  1,
+            ico_appeal_responded_late:     1,
+            ico_appeal_open_in_time:       1,
+            ico_appeal_open_late:          0,
+          })
       end
 
       it 'adds up individual business_unit stats' do
         expect(@results[@team_c.id])
           .to eq({
-                   business_group:                @bizgrp_cd.name,
-                   directorate:                   @dir_cd.name,
-                   business_unit:                 @team_c.name,
-                   responsible:                   @team_c.team_lead,
-                   ico_appeal_performance:        50.0,
-                   ico_appeal_total:              2,
-                   ico_appeal_responded_in_time:  1,
-                   ico_appeal_responded_late:     1,
-                   ico_appeal_open_in_time:       0,
-                   ico_appeal_open_late:          0,
-                 })
+            business_group:                @bizgrp_cd.name,
+            directorate:                   @dir_cd.name,
+            business_unit:                 @team_c.name,
+            responsible:                   @team_c.team_lead,
+            ico_appeal_performance:        50.0,
+            ico_appeal_total:              2,
+            ico_appeal_responded_in_time:  1,
+            ico_appeal_responded_late:     1,
+            ico_appeal_open_in_time:       0,
+            ico_appeal_open_late:          0,
+          })
       end
     end
 
@@ -255,20 +248,20 @@ module Stats
       if responded_date.nil?
         factory = "accepted_ico_#{type}_case".to_sym
         kase = create factory,
-                      creation_time: received_date,
-                      external_deadline: deadline_date,
-                      responding_team: team,
-                      responder: responder,
-                      identifier: ident
+          creation_time: received_date,
+          external_deadline: deadline_date,
+          responding_team: team,
+          responder: responder,
+          identifier: ident
       else
         factory = "responded_ico_#{type}_case".to_sym
         kase = create factory,
-                      creation_time: received_date,
-                      external_deadline: deadline_date,
-                      responding_team: team,
-                      responder: responder,
-                      date_responded: responded_date,
-                      identifier: ident
+          creation_time: received_date,
+          external_deadline: deadline_date,
+          responding_team: team,
+          responder: responder,
+          date_responded: responded_date,
+          identifier: ident
       end
       kase
     end

--- a/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
+++ b/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 module Stats
   describe R103SarBusinessUnitPerformanceReport do
 
-    before(:all) { find_or_create :report_type, :r103 }
-    after(:all) { ReportType.delete_all }
+    before(:all) { create_report_type(abbr: :r103) }
+    after(:all) { DbHousekeeping.clean(seed: true) }
 
     context 'date management, titles, description, etc' do
       context 'defining the period' do
@@ -42,7 +42,6 @@ module Stats
 
     context 'data' do
       before(:all) do
-        DbHousekeeping.clean
         @bizgrp_ab = create :business_group, name: 'BGAB'
         @dir_a     = create :directorate, name: 'DRA', business_group: @bizgrp_ab
         @dir_b     = create :directorate, name: 'DRB', business_group: @bizgrp_ab
@@ -89,10 +88,8 @@ module Stats
         Team.where('id > ?', @team_d.id).destroy_all
       end
 
-      after(:all)  { DbHousekeeping.clean }
 
       context 'without business unit columns' do
-
         # We only test that the correct cases are being selected for analysis.  The
         # analysis work, rolling up of business group and directorate toatls and calcualtion
         # of percentages is carried out in BasePerformanceUnitReport, and is fully testing

--- a/spec/services/stats/r105_sar_monthly_performance_report_spec.rb
+++ b/spec/services/stats/r105_sar_monthly_performance_report_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 module Stats
   describe R105SarMonthlyPerformanceReport do
+    after(:all) { DbHousekeeping.clean(seed: true) }
+
     describe '.title' do
       it 'returns correct title' do
         expect(R105SarMonthlyPerformanceReport.title).to eq 'Monthly report'
@@ -17,11 +19,7 @@ module Stats
 
     describe '#case_scope' do
       before do
-        create(:report_type, :r105) unless ReportType.find_by(abbr: 'R105')
-      end
-
-      after do
-        ReportType.r105.destroy if ReportType.find_by(abbr: 'R105')
+        create_report_type(abbr: :r105)
       end
 
       before(:all) do
@@ -67,7 +65,7 @@ module Stats
           in_time_unassigned_trigger_sar_case.update_attributes(
             external_deadline: Date.current + 10.days
           )
-          
+
           report = R105SarMonthlyPerformanceReport.new(
             period_start: @period_start,
             period_end: @period_end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,17 +17,16 @@
 require 'devise'
 require 'capybara/rspec'
 require 'pundit/rspec'
-
 require 'aws-sdk'
 
 # Required or we'll get errors when we try to pre-sign S# direct uploads.
 ENV['AWS_ACCESS_KEY_ID']     = 'test_access_key_id'
 ENV['AWS_SECRET_ACCESS_KEY'] = 'test_secret_access_key'
 
-
 RSpec.configure do |config|
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples

--- a/spec/support/create_report_type.rb
+++ b/spec/support/create_report_type.rb
@@ -1,0 +1,13 @@
+def create_report_type(abbr:, **options)
+  report_type = nil
+
+  begin
+    if !(report_type = ReportType.find_by(abbr: abbr.upcase))
+      report_type = find_or_create :report_type, abbr: abbr.upcase, **options
+    end
+  rescue
+    report_type = find_or_create :report_type, abbr.to_sym, **options
+  end
+
+  report_type
+end

--- a/spec/support/db_housekeeping.rb
+++ b/spec/support/db_housekeeping.rb
@@ -18,6 +18,7 @@ module DbHousekeeping
       cases_users_transitions_trackers
       linked_cases
       search_queries
+      report_types
     )
     tables.each do |table|
       ActiveRecord::Base.connection.execute("TRUNCATE #{table} CASCADE")


### PR DESCRIPTION
## Description
These changes are the latest attempt to rectify by ensuring the report_types table is in a consistent state (as well as the other tables) and therefore reduce the potential for test errors when using parallel tests.
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
  
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2408

### Notes
ReportType has the standard id as a primary key. It also has an abbr string field which is not constrained in the codebase. However, a database index exists which prevents abbr duplicates from being inserted and therefore makes abbr a secondary primary key.

This causes immense problems with intermittent build failures when using parallel_tests (i.e. on SemaphoreCI).


### Manual testing instructions
Run `rails:parallel:spec` locally and note results
