### PR TITLE
CT-2267 Generate dispatch letter

### DIFF
--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -127,6 +127,11 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
               new_case_letters_path(@case.id, "acknowledgement"),
               id: 'action--send-acknowledgement-letter',
               class: 'button-secondary'
+    when :send_dispatch_letter
+      link_to 'Send dispatch letter',
+              new_case_letters_path(@case.id, "dispatch"),
+              id: 'action--send-dispatch-letter',
+              class: 'button-secondary'
     end
   end
   #rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength

--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -33,4 +33,9 @@ class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
     clear_failed_checks
     check_user_is_a_manager
   end
+
+  def can_send_dispatch_letter?
+    clear_failed_checks
+    check_user_is_a_manager
+  end
 end

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -37,6 +37,7 @@
                   transition_to: closed
                 add_data_received:
                 add_note_to_case:
+                send_dispatch_letter:
               closed:
                 add_data_received:
                 add_note_to_case:

--- a/db/seeders/letter_template_seeder.rb
+++ b/db/seeders/letter_template_seeder.rb
@@ -1,4 +1,5 @@
 class LetterTemplateSeeder
+  #rubocop:disable Metrics/MethodLength
   def seed!
     puts "----Seeding Letter Templates----"
 
@@ -39,5 +40,51 @@ class LetterTemplateSeeder
                   Ministry of Justice
                 EOF
                 )
+
+    rec = LetterTemplate.find_by(abbreviation: 'solicitor-disclosed')
+    rec = LetterTemplate.new if rec.nil?
+    rec.update!(name: 'Solicitor disclosed letter',
+                abbreviation: 'solicitor-disclosed',
+                template_type: 'dispatch',
+                body: <<~EOF
+                  <%= values.name %>
+                  <%= values.third_party_company_name %>
+                  <%= values.postal_address %>
+
+                  Your Reference: <%= values.third_party_reference %>
+
+                  Our Reference:  DPA <%= values.number %>
+
+                  Date: <%= Date.today.strftime('%e %b %Y') %>
+
+                  DATA PROTECTION ACT 2018:  SUBJECT ACCESS REQUEST
+                  <%= values.subject_full_name&.upcase %>-<%= values.prison_number&.upcase%>
+
+                  I am writing in response to your request for information made under the Data Protection Act 1998 (DPA) for the above person. The Ministry of Justice (MoJ) is sorry for the delay in responding to your subject access request (SAR).
+
+                  Enclosed is all the information related to your request that I am able to release. Some information may have been withheld and this is because the information is exempt from disclosure under the DPA. The exemptions within the DPA include information which is processed for the prevention or detection of crime or the apprehension or prosecution of offenders, and information that would identify third parties. Where we have withheld exempt information, you will see items redacted on the documents.
+
+                  I can confirm that the personal data contained within these documents is being processed by the MoJ for the purposes of the administration of justice and for the exercise of any functions of the Crown, a Minister of the Crown or a government department. As such we may share or exchange data with other Departments or organisations if it is lawful to do so, for example the Police or the Probation Service.
+
+                  If you have any queries regarding your request please contact the Data Protection Compliance Team (DPCT), at the address above. It is also open to you to ask the Information Commissioner to look into the case. You can contact the Information Commissioner at this address:
+
+                  Information Commissioner’s Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF
+                  Internet: www.ico.gov.uk
+
+                  Please note that copies of the data provided to you will be retained for no longer than nine months. Once this period has passed, we will be unable to answer any questions you may have or provide duplicates of this information. It will not normally be disclosed in any futures SARs.
+
+                  I would like to suggest that you do not keep this information where it can be accessed by others. It would be helpful to remind your client of this. In a prison establishment the information can be placed in stored property.
+
+                  Finally, the MoJ is sorry that your SAR was not completed within 40 days. We take our obligations under the DPA very seriously and we make every effort to complete all SARs by the statutory deadline but regrettably there are occasions when we are unable to achieve this.
+
+                  Yours sincerely
+
+
+                  Application Team
+                  Data Protection Compliance Team
+                  Ministry of Justice
+                EOF
+                )
   end
+  #rubocop:enable Metrics/MethodLength
 end

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -26,7 +26,7 @@ describe ConfigurableStateMachine::Machine do
       },
       {
         state: :ready_to_dispatch,
-        specific_events: [:close]
+        specific_events: [:close, :send_dispatch_letter]
       },
     ].freeze
 


### PR DESCRIPTION
## Description
There are two types of letter template - the groundwork was already there but this PR introduces an actual letter template for 'dispatch' type letters and displays the appropriate button assuming the case is in "Ready for dispatch" state
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/66053863-f9921b80-e52a-11e9-9a53-f2fd1d057969.png)

![image](https://user-images.githubusercontent.com/1161161/66053880-01ea5680-e52b-11e9-99d7-a4b2403c3f06.png)

<img width="544" alt="image" src="https://user-images.githubusercontent.com/1161161/66290914-606f5600-e8d8-11e9-894e-9fc654cf6a5b.png">

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2267
 
### Deployment
Has a data migration. Either run `rails db:seed:dev:letter_templates` or `rake data:migrate` (if the previous PR to add letter templates to data migrations is merged)
 
### Manual testing instructions
Ensure the letter seeder is run as in Deployment above. Create a case in "ready to dispatch" state and click the "Send dispatch letter" button. Pick the one available template and continue to preview the letter with the relevant fields completed.
