### PR TITLE
Exclude filter specs outside of working hours

### DIFF
--- a/spec/features/cases/filters/external_deadline_spec.rb
+++ b/spec/features/cases/filters/external_deadline_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 def working_hours
-  Date.today.workday? &&  Time.now.during_business_hours?
+  Date.today.workday? && Time.now.during_business_hours?
 end
 
 feature 'filtering by external deadline', if: working_hours do

--- a/spec/features/cases/filters/external_deadline_spec.rb
+++ b/spec/features/cases/filters/external_deadline_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
-feature 'filtering by external deadline' do
+def working_hours
+  Date.today.workday? &&  Time.now.during_business_hours?
+end
+
+feature 'filtering by external deadline', if: working_hours do
   include Features::Interactions
 
   describe 'external deadline filter', js: true do
@@ -12,17 +16,15 @@ feature 'filtering by external deadline' do
 
       @setup = StandardSetup.new(only_cases: @all_cases)
 
-      Timecop.freeze(Time.new(2019, 9, 19, 11, 0, 0)) do
-        @case_due_today = create :case,
-                               received_date: 20.business_days.ago,
-                               subject: 'prison guards today'
-        @case_due_next_3_days = create :case,
-                                     received_date: 18.business_days.ago,
-                                     subject: 'prison guards next 3 days'
-        @case_due_next_10_days = create :case,
-                                      received_date: 10.business_days.ago,
-                                      subject: 'prison guards next 10 days'
-      end
+      @case_due_today = create :case,
+                             received_date: 20.business_days.ago,
+                             subject: 'prison guards today'
+      @case_due_next_3_days = create :case,
+                                   received_date: 18.business_days.ago,
+                                   subject: 'prison guards next 3 days'
+      @case_due_next_10_days = create :case,
+                                    received_date: 10.business_days.ago,
+                                    subject: 'prison guards next 10 days'
 
       @all_case_numbers = @setup.cases.values.map(&:number) +
                           [


### PR DESCRIPTION
These filter specs work great during the normal working day, but failed
when run out of hours or at the weekend. Since this code doesn't change
much and it proved problematic to solve using Timecop, we chose to only
run them during working hours when they run properly

## Description
Following Mo's excellent suggestion, made the recalcitrant spec conditional and only run when it has a chance of passing
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
 
### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
 
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
 
### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
