### PR TITLE
CT-2494 generate cover page

### DIFF
--- a/app/assets/stylesheets/print.css.scss
+++ b/app/assets/stylesheets/print.css.scss
@@ -73,6 +73,3 @@ a {
 .case-info {
   margin-bottom: 40px;
 }
-
-
-

--- a/app/assets/stylesheets/print.css.scss
+++ b/app/assets/stylesheets/print.css.scss
@@ -1,0 +1,78 @@
+@page {
+  margin: 2cm;
+}
+
+#skiplink-container,
+#global-cookie-message,
+#global-header,
+#global-header-bar,
+.phase-banner,
+.global-nav,
+.govuk-back-link,
+hr,
+.button,
+.feedback,
+#footer { display: none!important; }
+
+body {
+  font-size: 11pt;
+}
+
+h2,
+h3 {
+  page-break-after: avoid;
+}
+
+.heading-xlarge,
+.page-heading {
+  font-size: 18pt!important;
+
+  .page-heading--secondary {
+    font-size: 12pt;
+  }
+}
+
+h2,
+h2.request--heading {
+  font-size: 15pt!important;
+
+  &.print-large {
+    font-size: 18pt!important;
+  }
+}
+
+h3 {
+  font-size: 13pt!important;
+}
+
+table th,
+table td,
+p {
+  font-size: 11pt!important;
+}
+
+img {
+  max-width: 100% !important;
+}
+
+ul, img {
+  page-break-inside: avoid;
+}
+
+a {
+  font-weight: bolder;
+  text-decoration: none;
+}
+
+#content {
+  max-width: 100%!important;
+  width: 98%;
+  padding-bottom: 0;
+}
+
+.case-info {
+  margin-bottom: 40px;
+}
+
+
+

--- a/app/controllers/cases/cover_pages_controller.rb
+++ b/app/controllers/cases/cover_pages_controller.rb
@@ -1,0 +1,15 @@
+module Cases
+  class CoverPagesController < ApplicationController
+    before_filter :set_case, only: [:show]
+
+    def show
+
+    end
+
+    private
+
+    def set_case
+      @case = Case::Base.find(params[:case_id])
+    end
+  end
+end

--- a/app/controllers/cases/cover_pages_controller.rb
+++ b/app/controllers/cases/cover_pages_controller.rb
@@ -3,7 +3,6 @@ module Cases
     before_filter :set_case, only: [:show]
 
     def show
-
     end
 
     private

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -132,6 +132,11 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
               new_case_letters_path(@case.id, "dispatch"),
               id: 'action--send-dispatch-letter',
               class: 'button-secondary'
+    when :preview_cover_page
+      link_to 'Preview cover page',
+              case_cover_page_path(@case),
+              id: 'action--preview-cover-page',
+              class: 'button-secondary'
     end
   end
   #rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength

--- a/app/views/cases/cover_pages/_data_requests.html.slim
+++ b/app/views/cases/cover_pages/_data_requests.html.slim
@@ -1,0 +1,31 @@
+.grid-row
+  .column-full.data-requests
+    h2.request--heading.data-requests__title
+      = t('cases.data_requests.index.heading')
+
+    - if case_details.data_requests.empty?
+      p.data-requests__none
+        = t('cases.data_requests.index.none')
+
+    - else
+      table
+        thead
+          tr
+            th Location
+            th Data
+            th Date requested
+            th Date received
+        tbody
+          - case_details.data_requests.order(date_requested: :asc).each do |data_request|
+            tr
+              td
+                = data_request.location
+              td
+                = truncate(data_request.data, length: 140)
+              td
+                time datetime="#{data_request.date_requested}"
+                  = l data_request.date_requested, format: :default
+              td
+                - if data_request.cached_date_received.present?
+                  time datetime="#{data_request.cached_date_received}"
+                    = l data_request.cached_date_received, format: :default

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -35,6 +35,8 @@ section.case-info.section--vetting
           = t('cases.cover_sheet.vetter_name')
 
 section.case-info.final-deadline
-  h2.request--heading.heading--final-deadline.print-large Final deadline: #{l @case.external_deadline, format: :default}
+  h2.request--heading.heading--final-deadline.print-large
+    = t('cases.cover_sheet.final_deadline')
+    span  #{l @case.external_deadline, format: :default}
 
 = link_to "Print cover sheet", "javascript:window.print()", class: "button btn-primary", id: "print-cover-page"

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -5,7 +5,7 @@
 
 h1.page-heading
   span.page-heading--secondary
-    = "Print cover page"
+    = @case.number
   span.page-heading--primary
     = "#{@case.subject_full_name&.upcase}-#{@case.prison_number}"
 
@@ -13,34 +13,28 @@ section.case-info
   = render partial: 'cases/cover_pages/data_requests', locals: { case_details: @case }
 
 section.case-info.section--vetting
