### PR TITLE
CT-2380 Display case information

### DIFF
--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -83,9 +83,8 @@ class Case::SAR::Offender < Case::Base
   before_validation :reassign_gov_uk_dates
   before_save :set_subject
 
-  def set_subject
-    self.subject = subject_full_name
-  end
+  before_save :use_subject_as_requester,
+              if: -> { name.blank? }
 
   def validate_received_date
     super
@@ -131,5 +130,15 @@ class Case::SAR::Offender < Case::Base
   # the case state should not change
   def allow_waiting_for_data_state?
     self.current_state == 'data_to_be_requested'
+  end
+
+  private
+
+  def set_subject
+    self.subject = subject_full_name
+  end
+
+  def use_subject_as_requester
+    self.name = self.subject_full_name
   end
 end

--- a/app/views/cases/offender_sar/_case_details.html.slim
+++ b/app/views/cases/offender_sar/_case_details.html.slim
@@ -9,6 +9,11 @@
       tbody.sar-basic-details
         = render partial: 'cases/shared/case_type', locals: { case_details: case_details }
         = render partial: 'cases/sar/data_subject', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar/prison_number', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar/subject_aliases', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar/previous_case_numbers', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar/other_subject_ids', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar/date_of_birth', locals: { case_details: case_details }
         = render partial: 'cases/sar/subject_type', locals: { case_details: case_details }
         = render partial: 'cases/sar/third_party', locals: { case_details: case_details }
         = render partial: 'cases/shared/requester_name', locals: { case_details: case_details }

--- a/app/views/cases/offender_sar/_date_of_birth.html.slim
+++ b/app/views/cases/offender_sar/_date_of_birth.html.slim
@@ -1,0 +1,3 @@
+tr.date-of-birth
+  th = t('common.case.date_of_birth')
+  td = l case_details.date_of_birth, format: :default

--- a/app/views/cases/offender_sar/_other_subject_ids.html.slim
+++ b/app/views/cases/offender_sar/_other_subject_ids.html.slim
@@ -1,0 +1,3 @@
+tr.other-subject-ids
+  th = t('common.case.other_subject_ids')
+  td = case_details.other_subject_ids

--- a/app/views/cases/offender_sar/_previous_case_numbers.html.slim
+++ b/app/views/cases/offender_sar/_previous_case_numbers.html.slim
@@ -1,0 +1,3 @@
+tr.previous-case-numbers
+  th = t('common.case.previous_case_numbers')
+  td = case_details.previous_case_numbers

--- a/app/views/cases/offender_sar/_prison_number.html.slim
+++ b/app/views/cases/offender_sar/_prison_number.html.slim
@@ -1,0 +1,3 @@
+tr.prison-number
+  th = t('common.case.prison_number')
+  td = case_details.prison_number

--- a/app/views/cases/offender_sar/_subject_aliases.html.slim
+++ b/app/views/cases/offender_sar/_subject_aliases.html.slim
@@ -1,0 +1,3 @@
+tr.subject-aliases
+  th = t('common.case.subject_aliases')
+  td = case_details.subject_aliases

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -262,7 +262,7 @@ en:
     create_case: Create case
     feedback: Send feedback
     next_page_assign: Create case
-    request_amends: Request amends 
+    request_amends: Request amends
     save_changes: Save changes
     search: Search
 
@@ -306,6 +306,8 @@ en:
         flag_for_disclosure_specialists: Flag for disclosure specialist?
         subject_type: Who is the person the information is being requested about?
         third_party: Is the information being requested on someone's behalf?
+      offender_sar:
+        third_party: Please choose yes or no
       report:
         correspondence_type: Which type of cases do you want to report on?
         report_type_id: What should this report cover?
@@ -524,6 +526,7 @@ en:
       date_draft_uploaded: Date draft uploaded
       date_ico_decision_received: Date ICO's decision was received
       date_responded: Date response sent to requester
