### PR TITLE
CT-2149 Second attempt at generating new line between files

### DIFF
--- a/spec/services/stats/etl/closed_cases_spec.rb
+++ b/spec/services/stats/etl/closed_cases_spec.rb
@@ -9,17 +9,17 @@ module Stats
         Case::Base.all
       }
 
-      let(:closed_cases_etl) {
+      before(:all) do
         7.times do
           ::Warehouse::CaseReport.generate(create :foi_case)
         end
 
-        described_class.new(retrieval_scope: default_retrieval_scope)
-      }
+        @etl = described_class.new(retrieval_scope: Case::Base.all)
+      end
 
       describe '#initialize' do
         it 'generates a single zip file from multiple csv files' do
-          fragments_dir = closed_cases_etl.send(:folder)
+          fragments_dir = @etl.send(:folder)
 
           expect(Dir["#{fragments_dir}/closed-cases.csv"].first).to be_present
           expect(Dir["#{fragments_dir}/closed-cases.zip"].first).to be_present
@@ -27,46 +27,36 @@ module Stats
       end
 
       describe '#extract' do
-        let(:etl) {
-          described_class.new(retrieval_scope: default_retrieval_scope)
-        }
-        
-        let(:fragments_dir) { etl.send(:folder) }
+        let(:fragments_dir) { @etl.send(:folder) }
 
         it 'returns self' do
-          expect(etl.extract).to eq etl
+          expect(@etl.extract).to eq @etl
         end
 
         it 'generates the CSV header file (fragment)' do
-          expect(Dir["#{fragments_dir}/fragment_00_header*"].first).to be_present
+          expect(Dir["#{fragments_dir}/00-fragment-*"].first).to be_present
         end
 
         it 'generates 1 or more CSV files (fragments)' do
-          expect(Dir["#{fragments_dir}/fragment_01*"].first).to be_present
+          expect(Dir["#{fragments_dir}/01-fragment-*"].first).to be_present
         end
       end
 
       describe '#transform' do
         it 'returns self' do
-          etl = described_class.new(retrieval_scope: default_retrieval_scope)
-          expect(etl.transform).to eq etl
+          expect(@etl.transform).to eq @etl
         end
       end
 
       describe '#load' do
-        it 'returns self' do
-          etl = described_class.new(retrieval_scope: default_retrieval_scope)
-          expect(etl.load).to eq etl
-        end
-
         it 'sets the results_filepath on success' do
-          expect(closed_cases_etl.results_filepath).to be_present
+          expect(@etl.results_filepath).to be_present
         end
       end
 
       describe '#num_fragments' do
         it 'returns the number of csv files to generate' do
-          num_fragments = closed_cases_etl.send(:num_fragments)
+          num_fragments = @etl.send(:num_fragments)
 
           expect(::Warehouse::CaseReport.all.size).to eq 7
           expect(num_fragments).to eq 1
@@ -75,37 +65,52 @@ module Stats
 
       describe '#new_fragment' do
         it 'saves a new temp file with the given data' do
-          filename = 'useless-file'
           data = 'My name is bob'
-          file = closed_cases_etl.send(:new_fragment, filename, data)
-          expect(file.size).to be 15 # 14 chars + new line char
+          file = @etl.send(:new_fragment, data)
+          expect(file.size).to be 14 # bytes
         end
 
-        it 'allows multiple fragments to be concatenated with new line' do
+        it 'allows multiple fragments to be concatenated' do
           files = []
-          folder = closed_cases_etl.send(:folder)
+          folder = @etl.send(:folder)
           data = 'Baa Baa Black Sheep, Have you any wool?, Yes sir, Yes sir'
 
+          `cd #{folder}; rm *.*`
+
+          # Note explicit addition of new-line character
           3.times do |i|
-            filename = "csv-fragment-#{i}.csv"
-            files << closed_cases_etl.send(:new_fragment, filename, "#{data}-row#{i}")
+            files << @etl.send(:new_fragment, "#{data} -> row#{i}\n")
           end
 
-          `cd #{folder}; cat csv-fragment-* > test.csv`
+          num_files = `ls -1 #{folder} | wc -l`.to_i
+          expect(files.size).to eq 3
+          expect(num_files).to eq 3
+
+          `cd #{folder}; cat *.csv > test.csv`
 
           rows = CSV.read("#{folder}/test.csv")
           expect(rows.size).to eq 3
 
           # Crude check to show each row is different
-          expect(rows[0].last.end_with? '-row0').to be true
-          expect(rows[1].last.end_with? '-row1').to be true
-          expect(rows[2].last.end_with? '-row2').to be true
+          expect(rows[0].last.end_with? '-> row0').to be true
+          expect(rows[1].last.end_with? '-> row1').to be true
+          expect(rows[2].last.end_with? '-> row2').to be true
+        end
+
+        it 'increments current fragment number' do
+          data = 'Twinkle Twinkle Little Star'
+          @etl.instance_variable_set(:@current_fragment_num, 0)
+          file0 = @etl.send(:new_fragment, data)
+          file1 = @etl.send(:new_fragment, data)
+
+          expect(File.basename(file0.path).starts_with? '00-').to be true
+          expect(File.basename(file1.path).starts_with? '01-').to be true
         end
       end
 
       describe '#folder' do
         it 'returns a folder path to store temp files in' do
-          path = closed_cases_etl.send(:folder)
+          path = @etl.send(:folder)
           file = File.new(path + 'test-file.txt', 'w')
           expect(file).to be_present
         end
@@ -113,10 +118,10 @@ module Stats
 
       describe '#heading' do
         it 'returns a single line CSV' do
-          header = closed_cases_etl.send(:heading)
+          header = @etl.send(:heading)
           expect(header.size).to be > 0
           expect(header).to match(/([a-zA-Z0-9,\s])+/)
-          expect(header.include? "\n").to be false
+          expect(header.ends_with? "\n").to be true
           expect(header.last).not_to be ','
         end
       end
@@ -124,7 +129,7 @@ module Stats
       describe '#columns' do
         it 'returns list of Warehouse::CaseReport field names' do
           case_report = ::Warehouse::CaseReport.new
-          closed_cases_etl.send(:columns).each do |field|
+          @etl.send(:columns).each do |field|
             expect(case_report).to respond_to field
           end
         end
@@ -132,8 +137,18 @@ module Stats
 
       describe '#filename' do
         it 'should be a zip file' do
-          expect(closed_cases_etl.send(:filename).include?('.zip')).to be true
+          expect(@etl.send(:filename).include?('.zip')).to be true
         end
+      end
+
+      describe '#generate_header_fragment' do
+        subject { @etl.send(:generate_header_fragment) }
+        it { should respond_to :each }
+      end
+
+      describe '#generate_data_fragment' do
+        subject { @etl.send(:generate_data_fragments) }
+        it { should respond_to :each }
       end
     end
   end


### PR DESCRIPTION
## Description
On the production server, downloading the closed cases report results in a malformed CSV file because there is no newline character at the end of the header (line 1). This patch generates the header using ruby `CSV` class and removes the explicit newline added by `#new_fragment`.

Took the opportunity to  extract some code into functions.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [X] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
 
### Screenshots
N/A
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2419
 
### Deployment
N/A
 
### Manual testing instructions
Download a closed case with a small date interval initially. Open the resulting `closed-cases.csv` file in your favourite spreadsheet program. It should be properly output with a header and data rows thereafter.
