### PR TITLE
Use fixed time for freezing time, not relative

### DIFF
--- a/spec/features/cases/filters/external_deadline_spec.rb
+++ b/spec/features/cases/filters/external_deadline_spec.rb
@@ -12,7 +12,7 @@ feature 'filtering by external deadline' do
 
       @setup = StandardSetup.new(only_cases: @all_cases)
 
-      Timecop.freeze(4.business_hours.from_now) do
+      Timecop.freeze(Time.new(2019, 9, 19, 11, 0, 0)) do
         @case_due_today = create :case,
                                received_date: 20.business_days.ago,
                                subject: 'prison guards today'


### PR DESCRIPTION
had used TimeCop to freeze time "4.business_hours.from_now" which meant that when running our tests after 1pm, the case that was supposed to be created "today" instead got created "tomorrow" and the spec failed

## Description
Use an absolute date and time - now specs should pass even after 1pm 🤦‍♂ 
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
