### PR TITLE
CT-2372 Update dependabot recommended gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'paper_trail', '~> 10.3'
 gem 'pg', '~> 1.1'
 gem 'pg_search', '~> 2.3.0'
 gem 'pry-rails'
-gem 'puma', '~> 4.0'
+gem 'puma', '~> 4.1'
 gem 'pundit', '~>2.0'
 gem 'rails', '~> 5.0.7.2'
 gem 'rails-data-migrations', '~> 1.1.0'
@@ -68,7 +68,7 @@ gem 'uglifier', '>= 1.3.0'
 # gem 'bcrypt', '~> 3.1.7'
 
 group :test do
-  gem 'capybara', '~> 3.25.0'
+  gem 'capybara', '~> 3.28.0'
   gem 'codeclimate-test-reporter', '~> 1.0'
   gem 'i18n-tasks', '~> 0.9.29'
   gem 'rails-controller-testing', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
       activesupport (>= 3.2.0)
       tzinfo
     byebug (11.0.1)
-    capybara (3.25.0)
+    capybara (3.28.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -345,7 +345,7 @@ GEM
     net-http-digest_auth (1.4.1)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    nio4r (2.3.1)
+    nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
@@ -355,8 +355,8 @@ GEM
       jwt (>= 1.5, < 3)
     ntlm-http (0.1.1)
     orm_adapter (0.5.0)
-    paper_trail (10.3.0)
-      activerecord (>= 4.2, < 6.1)
+    paper_trail (10.3.1)
+      activerecord (>= 4.2)
       request_store (~> 1.1)
     parallel (1.17.0)
     parallel_tests (2.29.1)
@@ -377,7 +377,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (3.1.1)
-    puma (4.0.1)
+    puma (4.1.0)
       nio4r (~> 2.0)
     pundit (2.0.1)
       activesupport (>= 3.0.0)
@@ -425,7 +425,7 @@ GEM
       ffi (~> 1.0)
     recursive-open-struct (1.1.0)
     redis (4.1.1)
-    regexp_parser (1.5.1)
+    regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
     responders (2.4.1)
@@ -461,8 +461,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-performance (1.3.0)
-      rubocop (>= 0.68.0)
+    rubocop-performance (1.4.1)
+      rubocop (>= 0.71.0)
     rubocop-rspec (1.35.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
@@ -597,7 +597,7 @@ DEPENDENCIES
   bullet (~> 6.0.1)
   business_time
   byebug
-  capybara (~> 3.25.0)
+  capybara (~> 3.28.0)
   codeclimate-test-reporter (~> 1.0)
   colorize
   config (~> 2.0)
@@ -638,7 +638,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-rails
-  puma (~> 4.0)
+  puma (~> 4.1)
   pundit (~> 2.0)
   rails (~> 5.0.7.2)
   rails-controller-testing


### PR DESCRIPTION
## Description
Regular Dependabot generated gem updates. Includes:

- #883 Bump rubocop-performance from 1.3.0 to 1.4.1
- #882 Bump puma from 4.0.1 to 4.1.0
- #881 Bump paper_trail from 10.3.0 to 10.3.1
- #880 Bump capybara from 3.25.0 to 3.28.0

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
 
### Screenshots
N/A
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2372
 
### Deployment
N/A
 
### Manual testing instructions
N/A
