### PR TITLE
CT-2425 Add new case tabbed navigation and hide others

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -67,6 +67,7 @@
 @import "moj/component/quick_links";
 @import "moj/component/data_request";
 @import "moj/component/letters";
+@import "moj/case_tabs";
 
 @import "moj/govuk_overrides";
 //@import "moj/autocomplete";

--- a/app/assets/stylesheets/moj/_case_tabs.scss
+++ b/app/assets/stylesheets/moj/_case_tabs.scss
@@ -1,0 +1,89 @@
+.govuk-tabs {
+  margin-top: 5px;
+
+  &__title {
+    padding-top: $gutter;
+
+    @include media(tablet) {
+      display: none;
+    }
+  }
+
+  &__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+
+    @include media(tablet) {
+      border-bottom: 1px solid #bfc1c3;
+
+      &:after {
+        content: '';
+        display: block;
+        clear: both;
+      }
+    }
+  }
+
+  &__list-item {
+    display: list-item;
+    text-align: -webkit-match-parent;
+    margin-left: $gutter;
+
+    @include media(tablet) {
+      margin-left: 0;
+
+      a:link,
+      a:visited {
+        color: $black;
+      }
+    }
+
+    &:before {
+      content: "\2014";
+      margin-left: -25px;
+      padding-right: 5px;
+
+      @include media(tablet) {
+        content: '';
+        margin: 0;
+        padding: 0;
+      }
+    }
+  }
+
+  &__tab {
+    display: inline-block;
+    padding-top: 10px;
+    padding-bottom: 10px;
+
+    @include media(tablet) {
+      margin-right: 5px;
+      padding: 10px 20px;
+      float: left;
+      background-color: $highlight-colour;
+      text-align: center;
+      text-decoration: none;
+
+      &.active {
+        margin-top: -5px;
+        margin-bottom: -1px;
+        padding: 14px 19px 16px 19px;
+        border: 1px solid $border-colour;
+        border-bottom: 0;
+        background-color: $white;
+      }
+    }
+  }
+
+  &__panel {
+    @include media(tablet) {
+      margin-bottom: 0;
+      padding: $gutter;
+      border: 1px solid $border-colour;
+      border-top: 0;
+      margin-bottom: $gutter;
+    }
+  }
+}
+