+      date_of_birth: Date of birth
       draft_timeliness: Draft timeliness
       case/ico:
         date_responded: Date response sent to ICO
@@ -544,6 +547,9 @@ en:
       header_subject: "Case subject, "
       late_team: Business unit responsible for late response
       name: Requester
+      other_subject_ids: "Subject's PNC or other ID numbers"
+      previous_case_numbers: Previous SAR cases
+      prison_number: "Prison number"
       postal_address: "Requester’s postal address"
       progress_for_clearance: "Ready for Disclosure clearance"
       received_date: Date request received at MOJ
@@ -563,6 +569,7 @@ en:
       requester_type: "Type of requester"
       sar_response_address: Where the information should be sent
       status: Status
+      subject_aliases: Subject aliases
       third_party: Information requested on someone's behalf?
       third_party_relationship: Third party relationship
       time_taken: Time taken
@@ -612,7 +619,7 @@ en:
         heading: Cases
         subheadings:
           number_of_cases_created_over_past_week: No of Cases created over the past week
-          existing_cases: Existing cases 
+          existing_cases: Existing cases
         date: Date
         no_of_cases: No. of Cases
         id: ID
@@ -928,7 +935,7 @@ en:
     reassign_user:
       heading: Change team member
       action: Change team member
-    select_team: 
+    select_team:
       heading: Select team
     take_case_on:
       success: Case taken on

--- a/spec/factories/case/offender_sars.rb
+++ b/spec/factories/case/offender_sars.rb
@@ -27,6 +27,7 @@ FactoryBot.define do
     sequence(:subject_aliases)      { |n| "#{identifier} subject alias #{n}" }
     previous_case_numbers           { '54321' }
     prison_number                   { '123465' }
+    other_subject_ids               { 'ABC 123 DEF' }
     subject_type                    { 'offender' }
     third_party                     { false }
     flag_as_high_profile            { false }

--- a/spec/features/cases/filters/external_deadline_spec.rb
+++ b/spec/features/cases/filters/external_deadline_spec.rb
@@ -12,15 +12,17 @@ feature 'filtering by external deadline' do
 
       @setup = StandardSetup.new(only_cases: @all_cases)
 
-      @case_due_today = create :case,
+      Timecop.freeze(4.business_hours.from_now) do
+        @case_due_today = create :case,
                                received_date: 20.business_days.ago,
                                subject: 'prison guards today'
-      @case_due_next_3_days = create :case,
+        @case_due_next_3_days = create :case,
                                      received_date: 18.business_days.ago,
                                      subject: 'prison guards next 3 days'
-      @case_due_next_10_days = create :case,
+        @case_due_next_10_days = create :case,
                                       received_date: 10.business_days.ago,
                                       subject: 'prison guards next 10 days'
+      end
 
       @all_case_numbers = @setup.cases.values.map(&:number) +
                           [

--- a/spec/site_prism/page_objects/pages/application.rb
+++ b/spec/site_prism/page_objects/pages/application.rb
@@ -104,6 +104,7 @@ module PageObjects
         overturned_foi_case_details:  'Cases::OverturnedFOI::CaseDetailsSection',
         overturned_ico_new_form:      'Cases::OverturnedICO::NewFormSection',
         overturned_sar_case_details:  'Cases::OverturnedSAR::CaseDetailsSection',
+        offender_sar_case_details:    'Cases::OffenderSAR::CaseDetailsSection',
         dropzonejs_preview_template:  'Shared::DropzoneJSPreviewTemplateSection',
         pagination:                   'PaginationSection',
       }.each do |section_name, section_class|