-  h2.request--heading Vetting
+  h2.request--heading
+    = t('cases.cover_sheet.vetting')
 
   table
     thead
-      th Vet date
-      th By
+      th width="50%"
+        = t('cases.cover_sheet.vet_date')
+      th
+        = t('cases.cover_sheet.vet_by')
     tbody
       tr
-        td First vet date:
-        td Name:
+        td
+          = t('cases.cover_sheet.first_vet_date')
+        td
+          = t('cases.cover_sheet.vetter_name')
       tr
-        td Second vet date:
-        td Name:
+        td
+          = t('cases.cover_sheet.second_vet_date')
+        td
+          = t('cases.cover_sheet.vetter_name')
 
 section.case-info.final-deadline
-  h2.request--heading.heading--final-deadline Final deadline: #{l @case.external_deadline, format: :default}
+  h2.request--heading.heading--final-deadline.print-large Final deadline: #{l @case.external_deadline, format: :default}
 
 = link_to "Print cover sheet", "javascript:window.print()", class: "button btn-primary", id: "print-cover-page"
-
-/css: elements to hide in print css
-  html {background: white !important}
-  #skiplink-container,
-  #global-cookie-message,
-  #global-header,
-  #global-header-bar,
-  .phase-banner,
-  .global-nav,
-  .govuk-back-link,
-  hr,
-  #footer {display: none;}
-

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -1,0 +1,46 @@
+- content_for :page_title do
+  = t('page_title.preview_cover_page', case_number: @case.number)
+
+= link_to "Back", case_path(@case), class: 'govuk-back-link'
+
+h1.page-heading
+  span.page-heading--secondary
+    = "Print cover page"
+  span.page-heading--primary
+    = "#{@case.subject_full_name&.upcase}-#{@case.prison_number}"
+
+section.case-info
+  = render partial: 'cases/cover_pages/data_requests', locals: { case_details: @case }
+
+section.case-info.section--vetting
+  h2.request--heading Vetting
+
+  table
+    thead
+      th Vet date
+      th By
+    tbody
+      tr
+        td First vet date:
+        td Name:
+      tr
+        td Second vet date:
+        td Name:
+
+section.case-info.final-deadline
+  h2.request--heading.heading--final-deadline Final deadline: #{l @case.external_deadline, format: :default}
+
+= link_to "Print cover sheet", "javascript:window.print()", class: "button btn-primary", id: "print-cover-page"
+
+/css: elements to hide in print css
+  html {background: white !important}
+  #skiplink-container,
+  #global-cookie-message,
+  #global-header,
+  #global-header-bar,
+  .phase-banner,
+  .global-nav,
+  .govuk-back-link,
+  hr,
+  #footer {display: none;}
+

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,6 +13,7 @@
   meta name="format-detection" content="telephone=no" /
 
   = stylesheet_link_tag "application", media: "all"
+  = stylesheet_link_tag "print", media: "print"
 
   /[if lte IE 9]
     = stylesheet_link_tag "ie_shame", media: "all"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,3 +9,4 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 Rails.application.config.assets.precompile += %w( ie_shame.css )
+Rails.application.config.assets.precompile += %w( print.css )

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,5 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( ie_shame.css )
-Rails.application.config.assets.precompile += %w( print.css )
+Rails.application.config.assets.precompile += %w( ie_shame.css print.css )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -709,6 +709,14 @@ en:
             <li>uploaded the response and any supporting documents</li>
             <li>sent the response to the person who made the request</li>
           </ul>
+    cover_sheet:
+      vetting: Vetting
+      vet_date: Vet date
+      vet_by: By
+      vetter_name: 'Name:'
+      first_vet_date: 'First vet date:'
+      second_vet_date: 'Second vet date:'
+      final_deadline: 'Final deadline:'
     bypass_approvals_form:
       press_clearance_reqd: Does Press office need to clear this response?
       affirmative: 'Yes'

--- a/config/locales/page_titles.en.yml
+++ b/config/locales/page_titles.en.yml
@@ -28,6 +28,7 @@ en:
     my_cases: My open cases - Track-a-query
     new_letter_page: Generate a letter - Track-a-query
     pit_extension_page: Extend for Public Interest Test (PIT) - %{case_number} - Track-a-query
+    preview_cover_page: Preview cover page - %{case_number} - Track-a-query
     reassign_user_page: Change team member - %{case_number} - Track-a-query
     request_amends_page: Requesting amendments - %{case_number} - Track-a-query
     search: Searching for a case - Track-a-query

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,7 @@ Rails.application.routes.draw do
       patch :flag_for_clearance
     end
 
