### PR TITLE
CT-2404 Replace empty name with subject on closed case table

### DIFF
--- a/app/decorators/case/base_decorator.rb
+++ b/app/decorators/case/base_decorator.rb
@@ -195,6 +195,10 @@ class Case::BaseDecorator < Draper::Decorator
     end
   end
 
+  def closed_case_name
+    self.name.blank? ? self.subject : self.name
+  end
+
   private
 
   def translation_for_case(kase, path, key, options = {})

--- a/app/views/cases/filters/closed.html.slim
+++ b/app/views/cases/filters/closed.html.slim
@@ -36,7 +36,7 @@
               = kase.trigger_case_marker
             td aria-label="#{t('.name-subject')}"
               strong
-                = kase.name == '' ? kase.subject : kase.name
+                = kase.closed_case_name
               br
               span
                 = kase.subject

--- a/app/views/cases/filters/closed.html.slim
+++ b/app/views/cases/filters/closed.html.slim
@@ -36,7 +36,7 @@
               = kase.trigger_case_marker
             td aria-label="#{t('.name-subject')}"
               strong
-                = kase.name
+                = kase.name == '' ? kase.subject : kase.name
               br
               span
                 = kase.subject

--- a/spec/decorators/case/base_decorator_spec.rb
+++ b/spec/decorators/case/base_decorator_spec.rb
@@ -438,4 +438,39 @@ describe Case::BaseDecorator, type: :model do
       expect(accepted_case.pretty_type).to eq 'FOI'
     end
   end
+  describe '#closed_case_name' do
+
+    class MockCase
+      def initialize(representative_name:)
+        @representative_name = representative_name
+        @subject = 'Monalisa Khan'
+      end
+
+      def representative_name
+        @representative_name
+      end
+
+      def subject
+        @subject
+      end
+    end
+
+    context 'when case represenatative name is empty' do
+      it 'returns the subject as the represenatative' do
+        kase = MockCase.new(
+          representative_name: '',
+        )
+        expect(closed_case_name(kase)).to eq 'Monalisa Khan'
+      end
+    end
+
+    context 'when case represenatative name is not empty' do
+      it 'returns the case represenatative name' do
+        kase = MockCase.new(
+          representative_name: 'Ingrid Myers',
+        )
+        expect(closed_case_name(kase)).to eq 'Ingrid Myers'
+      end
+    end
+  end
 end

--- a/spec/decorators/case/base_decorator_spec.rb
+++ b/spec/decorators/case/base_decorator_spec.rb
@@ -433,43 +433,29 @@ describe Case::BaseDecorator, type: :model do
       end
     end
   end
+
   describe '#type_printer' do
     it 'pretty prints Case' do
       expect(accepted_case.pretty_type).to eq 'FOI'
     end
   end
+
   describe '#closed_case_name' do
+    let(:offender_sar_case) { build(:offender_sar_case, subject: 'The case subject') }
 
-    class MockCase
-      def initialize(representative_name:)
-        @representative_name = representative_name
-        @subject = 'Monalisa Khan'
-      end
-
-      def representative_name
-        @representative_name
-      end
-
-      def subject
-        @subject
+    context 'when name' do
+      context 'is not empty' do
+        it 'returns existing case name' do
+          offender_sar_case.name = 'Monalisa Khan'
+          expect(offender_sar_case.decorate.closed_case_name).to eq 'Monalisa Khan'
+        end
       end
     end
 
-    context 'when case represenatative name is empty' do
-      it 'returns the subject as the represenatative' do
-        kase = MockCase.new(
-          representative_name: '',
-        )
-        expect(closed_case_name(kase)).to eq 'Monalisa Khan'
-      end
-    end
-
-    context 'when case represenatative name is not empty' do
-      it 'returns the case represenatative name' do
-        kase = MockCase.new(
-          representative_name: 'Ingrid Myers',
-        )
-        expect(closed_case_name(kase)).to eq 'Ingrid Myers'
+    context 'is empty' do
+      it 'returns case subject instead' do
+        offender_sar_case.name = ''
+        expect(offender_sar_case.decorate.closed_case_name).to eq 'The case subject'
       end
     end
   end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
New:
![image](https://user-images.githubusercontent.com/22935203/64346485-1bf74e80-cfea-11e9-9eee-35a97c367b2e.png)





 ### Ticket
https://dsdmoj.atlassian.net/browse/CT-2404
 
### Deployment
n/a
 
### Manual testing instructions
Create Offender SAR case with no represeantative name. Then keep moving status until closed. View closed cases table and ensure that subject name is written twice in table. Then try with different representative name, now it should have representative in closed cases table with subject.