--- a/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
@@ -1,0 +1,134 @@
+module PageObjects
+  module Sections
+    module Cases
+      module OffenderSAR
+        class CaseDetailsSection < SitePrism::Section
+
+        element :section_heading, '.case-details .request--heading'
+        element :original_section_heading,
+                '.original-case-details .request--heading'
+
+        section :sar_basic_details, '.sar-basic-details' do
+          section :case_type, 'tr.case-type' do
+            element :sar_trigger, 'td .sar-trigger'
+            element :data, 'td'
+          end
+
+          section :data_subject, 'tr.data-subject' do
+            element :data, 'td'
+          end
+
+          section :data_subject_type, 'tr.data-subject-type' do
+            element :data, 'td'
+          end
+
+          section :requester_name, 'tr.requester-name' do
+            element :data, 'td'
+          end
+
+          section :third_party, 'tr.third-party' do
+            element :data, 'td'
+          end
+
+          section :prison_number, 'tr.prison-number' do
+            element :data, 'td'
+          end
+
+          section :subject_aliases, 'tr.subject-aliases' do
+            element :data, 'td'
+          end
+
+          section :previous_case_numbers, 'tr.previous-case-numbers' do
+            element :data, 'td'
+          end
+
+          section :other_subject_ids, 'tr.other-subject-ids' do
+            element :data, 'td'
+          end
+
+          section :date_received, 'tr.date-received' do
+            element :data, 'td'
+          end
+
+          section :date_of_birth, 'tr.date-of-birth' do
+            element :data, 'td'
+          end
+
+          section :internal_deadline, 'tr.case-internal-deadline' do
+            element :data, 'td'
+          end
+
+          section :external_deadline, 'tr.case-external-deadline' do
+            element :data, 'td'
+          end
+
+          section :response_address, 'tr.response-address' do
+            element :data, 'td'
+          end
+
+          section :team,  'tr.team' do
+            element :data, 'td'
+          end
+        end
+
+        section :responders_details, '.responder-details' do
+          section :team, '.team' do
+            element :data, 'td'
+          end
+
+          section :name, '.responder-name' do
+            element :data, 'td'
+          end
+        end
+
+        section :compliance_details, '.compliance-details' do
+          section :compliance_date, '.compliance-date' do
+            element :data, 'td'
+          end
+
+          section :compliant_timeliness, '.compliant-timeliness' do
+            element :data, 'td'
+          end
+        end
+
+        section :response_details, '.response-details' do
+
+          section :date_responded, '.date-responded' do
+            element :data, 'td'
+          end
+
+          section :timeliness, '.timeliness' do
+            element :data, 'td'
+          end
+
+          section :time_taken, '.time-taken' do
+            element :data, 'td'
+          end
+
+          section :info_held, '.info-held' do
+            element :data, 'td'
+          end
+          section :outcome, '.outcome' do
+            element :data, 'td'
+          end
+
+          section :refusal_reason, '.refusal-reason' do
+            element :data, 'td'
+          end
+
+          section :exemptions, '.exemptions' do
+            elements :list, 'td ul li'
+          end
+        end
+
+
+
+        element :edit_case, :xpath, '//a[contains(.,"Edit case details")]'
+        element :edit_case_link, :xpath, '//a[contains(.,"Edit case details")]'
+        element :edit_closure, :xpath, '//a[contains(.,"Edit closure details")]'
+        element :view_original_case_link, :xpath, '//a[contains(.,"See full original case details ")]'
+        end
+      end
+    end
+  end
+end

