### PR TITLE
CT-2419 Separate file fragments using new line character

### DIFF
--- a/app/services/stats/etl/closed_cases.rb
+++ b/app/services/stats/etl/closed_cases.rb
@@ -102,7 +102,7 @@ module Stats
 
       def new_fragment(filename, data)
         file = Tempfile.new([filename, '.csv'], folder)
-        file.write(data)
+        file.write(data, "\n")
         file.close
         file
       end

--- a/spec/services/stats/etl/closed_cases_spec.rb
+++ b/spec/services/stats/etl/closed_cases_spec.rb
@@ -78,7 +78,7 @@ module Stats
           filename = 'useless-file'
           data = 'My name is bob'
           file = closed_cases_etl.send(:new_fragment, filename, data)
-          expect(file.size).to be 15 # 14 bytes + new line char
+          expect(file.size).to be 15 # 14 chars + new line char
         end
 
         it 'allows multiple fragments to be concatenated with new line' do

--- a/spec/services/stats/etl/closed_cases_spec.rb
+++ b/spec/services/stats/etl/closed_cases_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 require 'fileutils'
+require 'csv'
 
 module Stats
   module ETL
@@ -77,7 +78,28 @@ module Stats
           filename = 'useless-file'
           data = 'My name is bob'
           file = closed_cases_etl.send(:new_fragment, filename, data)
-          expect(file.size).to be 14 # bytes
+          expect(file.size).to be 15 # 14 bytes + new line char
+        end
+
+        it 'allows multiple fragments to be concatenated with new line' do
+          files = []
+          folder = closed_cases_etl.send(:folder)
+          data = 'Baa Baa Black Sheep, Have you any wool?, Yes sir, Yes sir'
+
+          3.times do |i|
+            filename = "csv-fragment-#{i}.csv"
+            files << closed_cases_etl.send(:new_fragment, filename, "#{data}-row#{i}")
+          end
+
+          `cd #{folder}; cat csv-fragment-* > test.csv`
+
+          rows = CSV.read("#{folder}/test.csv")
+          expect(rows.size).to eq 3
+
+          # Crude check to show each row is different
+          expect(rows[0].last.end_with? '-row0').to be true
+          expect(rows[1].last.end_with? '-row1').to be true
+          expect(rows[2].last.end_with? '-row2').to be true
         end
       end
 


### PR DESCRIPTION
## Description
On the Linux production servers, generating closed cases results in odd concatenation behaviour resulting in a CSV file all occupying one spreadsheet row.
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
 
### Screenshots
N/A
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2419
 
### Deployment
N/A
 
### Manual testing instructions
Download a closed case report. Should open in excel or similar as expected.
