### PR TITLE
Attempt to get feature specs running headless again

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,20 +41,18 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :headless_chrome do |app|
-  if ENV['CHROME_DEBUG'].present?
-    configurationSetting = {}
-  else
-    configurationSetting = { args: %w(headless disable-gpu no-sandbox --start-maximized
-                                      --window-size=1980,2080 --enable-features=NetworkService,NetworkServiceInProcess) }
+  options = Selenium::WebDriver::Chrome::Options.new
+
+  unless ENV["CHROME_DEBUG"]
+    options.add_argument('--headless')
+    options.add_argument('--disable-gpu')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--start-maximized')
+    options.add_argument('--window-size=1980,2080')
+    options.add_argument('--enable-features=NetworkService,NetworkServiceInProcess')
   end
 
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-      chromeOptions: configurationSetting
-  )
-
-  Capybara::Selenium::Driver.new app,
-    browser: :chrome,
-    desired_capabilities: capabilities
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 
 Capybara.javascript_driver = :headless_chrome


### PR DESCRIPTION
## Description
At some point, SOMETHING stopped our headless specs running headless - we became headlessless. 

This PR introduces a tentative change which restores the ability for our JS feature specs to run headless and use CHROME_DEBUG=1 if you want to see them run
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
 
### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
 
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
 
### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->