--- a/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe 'cases/sar/case_details.html.slim', type: :view do
+  let(:offender_sar_case) {
+    (create :offender_sar_case, subject_aliases: 'John Smith',
+            date_of_birth: '2019-09-01').decorate
+  }
+
+  let(:branston_user)             { find_or_create :branston_user }
+
+
+  def login_as(user)
+    allow(view).to receive(:current_user).and_return(user)
+    super(user)
+  end
+
+  before(:each) { login_as branston_user }
+
+  describe 'basic_details' do
+    it 'displays the initial case details (non third party case)' do
+      assign(:case, offender_sar_case)
+      render partial: 'cases/offender_sar/case_details.html.slim',
+             locals: { case_details: offender_sar_case,
+                       link_type: nil }
+
+      partial = offender_sar_case_details_section(rendered).sar_basic_details
+      expect(case_details_section(rendered).section_heading.text).to eq 'Case details'
+
+      expect(partial.case_type).to have_no_sar_trigger
+      expect(partial.case_type.data.text).to eq "OFFENDER_SAR  "
+      expect(partial.date_received.data.text)
+          .to eq offender_sar_case.received_date.strftime(Settings.default_date_format)
+      expect(partial.external_deadline.data.text)
+          .to eq offender_sar_case.external_deadline
+      expect(partial.third_party.data.text).to eq 'No'
+      expect(partial.prison_number.data.text).to eq '123465'
+
+      expect(partial.subject_aliases.data.text).to eq 'John Smith'
+      expect(partial.previous_case_numbers.data.text).to eq '54321'
+      expect(partial.other_subject_ids.data.text).to eq 'ABC 123 DEF'
+      expect(partial.date_of_birth.data.text).to eq '1 Sep 2019'
+    end
+
+    it 'displays third party details if present' do
+      third_party_case = (create :sar_case, :third_party, name: 'Rick Westor').decorate
+      assign(:case, third_party_case)
+      render partial: 'cases/sar/case_details.html.slim', locals: {
+        case_details: third_party_case,
+        link_type: nil
+      }
+      partial = case_details_section(rendered).sar_basic_details
+      expect(partial.third_party.data.text).to eq 'Yes'
+      expect(partial.requester_name.data.text).to eq 'Rick Westor'
+    end
+
+    it 'does not display the email address if one is not provided' do
+      offender_sar_case.email = nil
+      offender_sar_case.postal_address = "1 High Street\nAnytown\nAT1 1AA"
+      offender_sar_case.reply_method = 'send_by_post'
+
+      assign(:case, offender_sar_case)
+      render partial: 'cases/sar/case_details.html.slim',
+             locals: { case_details: offender_sar_case,
+                       link_type: nil }
+
+      partial = case_details_section(rendered).sar_basic_details
+
+      expect(partial).to have_response_address
+      expect(partial.response_address.data.text).to eq "1 High Street\nAnytown\nAT1 1AA"
+    end
+
+    it 'does not display the postal address if one is not provided' do
+      offender_sar_case.postal_address = nil
+      offender_sar_case.email = 'john.doe@moj.com'
+
+      assign(:case, offender_sar_case)
+      render partial: 'cases/sar/case_details.html.slim',
+             locals:{ case_details: offender_sar_case,
+                      link_type: nil }
+
+      partial = case_details_section(rendered).sar_basic_details
+
+      expect(partial).to have_response_address
+      expect(partial.response_address.data.text).to eq 'john.doe@moj.com'
+    end
+  end
+end

--- a/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
@@ -27,7 +27,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
       expect(case_details_section(rendered).section_heading.text).to eq 'Case details'
 
       expect(partial.case_type).to have_no_sar_trigger
-      expect(partial.case_type.data.text).to eq "OFFENDER_SAR  "
+      expect(partial.case_type.data.text).to eq "OFFENDER-SAR  "
       expect(partial.date_received.data.text)
           .to eq offender_sar_case.received_date.strftime(Settings.default_date_format)
       expect(partial.external_deadline.data.text)


### PR DESCRIPTION
## Description
Up until now, we've been capturing some details and not displaying them on the Case page. This PR addresses this by outputting the subject details for Prison Number, Subject Aliases, Other IDs and Previous case numbers. It also adds a view spec and relevant site prism sections for offender sar
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/64022461-2f0fa780-cb2e-11e9-83a8-0d95e322ba50.png)
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2380
 
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
 
### Manual testing instructions
Create an offender SAR, taking care to add unique information for the fields named above; ensure they display correctly. Also, if the subject is the requester, their name should be output for requester.