### PR TITLE
CT-2318 Redirect if case is deleted

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -17,6 +17,8 @@ class AssignmentsController < ApplicationController
     :unaccept,
   ]
 
+  before_action :check_case_not_deleted, only: [:edit]
+
   before_action :validate_response, only: :accept_or_reject
 
   def new
@@ -249,7 +251,7 @@ class AssignmentsController < ApplicationController
     if Case::Base.exists?(id: params[:case_id])
       set_case
     end
-    if Assignment.exists?(id: params[:id])
+    if @case && Assignment.exists?(id: params[:id])
       @assignment = @case.assignments.find(params[:id])
     end
   end
@@ -260,6 +262,13 @@ class AssignmentsController < ApplicationController
               .find(params[:case_id])
               .decorate
     @case_transitions = @case.transitions.decorate
+  end
+
+  def check_case_not_deleted
+    if @case.nil? && Case::Base.unscoped.find(params[:case_id])
+      flash[:notice] = 'Case has been deleted.'
+      redirect_to open_filter_path
+    end
   end
 
   def set_team_users

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -17,8 +17,6 @@ class AssignmentsController < ApplicationController
     :unaccept,
   ]
 
-  before_action :check_case_not_deleted, only: [:edit]
-
   before_action :validate_response, only: :accept_or_reject
 
   def new
@@ -251,8 +249,18 @@ class AssignmentsController < ApplicationController
     if Case::Base.exists?(id: params[:case_id])
       set_case
     end
+
+    redirect_on_deleted_case!
+
     if @case && Assignment.exists?(id: params[:id])
       @assignment = @case.assignments.find(params[:id])
+    end
+  end
+
+  def redirect_on_deleted_case!
+    if @case.nil? && Case::Base.unscoped.find(params[:case_id])
+      flash[:notice] = 'Case has been deleted.'
+      redirect_to open_filter_path
     end
   end
 
@@ -262,13 +270,6 @@ class AssignmentsController < ApplicationController
               .find(params[:case_id])
               .decorate
     @case_transitions = @case.transitions.decorate
-  end
-
-  def check_case_not_deleted
-    if @case.nil? && Case::Base.unscoped.find(params[:case_id])
-      flash[:notice] = 'Case has been deleted.'
-      redirect_to open_filter_path
-    end
   end
 
   def set_team_users

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -246,19 +246,19 @@ class AssignmentsController < ApplicationController
   end
 
   def set_case_and_assignment
-    if Case::Base.exists?(id: params[:case_id])
-      set_case
-    end
+    redirect_on_deleted_case! and return
 
-    redirect_on_deleted_case!
+    set_case
 
-    if @case && Assignment.exists?(id: params[:id])
+    if Assignment.exists?(id: params[:id])
       @assignment = @case.assignments.find(params[:id])
     end
   end
 
   def redirect_on_deleted_case!
-    if @case.nil? && Case::Base.unscoped.find(params[:case_id])
+    # even if a case has been soft deleted users can still click
+    # existing links in emails to edit assigmments, etc
+    if Case::Base.unscoped.soft_deleted.exists?(params[:case_id])
       flash[:notice] = 'Case has been deleted.'
       redirect_to open_filter_path
     end

--- a/spec/features/cases/foi/case_assignment_responding_spec.rb
+++ b/spec/features/cases/foi/case_assignment_responding_spec.rb
@@ -123,4 +123,14 @@ feature 'respond to responder assignment' do
     expect(page).to_not have_content('This case has already been rejected.')
   end
 
+  scenario 'kilo clicks on a link to an assignment that has been deleted' do
+    assignment_id = assignment.id
+    assignment.accept responder
+    assigned_case.update_attribute(:deleted, true)
+
+    visit edit_case_assignment_path assigned_case, assignment_id
+
+    expect(page).to have_current_path(open_filter_path)
+    expect(page).to have_content("Case has been deleted.")
+  end
 end

--- a/spec/features/cases/foi/case_assignment_responding_spec.rb
+++ b/spec/features/cases/foi/case_assignment_responding_spec.rb
@@ -126,11 +126,14 @@ feature 'respond to responder assignment' do
   scenario 'kilo clicks on a link to an assignment that has been deleted' do
     assignment_id = assignment.id
     assignment.accept responder
-    assigned_case.update_attribute(:deleted, true)
+
+    assigned_case.deleted = true
+    assigned_case.reason_for_deletion = 'testing assignment for deleted case'
+    assigned_case.save!
 
     visit edit_case_assignment_path assigned_case, assignment_id
 
     expect(page).to have_current_path(open_filter_path)
-    expect(page).to have_content("Case has been deleted.")
+    expect(page).to have_content('Case has been deleted.')
   end
 end


### PR DESCRIPTION
## Description
One of our most frequently recurring Sentry issues - it transpired that the issue happens when someone clicks a link to edit the case assignment from an email but on a case that has been subsequently deleted. The exception is caused most directly because we were checking for the existence of the assignment directly via Assignment, but then trying to reach it through the case which is nil at that point. 

The wider problem is that the system was attempting to display the edit assignment page in the first place on a deleted case, so I added a before action to redirect to the home page with an appropriate message, and a feature spec to reproduce the bug and validate the new behaviour. 
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/64417180-84007000-d090-11e9-98a2-65802404ac8c.png)

 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2318
 
### Deployment
none
 
### Manual testing instructions
none