### PR TITLE
CT-2500 Remove minimum character limit on data request data fields

### DIFF
--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -3,8 +3,8 @@ class DataRequest < ApplicationRecord
   belongs_to :user
   has_many   :data_request_logs, after_add: :update_cached_attributes
 
-  validates :location, presence: true, length: { minimum: 5, maximum: 500 }
-  validates :data, presence: true, length: { minimum: 5 }
+  validates :location, presence: true, length: { maximum: 500 }
+  validates :data, presence: true
   validates :offender_sar_case, presence: true
   validates :user, presence: true
   validates :date_requested, presence: true

--- a/spec/features/cases/offender_sar/add_data_requests_spec.rb
+++ b/spec/features/cases/offender_sar/add_data_requests_spec.rb
@@ -54,7 +54,7 @@ feature 'Data Requests for an Offender SAR' do
     click_on 'Record requests'
 
     expect(data_request_page).to be_displayed
-    expect(data_request_page).to have_text 'errors prevented this form'
+    expect(data_request_page).to have_text 'error prevented this form'
   end
 
   scenario 'no data entry fails' do

--- a/spec/models/data_request_spec.rb
+++ b/spec/models/data_request_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe DataRequest, type: :model do
       it { should be_valid }
 
       it 'requires location' do
-        invalid_values = ['', ' ', nil, '1234']
+        invalid_values = ['', ' ', nil]
 
         invalid_values.each do |bad_location|
           data_request.location = bad_location
@@ -49,7 +49,7 @@ RSpec.describe DataRequest, type: :model do
       end
 
       it 'requires data' do
-        invalid_values = ['', ' ', nil, '1234']
+        invalid_values = ['', ' ', nil]
 
         invalid_values.each do |bad_data|
           data_request.data = bad_data

--- a/spec/services/case_remove_pit_extension_service_spec.rb
+++ b/spec/services/case_remove_pit_extension_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe CaseRemovePITExtensionService do
-  let!(:received_date) { Date.new(2018, 9, 27) }
+  let!(:received_date) { 7.business_days.ago.to_date }
   let!(:team_dacu)     { find_or_create :team_disclosure_bmt }
   let!(:manager)       { find_or_create :disclosure_bmt_user }
 

--- a/spec/services/data_request_create_service_spec.rb
+++ b/spec/services/data_request_create_service_spec.rb
@@ -71,7 +71,7 @@ describe DataRequestCreateService do
     context 'on failure' do
       it 'does not save DataRequest when validation errors' do
         params = data_request_attributes.clone
-        params.merge!({ '0' => { location: 'too', data: 'few' }})
+        params.merge!({ '0' => { location: 'too' * 500, data: 'many' }})
 
         service = described_class.new(
           kase: offender_sar_case,


### PR DESCRIPTION
## Description
When adding data requests, quite often Branston need to add names with fewer than 5 characters. "completely remove the character restriction and allow users to be able to enter data without forcing errors"
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/65748040-e5998480-e0fa-11e9-82f0-f465b482cf05.png)
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2500
 
### Deployment
None
 
### Manual testing instructions
Try adding data requests with location or data requested fewer than 5 characters