### PR TITLE
fix-duplicate-key Try to avoid duplicate key errors

### DIFF
--- a/app/models/warehouse/case_report.rb
+++ b/app/models/warehouse/case_report.rb
@@ -9,7 +9,7 @@ module Warehouse
     # Class methods to allow this class to be used in async jobs
     class << self
       def for(kase)
-        kase.warehouse_case_report || self.new(case_id: kase.id)
+        kase.warehouse_case_report || self.where(case_id: kase.id).first_or_create!
       end
 
       # Every field is deliberately set explicitly, please do not use any

--- a/spec/models/warehouse/case_report_spec.rb
+++ b/spec/models/warehouse/case_report_spec.rb
@@ -30,17 +30,19 @@ RSpec.describe ::Warehouse::CaseReport, type: :model do
       expect(kase.warehouse_case_report).to be_nil
 
       case_report = described_class.for(kase)
-      expect(case_report.new_record?).to be true
+      kase.reload
+
+      expect(kase.warehouse_case_report).to eq case_report
     end
 
     it 'returns existing CaseReport if it exists' do
       kase = create :accepted_sar
       expect(kase.warehouse_case_report).to be_nil
-      described_class.generate(kase)
+      case_report = described_class.generate(kase)
       kase.reload
 
-      case_report = described_class.for(kase)
-      expect(case_report.new_record?).to be false
+      expect(kase.warehouse_case_report).to eq case_report
+      expect(described_class.for(kase)).to eq case_report
     end
   end
 
@@ -53,7 +55,7 @@ RSpec.describe ::Warehouse::CaseReport, type: :model do
       end
     end
   end
-  
+
   describe '#generate_all' do
     it 'generates CaseReport for all existing Case::Base' do
       kases
@@ -62,13 +64,13 @@ RSpec.describe ::Warehouse::CaseReport, type: :model do
       expect(described_class.generate_all).to eq num_cases
     end
   end
-  
+
   describe '#reconcile' do
     it 'returns a tuple of number of processed missing and deleted cases' do
       expect(described_class.reconcile).to eq [0, 0]
     end
   end
-  
+
   describe '#reconcile_missing_cases' do
     it 'reconciles all undeleted missing cases' do
       new_kases = [create(:closed_case), create(:closed_sar)]


### PR DESCRIPTION
For some reason two or more workers are attempting to run the same sidekiq job simultaneously, both creating a new Warehouse::CaseReport and trying to save it

This fails for the second one with a duplicate key exception on case_id

Experiment with persisting the record to the database as soon as we find it's nil

## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
 
### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
 
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
 
### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
