### PR TITLE
CT-2584 Add ARIA IDs to filters for old IE and accessibility

### DIFF
--- a/app/views/cases/search_filters/_filters.html.slim
+++ b/app/views/cases/search_filters/_filters.html.slim
@@ -7,7 +7,7 @@
       summary aria-controls="filter-cases-accordion" aria-expanded="false" role="button"
         span.case-filters__summary.case-filters__summary--outer
           = t('filters.headings.filter_cases')
-      .case-filters__container#filter-cases-accordion aria-hidden="false"
+      .case-filters__container#filter-cases-accordion aria-hidden="true"
         details
           summary aria-controls="filter-status-content" aria-expanded="false" role="button"
             span.case-filters__summary

--- a/app/views/cases/search_filters/_filters.html.slim
+++ b/app/views/cases/search_filters/_filters.html.slim
@@ -7,12 +7,12 @@
       summary aria-controls="filter-cases-accordion" aria-expanded="false" role="button"
         span.case-filters__summary.case-filters__summary--outer
           = t('filters.headings.filter_cases')
-      .case-filters__container aria-hidden="false"
+      .case-filters__container#filter-cases-accordion aria-hidden="false"
         details
           summary aria-controls="filter-status-content" aria-expanded="false" role="button"
             span.case-filters__summary
               = t('filters.headings.filter_by_status')
-          .case-filters__content aria-hidden="true"
+          .case-filters__content#filter-status-content aria-hidden="true"
             = render partial: 'cases/search_filters/open_case_status', locals: { f: f }
         details
           summary aria-controls="filter-type-content" aria-expanded="false" role="button"
@@ -24,19 +24,19 @@
           summary aria-controls="filter-timeliness-content" aria-expanded="false" role="button"
             span.case-filters__summary
               = t('filters.headings.filter_by_timeliness')
-          .case-filters__content aria-hidden="true"
+          .case-filters__content#filter-timeliness-content aria-hidden="true"
             = render partial: 'cases/search_filters/timeliness', locals: { f: f }
         details
           summary aria-controls="filter-deadline-content" aria-expanded="false" role="button"
             span.case-filters__summary
               = t('filters.headings.filter_by_deadline')
-          .case-filters__content aria-hidden="true"
+          .case-filters__content#filter-deadline-content aria-hidden="true"
             = render partial: 'cases/search_filters/final_deadline', locals: { f: f }
         - if request.path.include? '/cases/search'
           details
             summary aria-controls="filter-exemptions-content" aria-expanded="false" role="button"
               span.case-filters__summary
                 = t('filters.headings.filter_exemptions')
-            .case-filters__content.case-filters__content--exemptions aria-hidden="true"
+            .case-filters__content.case-filters__content--exemptions#filter-exemptions-content aria-hidden="true"
               = render partial: 'cases/search_filters/exemptions', locals: { f: f }
         input.button type="submit" value="Filter"


### PR DESCRIPTION
## Description
Add back in the IDs to match ARIA attributes so that on older browsers / screen readers the filters work correctly.
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
n/a - same look n feel, just adding IDs back in for ARIA.
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2584
 
### Deployment
n/a
 
### Manual testing instructions
Try using the filters on the home page, should open / close properly on IE and ARIA attributes should switch correctly.