+    resource :cover_page, only: [:show], path: "cover-page"
     resources :data_requests
 
     resource :letters, only: [:new, :show], path: "letters/:type"

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -17,6 +17,7 @@
                 add_data_received:
                 add_note_to_case:
                 send_acknowledgement_letter:
+                preview_cover_page:
               ready_for_vetting:
                 mark_as_vetting_in_progress:
                   transition_to: vetting_in_progress

--- a/spec/controllers/cases/cover_pages_controller_spec.rb
+++ b/spec/controllers/cases/cover_pages_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Cases::CoverPagesController, type: :controller do
+  let(:manager) { find_or_create :branston_user }
+  let(:offender_sar_case) { create :offender_sar_case }
+
+  before do
+    sign_in manager
+  end
+
+  describe '#show' do
+    before do
+      get :show, params: { case_id: offender_sar_case.id }
+    end
+
+    it 'sets @case' do
+      expect(assigns(:case)).to eq offender_sar_case
+    end
+  end
+end

--- a/spec/features/cases/offender_sar/preview_cover_page_spec.rb
+++ b/spec/features/cases/offender_sar/preview_cover_page_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+feature 'Cover page for an Offender SAR' do
+  given(:manager) { find_or_create :branston_user }
+  given(:offender_sar_case) { create(:offender_sar_case, :waiting_for_data, received_date: 1.business_day.ago).decorate }
+
+  background do
+    5.times {
+      create(:data_request, offender_sar_case: offender_sar_case)
+    }
+    login_as manager
+  end
+
+  scenario 'for a case with 5 data requests' do
+    cases_show_page.load(id: offender_sar_case.id)
+    click_on 'Preview cover page'
+
+    expect(cases_cover_page).to be_displayed
+    data_requests = cases_cover_page.data_requests.rows
+    expect(data_requests.size).to eq 5
+    expect(cases_cover_page.final_deadline).to have_text "Final deadline: #{offender_sar_case.external_deadline}"
+  end
+end

--- a/spec/routing/cases_routes_spec.rb
+++ b/spec/routing/cases_routes_spec.rb
@@ -76,4 +76,8 @@ describe 'cases routes', type: :routing do
   describe get: '/cases/1/letters/acknowledgement' do
     it { should route_to controller: 'cases/letters', action: 'show', case_id: '1', type: 'acknowledgement' }
   end
+
+  describe get: '/cases/1/cover-page' do
+    it { should route_to controller: 'cases/cover_pages', action: 'show', case_id: '1' }
+  end
 end

--- a/spec/site_prism/page_objects/pages/application.rb
+++ b/spec/site_prism/page_objects/pages/application.rb
@@ -50,6 +50,7 @@ module PageObjects
         cases_respond:                  'Cases::RespondPage',
         cases_search:                   'Cases::SearchPage',
         cases_show:                     'Cases::ShowPage',
+        cases_cover:                    'Cases::CoverPage',
         closed_cases:                   'Cases::ClosedCasesPage',
         confirm_destroy:                'Cases::ConfirmDestroyPage',
         cases_extend_for_pit:           'Cases::ExtendForPITPage',

--- a/spec/site_prism/page_objects/pages/cases/cover_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/cover_page.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module Pages
+    module Cases
+      class CoverPage < SitePrism::Page
+        set_url '/cases/{id}/cover-page'
+
+        section :primary_navigation,
+                PageObjects::Sections::PrimaryNavigationSection, '.global-nav'
+
+        section :data_requests,
+          PageObjects::Sections::Cases::DataRequestsSection, '.data-requests'
+
+        element :final_deadline, '.heading--final-deadline'
+      end
+    end
+  end
+end

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -10,7 +10,7 @@ describe ConfigurableStateMachine::Machine do
       },
       {
         state: :waiting_for_data,
-        specific_events: [:mark_as_ready_for_vetting, :send_acknowledgement_letter]
+        specific_events: [:mark_as_ready_for_vetting, :send_acknowledgement_letter, :preview_cover_page]
       },
       {
         state: :ready_for_vetting,


### PR DESCRIPTION
## Description
Manager can generate printable cover page from case in "Waiting for data" state, containing the list of data requests, space to write in vetting status, and final deadline
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
Non print:
![image](https://user-images.githubusercontent.com/22935203/65963986-ce88c880-e453-11e9-8a08-ee0de3abbf82.png)
Print 10: 
![image](https://user-images.githubusercontent.com/22935203/65964100-1576be00-e454-11e9-8463-ed7103481d0e.png)
Print 2
![image](https://user-images.githubusercontent.com/22935203/65964112-1d366280-e454-11e9-96ab-3433d8e6fa32.png)

 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2494
 
### Deployment
none
 
### Manual testing instructions
Create a case in waiting for data state, press "Preview cover page" then click on Print. The system print dialog box should open. All the current data requests should be listed, and the preview should not include the site chrome, header, footer, back button, etc
