### PR TITLE
CT-2456 Add new fields for third party reference and company name

### DIFF
--- a/app/controllers/concerns/offender_sar_cases_params.rb
+++ b/app/controllers/concerns/offender_sar_cases_params.rb
@@ -21,6 +21,8 @@ module OffenderSARCasesParams
       :subject_type,
       :third_party,
       :third_party_relationship,
+      :third_party_reference,
+      :third_party_company_name,
       :reply_method,
       uploaded_request_files: [],
       )

--- a/app/form_models/offender_sar_case_form.rb
+++ b/app/form_models/offender_sar_case_form.rb
@@ -31,6 +31,8 @@ class OffenderSARCaseForm
            :subject_full_name,
            :subject_type,
            :third_party_relationship,
+           :third_party_reference,
+           :third_party_company_name,
            :third_party,
            :type_abbreviation,
            to: :@case

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -40,6 +40,8 @@ class Case::SAR::Offender < Case::Base
                  subject_type: :string,
                  third_party_relationship: :string,
                  third_party: :boolean,
+                 third_party_reference: :string,
+                 third_party_company_name: :string,
                  late_team_id: :integer
 
   enum subject_type: {

--- a/app/views/cases/offender_sar/_case_details.html.slim
+++ b/app/views/cases/offender_sar/_case_details.html.slim
@@ -19,8 +19,8 @@
         = render partial: 'cases/shared/requester_name', locals: { case_details: case_details }
         - if case_details.third_party?
           = render partial: 'cases/sar/third_party_relationship', locals: { case_details: case_details }
-          = render partial: 'cases/offender_sar/third_party_reference', locals: { case_details: case_details }
           = render partial: 'cases/offender_sar/third_party_company_name', locals: { case_details: case_details }
+          = render partial: 'cases/offender_sar/third_party_reference', locals: { case_details: case_details }
         = render partial: 'cases/shared/date_received', locals: { case_details: case_details }
         = render partial: 'cases/shared/case_deadlines', locals: { case_details: case_details }
         = render partial: 'cases/sar/response_address', locals: { case_details: case_details }

--- a/app/views/cases/offender_sar/_case_details.html.slim
+++ b/app/views/cases/offender_sar/_case_details.html.slim
@@ -19,6 +19,8 @@
         = render partial: 'cases/shared/requester_name', locals: { case_details: case_details }
         - if case_details.third_party?
           = render partial: 'cases/sar/third_party_relationship', locals: { case_details: case_details }
+          = render partial: 'cases/offender_sar/third_party_reference', locals: { case_details: case_details }
+          = render partial: 'cases/offender_sar/third_party_company_name', locals: { case_details: case_details }
         = render partial: 'cases/shared/date_received', locals: { case_details: case_details }
         = render partial: 'cases/shared/case_deadlines', locals: { case_details: case_details }
         = render partial: 'cases/sar/response_address', locals: { case_details: case_details }

--- a/app/views/cases/offender_sar/_requester_details_step.html.slim
+++ b/app/views/cases/offender_sar/_requester_details_step.html.slim
@@ -16,6 +16,8 @@
       - fieldset.radio_input(true, text_method: :humanize)
         = f.text_field :name
         = f.text_field :third_party_relationship
+        = f.text_field :third_party_reference
+        = f.text_field :third_party_company_name
       - fieldset.radio_input(false, text_method: :humanize)
 
   h2.heading-medium

--- a/app/views/cases/offender_sar/_requester_details_step.html.slim
+++ b/app/views/cases/offender_sar/_requester_details_step.html.slim
@@ -16,8 +16,8 @@
       - fieldset.radio_input(true, text_method: :humanize)
         = f.text_field :name
         = f.text_field :third_party_relationship
-        = f.text_field :third_party_reference
         = f.text_field :third_party_company_name
+        = f.text_field :third_party_reference
       - fieldset.radio_input(false, text_method: :humanize)
 
   h2.heading-medium

--- a/app/views/cases/offender_sar/_third_party_company_name.html.slim
+++ b/app/views/cases/offender_sar/_third_party_company_name.html.slim
@@ -1,0 +1,3 @@
+tr.third-party-company-name
+  th = t('common.case.third_party_company_name')
+  td = case_details.third_party_company_name

--- a/app/views/cases/offender_sar/_third_party_reference.html.slim
+++ b/app/views/cases/offender_sar/_third_party_reference.html.slim
@@ -1,0 +1,3 @@
+tr.third-party-reference
+  th = t('common.case.third_party_reference')
+  td = case_details.third_party_reference

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -460,6 +460,8 @@ en:
           offender: Offender
         third_party: Is this information being requested on someone else's behalf?
         third_party_relationship: Relationship to the subject
+        third_party_reference: Their reference (optional)
+        third_party_company_name: Company name (optional)
       feedback:
         comment: Help make this service better
       search_query:
@@ -576,6 +578,8 @@ en:
       subject_aliases: Subject aliases
       third_party: Information requested on someone's behalf?
       third_party_relationship: Third party relationship
+      third_party_reference: Third party reference
+      third_party_company_name: Third party company name
       time_taken: Time taken
       time_taken_result:
         one: "%{count} working day"
@@ -866,7 +870,7 @@ en:
         extend_further: The deadline for this case will be extended by a further %{num_days} days.
     search_bar:
       heading: Case number, requester name or keyword
-      hint: For example, 170113001, John Smith or prison meals 
+      hint: For example, 170113001, John Smith or prison meals
     searches:
       show:
         heading: Search

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -460,7 +460,7 @@ en:
           offender: Offender
         third_party: Is this information being requested on someone else's behalf?
         third_party_relationship: Relationship to the subject
-        third_party_reference: Their reference (optional)
+        third_party_reference: Requester reference (optional)
         third_party_company_name: Company name (optional)
       feedback:
         comment: Help make this service better

--- a/spec/factories/case/offender_sars.rb
+++ b/spec/factories/case/offender_sars.rb
@@ -37,7 +37,9 @@ FactoryBot.define do
 
   trait :third_party do
     third_party { true }
-    third_party_relationship { 'Aunt' }
+    third_party_relationship { 'Solicitor' }
+    third_party_reference { 'FOOG1234' }
+    third_party_company_name { 'Foogle and Sons Solicitors at Law' }
   end
 
   trait :data_to_be_requested do

--- a/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
@@ -30,6 +30,14 @@ module PageObjects
             element :data, 'td'
           end
 
+          section :third_party_reference, 'tr.third-party-reference' do
+            element :data, 'td'
+          end
+
+          section :third_party_company_name, 'tr.third-party-company-name' do
+            element :data, 'td'
+          end
+
           section :prison_number, 'tr.prison-number' do
             element :data, 'td'
           end

--- a/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
@@ -42,15 +42,17 @@ describe 'cases/sar/case_details.html.slim', type: :view do
     end
 
     it 'displays third party details if present' do
-      third_party_case = (create :sar_case, :third_party, name: 'Rick Westor').decorate
+      third_party_case = (create :offender_sar_case, :third_party, name: 'Rick Westor').decorate
       assign(:case, third_party_case)
-      render partial: 'cases/sar/case_details.html.slim', locals: {
+      render partial: 'cases/offender_sar/case_details.html.slim', locals: {
         case_details: third_party_case,
         link_type: nil
       }
-      partial = case_details_section(rendered).sar_basic_details
+      partial = offender_sar_case_details_section(rendered).sar_basic_details
       expect(partial.third_party.data.text).to eq 'Yes'
       expect(partial.requester_name.data.text).to eq 'Rick Westor'
+      expect(partial.third_party_reference.data.text).to eq 'FOOG1234'
+      expect(partial.third_party_company_name.data.text).to eq 'Foogle and Sons Solicitors at Law'
     end
 
     it 'does not display the email address if one is not provided' do
@@ -59,11 +61,11 @@ describe 'cases/sar/case_details.html.slim', type: :view do
       offender_sar_case.reply_method = 'send_by_post'
 
       assign(:case, offender_sar_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/offender_sar/case_details.html.slim',
              locals: { case_details: offender_sar_case,
                        link_type: nil }
 
-      partial = case_details_section(rendered).sar_basic_details
+      partial = offender_sar_case_details_section(rendered).sar_basic_details
 
       expect(partial).to have_response_address
       expect(partial.response_address.data.text).to eq "1 High Street\nAnytown\nAT1 1AA"
@@ -74,11 +76,11 @@ describe 'cases/sar/case_details.html.slim', type: :view do
       offender_sar_case.email = 'john.doe@moj.com'
 
       assign(:case, offender_sar_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/offender_sar/case_details.html.slim',
              locals:{ case_details: offender_sar_case,
                       link_type: nil }
 
-      partial = case_details_section(rendered).sar_basic_details
+      partial = offender_sar_case_details_section(rendered).sar_basic_details
 
       expect(partial).to have_response_address
       expect(partial.response_address.data.text).to eq 'john.doe@moj.com'


### PR DESCRIPTION
## Description
Add new fields when requester is a third party - optional "their reference" and "company name" fields, to be displayed on the case details page.
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->


![image](https://user-images.githubusercontent.com/1161161/65761640-1f788400-e117-11e9-867d-06e24e52c761.png)

![image](https://user-images.githubusercontent.com/1161161/65761652-256e6500-e117-11e9-83e0-03e189006c95.png)

 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2456 
### Deployment
Added new columns to JSON properties on case, no migration needed
 
### Manual testing instructions
Create a new offender SAR case, choosing third party, and complete the fields to see them displayed on the case page. Try submitting the form empty to verify they are optional and not mandatory.

![image](https://user-images.githubusercontent.com/1161161/65747110-82a6ee00-e0f8-11e9-8a55-1749f4bbbf4e.png)