--- a/app/assets/stylesheets/moj/_case_tabs.scss
+++ b/app/assets/stylesheets/moj/_case_tabs.scss
@@ -27,7 +27,6 @@
 
   &__list-item {
     display: list-item;
-    text-align: -webkit-match-parent;
     margin-left: $gutter;
 
     @include media(tablet) {

--- a/app/assets/stylesheets/moj/component/_global_navigation.scss
+++ b/app/assets/stylesheets/moj/component/_global_navigation.scss
@@ -51,9 +51,10 @@
       display: block;
     }
 
-    // JAZ: Have to hide navigation items as they show on tabs anyway. Changing in
-    // settings.yml file breaks a lot of things on the app so to avoid major
-    // refactoring
+    // Javid: Current navigation is controlled by data definition in settings.yml
+    // Therefore cannot delete entries in settings.yml without causing significant
+    // breaking changes to the system, e.g. filters / page loading
+    // Workaround is to hide the nagivation items in the current global nav bar
     &.incoming_cases,
     &.closed_cases,
     &.my_open_cases {

--- a/app/assets/stylesheets/moj/component/_global_navigation.scss
+++ b/app/assets/stylesheets/moj/component/_global_navigation.scss
@@ -3,6 +3,7 @@
   margin-bottom: $gutter;
   border-bottom: 1px solid #DEE0E2;
   background: #F8F8F8;
+
   @media print {
     display: none;
   }
@@ -19,12 +20,14 @@
   &.active {
     border-bottom: 5px solid $link-colour;
   }
+
   @include media(tablet) {
     @include bold-16();
     display: inline-block;
     height: 100%;
     padding: 0.75em 1em;
   }
+
   @include media(desktop) {
     @include bold-19();
     display: inline-block;
@@ -39,12 +42,22 @@
   top: 1px;
   margin: 0;
   padding: 0;
+
   li {
     display: inline-block;
     list-style: none;
     @include media(mobile) {
       float: none;
       display: block;
+    }
+
+    // JAZ: Have to hide navigation items as they show on tabs anyway. Changing in
+    // settings.yml file breaks a lot of things on the app so to avoid major
+    // refactoring
+    &.incoming_cases,
+    &.closed_cases,
+    &.my_open_cases {
+      display: none!important;
     }
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!, :set_user, except: [:ping, :healthcheck]
   before_action :set_global_nav, if: -> { current_user.present?  && global_nav_required? }
   before_action :add_security_headers
+  before_action :set_hompepage_nav, if: -> { current_user.present?  && global_nav_required? }
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
@@ -59,6 +60,14 @@ class ApplicationController < ActionController::Base
       current_user,
       request,
       Settings.global_navigation.pages,
+    )
+  end
+
+  def set_hompepage_nav
+    @homepage_nav_manager = GlobalNavManager.new(
+      current_user,
+      request,
+      Settings.homepage_navigation.pages,
     )
   end
 

--- a/app/views/cases/filters/closed.html.slim
+++ b/app/views/cases/filters/closed.html.slim
@@ -8,41 +8,44 @@
 
 = render partial: 'cases/shared/search_bar'
 
-.download-cases-link
-  = link_to 'Download cases', new_stat_path(select: 'CLOSED_CASES')
+= render partial: 'cases/shared/case_tabs'
 
-.grid-row
-  .column-full.table-container.container
-    table.report.closed-case-report.table-font-xsmall
-      colgroup
-        col
-        col
-        col
-      thead
-        th scope='col'
-          = t('.number_html')
-        th scope='col'
-          = t('common.case_list.type')
-        th.closed-case-heading scope='col'
-          = t('.name-subject')
-      tbody
-        - @cases.each do |kase|
-          tr.case_row
-            td aria-label="#{t('.number')}"
-              span.visually-hidden
-                = t('.view_case')
-              = " "
-              = link_to kase.number, case_path(kase.id)
-            td aria-label="#{t('common.case_list.type')}"
-              = "#{kase.pretty_type} "
-              = kase.trigger_case_marker
-            td aria-label="#{t('.name-subject')}"
-              strong
-                = kase.closed_case_name
-              br
-              span
-                = kase.subject
-    = paginate @cases
-.download-cases-link
-  = link_to 'Download deleted cases', deleted_filter_path(format: :csv), id: 'download_deleted_cases'
-  | &nbsp;(.csv file)
+section.govuk-tabs__panel
+  .download-cases-link
+    = link_to 'Download cases', new_stat_path(select: 'CLOSED_CASES')
+
+  .grid-row
+    .column-full.table-container.container
+      table.report.closed-case-report.table-font-xsmall
+        colgroup
+          col
+          col
+          col
+        thead
+          th scope='col'
+            = t('.number_html')
+          th scope='col'
+            = t('common.case_list.type')
+          th.closed-case-heading scope='col'
+            = t('.name-subject')
+        tbody
+          - @cases.each do |kase|
+            tr.case_row
+              td aria-label="#{t('.number')}"
+                span.visually-hidden
+                  = t('.view_case')
+                = " "
+                = link_to kase.number, case_path(kase.id)
+              td aria-label="#{t('common.case_list.type')}"
+                = "#{kase.pretty_type} "
+                = kase.trigger_case_marker
+              td aria-label="#{t('.name-subject')}"
+                strong
+                  = kase.closed_case_name
+                br
+                span
+                  = kase.subject
+      = paginate @cases
+  .download-cases-link
+    = link_to 'Download deleted cases', deleted_filter_path(format: :csv), id: 'download_deleted_cases'
+    | &nbsp;(.csv file)

--- a/app/views/cases/filters/incoming.html.slim
+++ b/app/views/cases/filters/incoming.html.slim
@@ -6,50 +6,53 @@
 
 = render partial: 'layouts/header'
 
-.grid-row
-  .column-full.table-container.container
-    table.report.table-font-xsmall
-      colgroup
-        col
-        col
-        col
-      thead
-        th scope='col' style='width:12%'
-          = t('.number_html')
-        th scope='col'
-          = t('.request')
-        th scope='col' style='width:21%'
-          = t('.actions')
-      tbody
-        - @cases.each do |kase|
-          tr.case_row id="case-#{kase.id}"
-            td aria-label="#{t('.number')}"
-              span.visually-hidden
-                = t('.view_case')
-              = " "
-              = link_to kase.number, case_path(kase.id)
-            td aria-label="#{t('.request')}"
-              .case_subject
-                strong
-                  = kase.subject
-              .case_name
-                = kase.requester_name_and_type
-              .case_message_extract
-                = kase.shortened_message
-            td.js-take-case-on-container aria-label="#{t('.actions')}"
-              .container-actions
-                - if kase.approver_assignments.with_teams(current_user.teams)
-                  = render partial: 'cases/shared/take_case_on_or_de_escalate',
-                           locals: { case_details: kase }
-                - elsif kase.state_machine.permitted_events(current_user.id).include? :take_on_for_approval
-                  = render partial: 'cases/shared/take_case_on_for_approver',
-                          locals: { case_details: kase }
-              - if kase.transitions.further_clearance.present?
-                .container-notices
-                  - if kase.transitions.further_clearance.last.target_team.nil?
-                    = "Further clearance requested"
-                  - else
-                    = "Clearance requested by: "
-                    strong
-                      = kase.transitions.further_clearance.last.target_team.name
-    = paginate @cases
+= render partial: 'cases/shared/case_tabs'
+
+section.govuk-tabs__panel
+  .grid-row
+    .column-full.table-container.container
+      table.report.table-font-xsmall
+        colgroup
+          col
+          col
+          col
+        thead
+          th scope='col' style='width:12%'
+            = t('.number_html')
+          th scope='col'
+            = t('.request')
+          th scope='col' style='width:21%'
+            = t('.actions')
+        tbody
+          - @cases.each do |kase|
+            tr.case_row id="case-#{kase.id}"
+              td aria-label="#{t('.number')}"
+                span.visually-hidden
+                  = t('.view_case')
+                = " "
+                = link_to kase.number, case_path(kase.id)
+              td aria-label="#{t('.request')}"
+                .case_subject
+                  strong
+                    = kase.subject
+                .case_name
+                  = kase.requester_name_and_type
+                .case_message_extract
+                  = kase.shortened_message
+              td.js-take-case-on-container aria-label="#{t('.actions')}"
+                .container-actions
+                  - if kase.approver_assignments.with_teams(current_user.teams)
+                    = render partial: 'cases/shared/take_case_on_or_de_escalate',
+                             locals: { case_details: kase }
+                  - elsif kase.state_machine.permitted_events(current_user.id).include? :take_on_for_approval
+                    = render partial: 'cases/shared/take_case_on_for_approver',
+                            locals: { case_details: kase }
+                - if kase.transitions.further_clearance.present?
+                  .container-notices
+                    - if kase.transitions.further_clearance.last.target_team.nil?
+                      = "Further clearance requested"
+                    - else
+                      = "Clearance requested by: "
+                      strong
+                        = kase.transitions.further_clearance.last.target_team.name
+      = paginate @cases

--- a/app/views/cases/filters/index.html.slim
+++ b/app/views/cases/filters/index.html.slim
@@ -13,125 +13,128 @@
 
 = render partial: 'cases/shared/search_bar'
 
-- if request.path.include? '/cases/open'
-  .grid-row
-    .column-full.ct-tab-container
-      .ct-tab-label
-        = "Filter by"
+= render partial: 'cases/shared/case_tabs'
 
-      ul role="tablist" aria-label="Filter by" class="ct-tab-wrapper"
-        li.ct-tab-item role="presentation"
-          a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-type"
-            = "Type"
-        li.ct-tab-item role="presentation"
-          a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-timeliness"
-            = "Timeliness"
-        li.ct-tab-item role="presentation"
-          a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-status"
-            = "Open case status"
-        li.ct-tab-item role="presentation"
-          a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-final-deadline"
-            = "Final deadline"
-        li.ct-tab-item role="presentation"
-          a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-assigned-to"
-            = "Assigned to"
-
-      .ct-tab-panels aria-expanded="false"
-
-        #ct-tab-panel-type.ct-tab-panel
-          = render partial: 'cases/search_filters/case_types'
-        #ct-tab-panel-timeliness.ct-tab-panel
-          = render partial: 'cases/search_filters/timeliness'
-        #ct-tab-panel-status.ct-tab-panel
-          = render partial: 'cases/search_filters/open_case_status'
-        #ct-tab-panel-final-deadline.ct-tab-panel
-          = render partial: 'cases/search_filters/final_deadline'
-        #ct-tab-panel-assigned-to.ct-tab-panel
-          = render partial: 'cases/search_filters/assigned_to'
-
-  - if @query.filter_crumbs.present?
-    = render partial: 'cases/search_filters/filter_crumbs',
-             locals: { query: @query,
-                       clear_params: {} }
-- else
-  = render partial: 'state_filter_form' unless request.path == '/cases/my_open'
-
-- if @global_nav_manager.current_page.tabs.present?
-  .grid-row
-    .column-full
-      nav.section-tabs
-        ul
-          - @global_nav_manager.current_page.tabs.each do |tab|
-            li class="tab #{active_link_class(tab.fullpath)}"
-              = link_to t("nav.tabs.#{tab.name}_html",
-                         count: tab.cases.count),
-                        tab.fullpath_with_query
-
-- if @cases.present?
-  - if request.path == '/cases/open'
-    = render partial: 'cases/shared/case_list'
-
-  - else
-    .download-cases-link
-      = download_csv_link(request.fullpath)
-      | &nbsp;(.csv file)
+section.govuk-tabs__panel
+  - if request.path.include? '/cases/open'
     .grid-row
-      .column-full.table-container.container
-        table.report.table-font-xsmall
-          colgroup
-            col
-            col
-            col
-            col
-            col
-            col
-            col
-            col
-            col
-          thead
-            th scope='col'
-              = t('.number_html')
-            th scope='col'
-              = t('.flag')
-            th scope='col'
-              = t('.type')
-            th scope='col'
-              = t('.request')
-            th scope='col'
-              = t('.draft_deadline')
-            th scope='col'
-              = t('.external_deadline')
-            th scope='col'
-              = t('.status')
-            th scope='col'
-              = t('.who_its_with')
-            th scope='col'
-              span.visually-hidden
-                = t('.message_notification')
-          tbody
-            - @cases.each do |kase|
-              tr.case_row
-                td aria-label="#{t('.number')}"
-                  span.visually-hidden
-                    = t('.view_case')
-                  = link_to kase.number, case_path(kase.id)
-                td aria-label="#{t('.flag')}"
-                  = kase.trigger_case_marker
-                td aria-label="#{t('.type')}"
-                  = "#{kase.pretty_type} "
-                td aria-label="#{t('.request_detail')}"
-                  = request_details_html(kase)
-                td aria-label="#{t('.draft_deadline')}"
-                  = kase.internal_deadline
-                td aria-label="#{t('.external_deadline')}"
-                  = kase.external_deadline
-                td aria-label="#{t('.status')}"
-                  = kase.status
-                td aria-label="#{t('.who_its_with')}"
-                  = kase.who_its_with
-                td aria-label="#{t('.message_notification')}"
-                  - if kase.message_notification_visible?(current_user)
-                    img { src=image_path('icons/message-bubble.svg')
-                          class="notification-speech-bubble"
-                          alt= "New notifications for case #{kase.number}" }
-        = paginate @cases
+      .column-full.ct-tab-container
+        .ct-tab-label
+          = "Filter by"
+
+        ul role="tablist" aria-label="Filter by" class="ct-tab-wrapper"
+          li.ct-tab-item role="presentation"
+            a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-type"
+              = "Type"
+          li.ct-tab-item role="presentation"
+            a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-timeliness"
+              = "Timeliness"
+          li.ct-tab-item role="presentation"
+            a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-status"
+              = "Open case status"
+          li.ct-tab-item role="presentation"
+            a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-final-deadline"
+              = "Final deadline"
+          li.ct-tab-item role="presentation"
+            a.ct-tab role="tab" tabindex="-1" href="#ct-tab-panel-assigned-to"
+              = "Assigned to"
+
+        .ct-tab-panels aria-expanded="false"
+
+          #ct-tab-panel-type.ct-tab-panel
+            = render partial: 'cases/search_filters/case_types'
+          #ct-tab-panel-timeliness.ct-tab-panel
+            = render partial: 'cases/search_filters/timeliness'
+          #ct-tab-panel-status.ct-tab-panel
+            = render partial: 'cases/search_filters/open_case_status'
+          #ct-tab-panel-final-deadline.ct-tab-panel
+            = render partial: 'cases/search_filters/final_deadline'
+          #ct-tab-panel-assigned-to.ct-tab-panel
+            = render partial: 'cases/search_filters/assigned_to'
+
+    - if @query.filter_crumbs.present?
+      = render partial: 'cases/search_filters/filter_crumbs',
+               locals: { query: @query,
+                         clear_params: {} }
+  - else
+    = render partial: 'state_filter_form' unless request.path == '/cases/my_open'
+
+  - if @global_nav_manager.current_page.tabs.present?
+    .grid-row
+      .column-full
+        nav.section-tabs
+          ul
+            - @global_nav_manager.current_page.tabs.each do |tab|
+              li class="tab #{active_link_class(tab.fullpath)}"
+                = link_to t("nav.tabs.#{tab.name}_html",
+                           count: tab.cases.count),
+                          tab.fullpath_with_query
+
+  - if @cases.present?
+    - if request.path == '/cases/open'
+      = render partial: 'cases/shared/case_list'
+
+    - else
+      .download-cases-link
+        = download_csv_link(request.fullpath)
+        | &nbsp;(.csv file)
+      .grid-row
+        .column-full.table-container.container
+          table.report.table-font-xsmall
+            colgroup
+              col
+              col
+              col
+              col
+              col
+              col
+              col
+              col
+              col
+            thead
+              th scope='col'
+                = t('.number_html')
+              th scope='col'
+                = t('.flag')
+              th scope='col'
+                = t('.type')
+              th scope='col'
+                = t('.request')
+              th scope='col'
+                = t('.draft_deadline')
+              th scope='col'
+                = t('.external_deadline')
+              th scope='col'
+                = t('.status')
+              th scope='col'
+                = t('.who_its_with')
+              th scope='col'
+                span.visually-hidden
+                  = t('.message_notification')
+            tbody
+              - @cases.each do |kase|
+                tr.case_row
+                  td aria-label="#{t('.number')}"
+                    span.visually-hidden
+                      = t('.view_case')
+                    = link_to kase.number, case_path(kase.id)
+                  td aria-label="#{t('.flag')}"
+                    = kase.trigger_case_marker
+                  td aria-label="#{t('.type')}"
+                    = "#{kase.pretty_type} "
+                  td aria-label="#{t('.request_detail')}"
+                    = request_details_html(kase)
+                  td aria-label="#{t('.draft_deadline')}"
+                    = kase.internal_deadline
+                  td aria-label="#{t('.external_deadline')}"
+                    = kase.external_deadline
+                  td aria-label="#{t('.status')}"
+                    = kase.status
+                  td aria-label="#{t('.who_its_with')}"
+                    = kase.who_its_with
+                  td aria-label="#{t('.message_notification')}"
+                    - if kase.message_notification_visible?(current_user)
+                      img { src=image_path('icons/message-bubble.svg')
+                            class="notification-speech-bubble"
+                            alt= "New notifications for case #{kase.number}" }
+          = paginate @cases

--- a/app/views/cases/shared/_case_tabs.html.slim
+++ b/app/views/cases/shared/_case_tabs.html.slim
@@ -4,6 +4,8 @@ div.govuk-tabs
   ul#homepage-navigation.govuk-tabs__list
     - @homepage_nav_manager.each do |page|
         li.govuk-tabs__list-item
-          = link_to t("homepage_nav.pages.#{page.name}", count: current_user.teams.size), page.fullpath, {class: "govuk-tabs__tab #{active_link_class(page.fullpath)}"}
+          = link_to t("homepage_nav.pages.#{page.name}",
+              count: current_user.teams.size), page.fullpath,
+              {class: "govuk-tabs__tab #{active_link_class(page.fullpath)}"}
 style[type="text/css"]
   | .global-nav-item.open_cases a { border-bottom: 5px solid #005ea5; }

--- a/app/views/cases/shared/_case_tabs.html.slim
+++ b/app/views/cases/shared/_case_tabs.html.slim
@@ -1,9 +1,9 @@
 div.govuk-tabs
   h2.govuk-tabs__title.heading-medium
     = "Contents"
-  ul.govuk-tabs__list
+  ul#homepage-navigation.govuk-tabs__list
     - @homepage_nav_manager.each do |page|
-        li class="govuk-tabs__list-item"
+        li.govuk-tabs__list-item
           = link_to t("homepage_nav.pages.#{page.name}", count: current_user.teams.size), page.fullpath, {class: "govuk-tabs__tab #{active_link_class(page.fullpath)}"}
 style[type="text/css"]
   | .global-nav-item.open_cases a { border-bottom: 5px solid #005ea5; }

--- a/app/views/cases/shared/_case_tabs.html.slim
+++ b/app/views/cases/shared/_case_tabs.html.slim
@@ -1,0 +1,9 @@
+div.govuk-tabs
+  h2.govuk-tabs__title.heading-medium
+    = "Contents"
+  ul.govuk-tabs__list
+    - @homepage_nav_manager.each do |page|
+        li class="govuk-tabs__list-item"
+          = link_to t("homepage_nav.pages.#{page.name}", count: current_user.teams.size), page.fullpath, {class: "govuk-tabs__tab #{active_link_class(page.fullpath)}"}
+style[type="text/css"]
+  | .global-nav-item.open_cases a { border-bottom: 5px solid #005ea5; }

--- a/app/views/layouts/_global_nav.html.slim
+++ b/app/views/layouts/_global_nav.html.slim
@@ -2,5 +2,8 @@ nav.global-nav
   ul
     - @global_nav_manager.each do |page|
       li class="global-nav-item #{page.name}"
-        = link_to t("nav.pages.#{page.name}", count: current_user.teams.size), page.fullpath, {class: active_link_class(page.fullpath)}
+        = link_to t("nav.pages.#{page.name}",
+            count: current_user.teams.size),
+            page.fullpath,
+            {class: active_link_class(page.fullpath)}
 

--- a/app/views/layouts/_global_nav.html.slim
+++ b/app/views/layouts/_global_nav.html.slim
@@ -1,6 +1,6 @@
 nav.global-nav
   ul
     - @global_nav_manager.each do |page|
-      li class="global-nav-item"
+      li class="global-nav-item #{page.name}"
         = link_to t("nav.pages.#{page.name}", count: current_user.teams.size), page.fullpath, {class: active_link_class(page.fullpath)}
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -734,7 +734,7 @@ en:
       form:
         uploaded_request_files: Upload relevant files (optional)
     index: &cases_list
-      heading_all_cases: All open cases
+      heading_all_cases: Cases
       heading_my_cases: My open cases
       view_case: "Link to case "
       message_notification: Conversations

--- a/config/locales/nav.en.yml
+++ b/config/locales/nav.en.yml
@@ -1,10 +1,16 @@
 en:
-  nav:
+  homepage_nav: 
     pages:
       closed_cases: Closed cases
       incoming_cases: New cases
       my_open_cases: My open cases
       open_cases: All open cases
+  nav:
+    pages:
+      closed_cases: Closed cases
+      incoming_cases: New cases
+      my_open_cases: My open cases
+      open_cases: Cases
       search_cases: Search
       teams:
         one: Team

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -69,6 +69,41 @@ private_office_team_name: Private Office
 press_office_team_code: PRESS-OFFICE
 private_office_team_code: PRIVATE-OFFICE
 
+homepage_navigation:
+  pages:
+    incoming_cases:
+      path: /cases/incoming
+
+      visibility: approver
+      scope:
+        'DISCLOSURE': incoming_approving_cases
+        'PRESS-OFFICE': incoming_cases_press_office
+        'PRIVATE-OFFICE': incoming_cases_private_office
+
+    open_cases:
+      path: /cases/open
+
+      scope:
+        approver: open_flagged_for_approval
+        manager: open_cases
+        responder: open_cases
+
+    my_open_cases:
+      path: /cases/my_open
+      scope:
+        approver: my_open_flagged_for_approval_cases
+        manager: my_open_cases
+        responder: my_open_cases
+      tabs:
+        in_time:
+          scope: in_time_cases
+        late:
+          scope: late_cases
+
+    closed_cases:
+      path: /cases/closed
+      scope: closed_cases
+
 global_navigation:
   default_urls:
     approver: /cases/open
@@ -87,7 +122,6 @@ global_navigation:
 
     open_cases:
       path: /cases/open
-
       scope:
         approver: open_flagged_for_approval
         manager: open_cases

--- a/spec/features/common/homepage_navigation.spec.rb
+++ b/spec/features/common/homepage_navigation.spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+feature "Top level global navigation" do
+  let(:responder)                 { find_or_create(:foi_responder) }
+  let(:manager)                   { create(:manager)  }
+  let(:managing_team)             { create :managing_team, managers: [manager] }
+  let(:disclosure_specialist)     { find_or_create :disclosure_specialist }
+  let(:disclosure_specialist_bmt) { find_or_create :disclosure_specialist_bmt }
+  let(:dacu)                      { find_or_create :team_dacu }
+
+  before do
+    responder
+    dacu
+  end
+
+  context 'as a manager' do
+    background do
+      login_as manager
+    end
+
+    scenario "Home page should have navigation" do
+      open_cases_page.load
+      expect(open_cases_page).to have_homepage_navigation
+      expect(open_cases_page.homepage_navigation.active_link[:href])
+        .to eq '/cases/open'
+    end
+
+    scenario "case pages should have nav entries for all pages" do
+      open_cases_page.load
+      nav_links = open_cases_page.homepage_navigation.all_links
+      expect(nav_links.count).to eq 3
+      expect(nav_links[0]).to have_text('All open cases')
+      expect(nav_links[1]).to have_text('My open cases')
+      expect(nav_links[2]).to have_text('Closed cases')
+    end
+  end
+
+  context 'as a disclosure specialist' do
+    background do
+      login_as disclosure_specialist
+    end
+
+    scenario "incoming case pages has nav entries" do
+      incoming_cases_page.load
+      expect(incoming_cases_page.homepage_navigation.active_link[:href])
+        .to eq '/cases/incoming'
+      nav_links = incoming_cases_page.homepage_navigation.all_links
+      expect(nav_links.count).to eq 4
+      expect(nav_links[0]).to have_text('New cases')
+      expect(nav_links[1]).to have_text('All open cases')
+      expect(nav_links[2]).to have_text('My open cases')
+      expect(nav_links[3]).to have_text('Closed cases')
+    end
+
+    scenario "open all cases page has nav entries" do
+      open_cases_page.load
+      expect(open_cases_page.homepage_navigation.active_link[:href])
+        .to eq '/cases/open'
+      nav_links = open_cases_page.homepage_navigation.all_links
+      expect(nav_links.count).to eq 4
+      expect(nav_links[0]).to have_text('New cases')
+      expect(nav_links[1]).to have_text('All open cases')
+      expect(nav_links[2]).to have_text('My open cases')
+      expect(nav_links[3]).to have_text('Closed cases')
+    end
+
+    scenario "open my cases page has nav entries" do
+      my_open_cases_page.load
+      expect(open_cases_page.homepage_navigation.active_link[:href])
+        .to eq '/cases/my_open/in_time'
+      nav_links = open_cases_page.homepage_navigation.all_links
+      expect(nav_links.count).to eq 4
+      expect(nav_links[0]).to have_text('New cases')
+      expect(nav_links[1]).to have_text('All open cases')
+      expect(nav_links[2]).to have_text('My open cases')
+      expect(nav_links[3]).to have_text('Closed cases')
+    end
+
+    scenario "open closed cases page has nav entries" do
+      closed_cases_page.load
+      expect(open_cases_page.homepage_navigation.active_link[:href])
+        .to eq '/cases/closed'
+      nav_links = open_cases_page.homepage_navigation.all_links
+      expect(nav_links.count).to eq 4
+      expect(nav_links[0]).to have_text('New cases')
+      expect(nav_links[1]).to have_text('All open cases')
+      expect(nav_links[2]).to have_text('My open cases')
+      expect(nav_links[3]).to have_text('Closed cases')
+    end
+  end
+
+  context 'as a disclosure specialist / bmt' do
+    background do
+      login_as disclosure_specialist_bmt
+    end
+
+    scenario "incoming case pages has nav entries" do
+      incoming_cases_page.load
+      expect(incoming_cases_page.homepage_navigation.active_link[:href])
+        .to eq '/cases/incoming'
+      nav_links = incoming_cases_page.homepage_navigation.all_links
+      expect(nav_links.count).to eq 4
+      expect(nav_links[0]).to have_text('New cases')
+      expect(nav_links[1]).to have_text('All open cases')
+      expect(nav_links[2]).to have_text('My open cases')
+      expect(nav_links[3]).to have_text('Closed cases')
+    end
+
+    scenario "open in-time page has nav entries" do
+      open_cases_page.load
+      expect(open_cases_page.homepage_navigation.active_link[:href])
+        .to eq '/cases/open'
+      nav_links = open_cases_page.homepage_navigation.all_links
+      expect(nav_links.count).to eq 4
+      expect(nav_links[0]).to have_text('New cases')
+      expect(nav_links[1]).to have_text('All open cases')
+      expect(nav_links[2]).to have_text('My open cases')
+      expect(nav_links[3]).to have_text('Closed cases')
+    end
+  end
+end

--- a/spec/features/common/homepage_navigation.spec.rb
+++ b/spec/features/common/homepage_navigation.spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature "Top level global navigation" do
+feature 'top level global navigation' do
   let(:responder)                 { find_or_create(:foi_responder) }
   let(:manager)                   { create(:manager)  }
   let(:managing_team)             { create :managing_team, managers: [manager] }
@@ -18,15 +18,11 @@ feature "Top level global navigation" do
       login_as manager
     end
 
-    scenario "Home page should have navigation" do
+    scenario 'case pages should have nav entries for all pages' do
       open_cases_page.load
-      expect(open_cases_page).to have_homepage_navigation
       expect(open_cases_page.homepage_navigation.active_link[:href])
         .to eq '/cases/open'
-    end
 
-    scenario "case pages should have nav entries for all pages" do
-      open_cases_page.load
       nav_links = open_cases_page.homepage_navigation.all_links
       expect(nav_links.count).to eq 3
       expect(nav_links[0]).to have_text('All open cases')
@@ -40,82 +36,72 @@ feature "Top level global navigation" do
       login_as disclosure_specialist
     end
 
-    scenario "incoming case pages has nav entries" do
+    scenario 'incoming case pages has nav entries' do
       incoming_cases_page.load
       expect(incoming_cases_page.homepage_navigation.active_link[:href])
         .to eq '/cases/incoming'
+
       nav_links = incoming_cases_page.homepage_navigation.all_links
-      expect(nav_links.count).to eq 4
-      expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      has_all_nav_links?(nav_links)
     end
 
-    scenario "open all cases page has nav entries" do
+    scenario 'open all cases page has nav entries' do
       open_cases_page.load
       expect(open_cases_page.homepage_navigation.active_link[:href])
         .to eq '/cases/open'
+
       nav_links = open_cases_page.homepage_navigation.all_links
-      expect(nav_links.count).to eq 4
-      expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      has_all_nav_links?(nav_links)
     end
 
-    scenario "open my cases page has nav entries" do
+    scenario 'open my cases page has nav entries' do
       my_open_cases_page.load
       expect(open_cases_page.homepage_navigation.active_link[:href])
         .to eq '/cases/my_open/in_time'
+
       nav_links = open_cases_page.homepage_navigation.all_links
-      expect(nav_links.count).to eq 4
-      expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      has_all_nav_links?(nav_links)
     end
 
-    scenario "open closed cases page has nav entries" do
+    scenario 'open closed cases page has nav entries' do
       closed_cases_page.load
       expect(open_cases_page.homepage_navigation.active_link[:href])
         .to eq '/cases/closed'
+
       nav_links = open_cases_page.homepage_navigation.all_links
-      expect(nav_links.count).to eq 4
-      expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      has_all_nav_links?(nav_links)
     end
   end
 
-  context 'as a disclosure specialist / bmt' do
+  context 'as a disclosure specialist bmt' do
     background do
       login_as disclosure_specialist_bmt
     end
 
-    scenario "incoming case pages has nav entries" do
+    scenario 'incoming case pages has nav entries' do
       incoming_cases_page.load
       expect(incoming_cases_page.homepage_navigation.active_link[:href])
         .to eq '/cases/incoming'
+
       nav_links = incoming_cases_page.homepage_navigation.all_links
-      expect(nav_links.count).to eq 4
-      expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      has_all_nav_links?(nav_links)
     end
 
-    scenario "open in-time page has nav entries" do
+    scenario 'open in-time page has nav entries' do
       open_cases_page.load
       expect(open_cases_page.homepage_navigation.active_link[:href])
         .to eq '/cases/open'
+
       nav_links = open_cases_page.homepage_navigation.all_links
-      expect(nav_links.count).to eq 4
-      expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      has_all_nav_links?(nav_links)
     end
+  end
+
+  def has_all_nav_links?(nav_links)
+    expect(nav_links.count).to eq 4
+    expect(nav_links[0]).to have_text('New cases')
+    expect(nav_links[1]).to have_text('All open cases')
+    expect(nav_links[2]).to have_text('My open cases')
+    expect(nav_links[3]).to have_text('Closed cases')
   end
 end

--- a/spec/features/common/primary_navigation_spec.rb
+++ b/spec/features/common/primary_navigation_spec.rb
@@ -35,9 +35,7 @@ feature "Top level global navigation" do
       open_cases_page.load
       nav_links = open_cases_page.primary_navigation.all_links
       expect(nav_links.count).to eq 6
-      expect(nav_links[0]).to have_text('All open cases')
-      expect(nav_links[1]).to have_text('My open cases')
-      expect(nav_links[2]).to have_text('Closed cases')
+      expect(nav_links[0]).to have_text('Cases')
     end
   end
 
@@ -53,9 +51,7 @@ feature "Top level global navigation" do
       nav_links = incoming_cases_page.primary_navigation.all_links
       expect(nav_links.count).to eq 6
       expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      expect(nav_links[1]).to have_text('Cases')
       expect(nav_links[4]).to have_text('Search')
       expect(nav_links[5]).to have_text('Team')
     end
@@ -67,9 +63,7 @@ feature "Top level global navigation" do
       nav_links = open_cases_page.primary_navigation.all_links
       expect(nav_links.count).to eq 6
       expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      expect(nav_links[1]).to have_text('Cases')
       expect(nav_links[4]).to have_text('Search')
       expect(nav_links[5]).to have_text('Team')
     end
@@ -94,9 +88,7 @@ feature "Top level global navigation" do
       nav_links = incoming_cases_page.primary_navigation.all_links
       expect(nav_links.count).to eq 7
       expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      expect(nav_links[1]).to have_text('Cases')
       expect(nav_links[4]).to have_text('Search')
       expect(nav_links[5]).to have_text('Teams')
       expect(nav_links[6]).to have_text('Performance')
@@ -109,9 +101,7 @@ feature "Top level global navigation" do
       nav_links = open_cases_page.primary_navigation.all_links
       expect(nav_links.count).to eq 7
       expect(nav_links[0]).to have_text('New cases')
-      expect(nav_links[1]).to have_text('All open cases')
-      expect(nav_links[2]).to have_text('My open cases')
-      expect(nav_links[3]).to have_text('Closed cases')
+      expect(nav_links[1]).to have_text('Cases')
       expect(nav_links[4]).to have_text('Search')
       expect(nav_links[5]).to have_text('Teams')
       expect(nav_links[6]).to have_text('Performance')

--- a/spec/site_prism/page_objects/pages/cases/incoming_cases_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/incoming_cases_page.rb
@@ -27,6 +27,8 @@ module PageObjects
 
         section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, '.feedback'
         section :primary_navigation, PageObjects::Sections::PrimaryNavigationSection, '.global-nav'
+        section :homepage_navigation, PageObjects::Sections::HomepageNavigationSection, '#homepage-navigation'
+
 
         def case_numbers
           case_list.map do |row|

--- a/spec/site_prism/page_objects/pages/cases_page.rb
+++ b/spec/site_prism/page_objects/pages/cases_page.rb
@@ -10,6 +10,9 @@ module PageObjects
       section :primary_navigation,
               PageObjects::Sections::PrimaryNavigationSection, '.global-nav'
 
+      section :homepage_navigation,
+              PageObjects::Sections::HomepageNavigationSection, '#homepage-navigation'
+
       section :state_filter, '.state-filter' do
         elements :check_boxes, 'label'
         element :apply_filter_button, 'input[value="Filter"]'

--- a/spec/site_prism/page_objects/sections/homepage_navigation.rb
+++ b/spec/site_prism/page_objects/sections/homepage_navigation.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module Sections
+    class HomepageNavigationSection < SitePrism::Section
+      elements :all_links, 'a'
+      element :active_link, 'a.active'
+      element :all_open_cases, 'a[href="/cases/open"]'
+      element :new_cases, 'a[href="/cases/incoming"]'
+    end
+  end
+end

--- a/spec/site_prism/page_objects/sections/primary_navigation_section.rb
+++ b/spec/site_prism/page_objects/sections/primary_navigation_section.rb
@@ -4,7 +4,6 @@ module PageObjects
       elements :all_links, 'a'
       element :active_link, 'a.active'
       element :all_open_cases, 'a[href="/cases/open"]'
-      element :new_cases, 'a[href="/cases/incoming"]'
       element :search, 'a[href="/cases/search"]'
       element :settings, 'a[href="/teams"]'
       element :stats, 'a[href="/stats"]'

--- a/spec/support/features/steps/cases/create_steps.rb
+++ b/spec/support/features/steps/cases/create_steps.rb
@@ -106,7 +106,7 @@ def create_offender_sar_case_step(params = {})
   expect(cases_show_page).to be_displayed
   expect(cases_show_page).to have_content "Case created successfully"
   expect(cases_show_page.page_heading).to have_content "Sabrina Adams"
-  click_on "All open cases"
+  click_on "Cases"
 
   expect(open_cases_page).to be_displayed
   expect(cases_page).to have_content "Branston Registry"

--- a/spec/support/features/steps/cases/viewing_steps.rb
+++ b/spec/support/features/steps/cases/viewing_steps.rb
@@ -34,7 +34,7 @@ def go_to_case_details_step(kase:,
 end
 
 def go_to_incoming_cases_step expect_not_to_see_cases: []
-  cases_page.primary_navigation.new_cases.click
+  cases_page.homepage_navigation.new_cases.click
   if expect_not_to_see_cases.present?
     expect_not_to_see_cases.each do |kase|
       row_for_case = incoming_cases_page.row_for_case_number(kase.number)

--- a/spec/views/cases/filters/closed_cases_html_slim_spec.rb
+++ b/spec/views/cases/filters/closed_cases_html_slim_spec.rb
@@ -4,6 +4,23 @@ describe 'cases/filters/closed.html.slim' do
   let!(:case_1) { create :closed_case, received_date: 20.business_days.ago }
   let!(:case_2) { create :closed_case }
   let(:search_query) { build :search_query }
+  #let(:homepage_nav_manager) {
+  #  instance_double(GlobalNavManager, current_page_or_tab: current_page)
+  #}
+  let(:request)         { instance_double ActionDispatch::Request,
+                                          path: '/cases/closed',
+                                          fullpath: '/cases/closed',
+                                          query_parameters: {},
+                                          params: {}}
+  let(:disclosure_specialist)             { find_or_create :disclosure_specialist }
+
+  before do
+    allow(request).to receive(:filtered_parameters).and_return({})
+    assign(:homepage_nav_manager, GlobalNavManager.new(disclosure_specialist,
+                                                     request,
+                                                     Settings.homepage_navigation.pages))
+    allow(controller).to receive(:current_user).and_return(disclosure_specialist)
+  end
 
   it 'displays all the cases' do
     cases = Case::Base.closed.most_recent_first.page.decorate

--- a/spec/views/cases/filters/closed_cases_html_slim_spec.rb
+++ b/spec/views/cases/filters/closed_cases_html_slim_spec.rb
@@ -4,9 +4,6 @@ describe 'cases/filters/closed.html.slim' do
   let!(:case_1) { create :closed_case, received_date: 20.business_days.ago }
   let!(:case_2) { create :closed_case }
   let(:search_query) { build :search_query }
-  #let(:homepage_nav_manager) {
-  #  instance_double(GlobalNavManager, current_page_or_tab: current_page)
-  #}
   let(:request)         { instance_double ActionDispatch::Request,
                                           path: '/cases/closed',
                                           fullpath: '/cases/closed',

--- a/spec/views/cases/filters/incoming_cases_html_slim_spec.rb
+++ b/spec/views/cases/filters/incoming_cases_html_slim_spec.rb
@@ -14,11 +14,23 @@ describe 'cases/filters/incoming.html.slim', type: :view do
                        name: 'Jane Doe',
                        subject: 'Court Reform',
                        message: 'message number 2').decorate }
-   let(:further_clearance_case) { create(:assigned_case, :flagged, :further_clearance_requested,
+  let(:further_clearance_case) { create(:assigned_case, :flagged, :further_clearance_requested,
                                    approving_team: team_dacu_disclosure,
                                    name: 'Questioning Jim',
                                    subject: 'Reform Reform',
                                    message: 'message number 3').decorate }
+  let(:request)         { instance_double ActionDispatch::Request,
+                                          path: '/cases/incoming',
+                                          fullpath: '/cases/incoming',
+                                          query_parameters: {},
+                                          params: {}}
+
+  before do
+    assign(:homepage_nav_manager, GlobalNavManager.new(disclosure_specialist,
+                                                     request,
+                                                     Settings.homepage_navigation.pages))
+    allow(controller).to receive(:current_user).and_return(disclosure_specialist)
+  end
 
   it 'displays the cases given it' do
     case1


### PR DESCRIPTION
## Description
Add new case tabs as per prototype: https://cts-prototype.herokuapp.com/cases
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
Old:
![image](https://user-images.githubusercontent.com/22935203/66743361-a34da280-ee71-11e9-81c6-e3e588569aed.png)

New:
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/22935203/66743265-6ed9e680-ee71-11e9-95b3-9be5ce48f230.png)
![image](https://user-images.githubusercontent.com/22935203/66743308-83b67a00-ee71-11e9-9565-44a220ce1007.png)

 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2425
 
### Deployment
n/a
 
### Manual testing instructions
View cases homepage and cycle through the new tabs, check highlight on global nav makes sense, and that the correct tab is highlighted, and nothing's broken
