### PR TITLE
CT-2292 Move business unit UX working

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -2,14 +2,14 @@ class TeamsController < ApplicationController
 
   before_action :set_team, only: [:business_areas_covered,
                                   :create_business_areas_covered,
-                                  :show,
-                                  :edit,
                                   :destroy,
                                   :destroy_business_area,
+                                  :edit,
+                                  :move_to_directorate,
+                                  :show,
+                                  :update,
                                   :update_business_area,
                                   :update_business_area_form,
-                                  :update,
-                                  :move_to_directorate,
                                   :update_directorate]
 
   before_action :set_areas, only: [:business_areas_covered,

--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -16,6 +16,13 @@ module AssignmentsHelper
     end
   end
 
+  def filtered_directorate_heading(params)
+    if params[:business_group_id]
+      business_group = BusinessGroup.find(params[:business_group_id])
+      "#{ business_group.name } directorates"
+    end
+  end
+
   def all_option_for_new_case(kase, params)
     if params[:show_all]
       "See all business units"

--- a/app/views/teams/_browse_directorates.html.slim
+++ b/app/views/teams/_browse_directorates.html.slim
@@ -1,0 +1,34 @@
+p.bold-medium
+  | Browse by business group
+
+ul.business-groups.list
+  - BusinessGroup.all.order(:name).each do |business_group|
+    li.business-group
+      - if business_group.id == params[:business_group_id].to_i
+        = business_group.name
+      - else
+        = link_to(business_group.name,
+                move_to_directorate_team_path(@team, business_group_id: business_group.id))
+
+- if params[:business_group_id]
+  p.bold-medium
+    = filtered_directorate_heading(params)
+
+- if defined?(@directorates)
+  ul.teams
+    - @directorates.each do |directorate|
+      li.team
+        .team-details
+          h3
+            .team-unit-name
+              = directorate.name
+
+        .team-actions
+          - if directorate == @team.directorate
+            = "This is where the team is currently located"
+          - else
+            = link_to t('button.move'),
+                update_directorate_team_path(@team, directorate_id: directorate.id),
+                method: :patch,
+                data: {confirm: I18n.t("teams.move.confirm_message")},
+                class: 'button'

--- a/app/views/teams/_business_unit_detail.html.slim
+++ b/app/views/teams/_business_unit_detail.html.slim
@@ -77,4 +77,7 @@ p
                 class: 'button')
 hr
 
-= show_deactivate_link_or_info(current_user, @team)
+- if FeatureSet.move_business_unit.enabled?
+  p = link_to "Move business unit", move_to_directorate_team_path(team.id), id: 'move-team-link'
+
+p = show_deactivate_link_or_info(current_user, @team)

--- a/app/views/teams/move_to_directorate.html.slim
+++ b/app/views/teams/move_to_directorate.html.slim
@@ -1,0 +1,13 @@
+- content_for :page_title do
+  = t('page_title.move_team_page', team_name: @team.name)
+
+- content_for :heading
+  = t('teams.move.heading')
+
+- content_for :sub_heading
+  = t('teams.move.subhead', team_name: @team.name)
+
+= render partial: 'layouts/header'
+
+= render partial: 'browse_directorates'
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,6 +258,7 @@ en:
   button:
     add_to_case_history: Add to case history
     assign: Assign to this unit
+    move: Move to this directorate
     confirm: Confirm
     create_case: Create case
     feedback: Send feedback
@@ -996,6 +997,11 @@ en:
     deactivate_info:
       directorate: To deactivate this directorate you need to first deactivate all business units within it.
       business_unit: To deactivate this business unit you need to first deactivate all users within it.
+    move:
+      subhead: "Business unit: %{team_name}"
+      heading: Move business unit
+      moved_successfully: "%{team_name} has been moved to %{destination_directorate_name}"
+      confirm_message: Are you sure you want to do this? This business unit will be deactivated to preserve its history, and a new one will be created
 
   users:
     new:

--- a/config/locales/page_titles.en.yml
+++ b/config/locales/page_titles.en.yml
@@ -40,3 +40,4 @@ en:
     show_letter_page: Viewing generated letter - %{case_number} - Track-a-query
     stats: Performance Reports - Track-a-query
     upload_responses_page: Uploading a response - %{case_number} - Track-a-query
+    move_team_page: Moving a business unit - %{team_name} - Track-a-query

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,8 @@ Rails.application.routes.draw do
     delete 'destroy_business_area' => 'teams#destroy_business_area', on: :member
     patch 'update_business_area' => 'teams#update_business_area', on: :member
     get 'update_business_area_form' => 'teams#update_business_area_form', on: :member
+    get 'move_to_directorate' => 'teams#move_to_directorate', on: :member
+    patch 'update_directorate' => 'teams#update_directorate', on: :member
   end
 
   authenticated :user, ->(u) { u.admin? } do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -112,7 +112,7 @@ global_navigation:
     create_case:
       path: /cases/new
       visibility: manager
-      
+
     incoming_cases:
       path: /cases/incoming
       visibility: approver
@@ -260,6 +260,12 @@ enabled_features:
     Host-demo: true
     Host-staging: true
     Host-prod: true
+  move_business_unit:
+    Local: true
+    Host-dev: true
+    Host-demo: false
+    Host-staging: true
+    Host-prod: false
   overturned_trigger_sars:
     Local: true
     Host-dev: true

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -563,6 +563,94 @@ RSpec.describe TeamsController, type: :controller do
     end
   end
 
+  describe "#move_to_directorate" do
+    before do
+      sign_in manager
+    end
+
+    context "without choosing a business group" do
+      let(:params) {
+        {
+            id: business_unit.id
+        }
+      }
+
+      it 'authorises' do
+        pending "this doesn't work yet"
+        expect{
+          get :move_to_directorate, params: params
+        }.to require_permission(:business_areas_covered?)
+                 .with_args(manager, business_unit)
+      end
+
+      it 'assigns @team' do
+        get :move_to_directorate, params: params
+        expect(assigns(:team)).to eq business_unit
+      end
+
+      it 'renders the get_update_form.js.erb' do
+        get :move_to_directorate, params: params
+        expect(response).to render_template('teams/move_to_directorate')
+      end
+    end
+
+    context "with a business group selected" do
+      let(:params) {
+        {
+            id: business_unit.id,
+            business_group_id: bg.id
+        }
+      }
+
+      it 'assigns @directorates' do
+        get :move_to_directorate, params: params
+        expect(assigns(:directorates)).to match_array [directorate]
+      end
+    end
+  end
+
+  describe "PATCH #update_directorate" do
+    let(:destination_directorate)     { find_or_create :directorate, name: 'Destination Directorate' }
+    let(:params) {
+      {
+          id: business_unit.id,
+          directorate_id: destination_directorate.id
+      }
+    }
+
+    before do
+      sign_in manager
+    end
+
+    it 'authorises' do
+      pending "this doesn't work yet"
+      expect{
+        patch :update_directorate, params: params
+      }.to require_permission(:business_areas_covered?)
+               .with_args(manager, business_unit)
+    end
+
+    it 'assigns @team' do
+      patch :update_directorate, params: params
+      expect(assigns(:team)).to eq business_unit
+    end
+
+    it 'redirects away from team' do
+      pending "this will work after we are finished"
+      patch :update_directorate, params: params
+      expect(response).not_to redirect_to(team_path(business_unit))
+      expect(flash[:notice]).to have_content 'has been moved to'
+    end
+
+    it 'updates the area' do
+      pending 'this will work after we are finished'
+      old_parent = business_unit.parent
+      patch :update_directorate, params: params
+      expect(business_unit.reload.parent).not_to eq old_parent
+      expect(business_unit.reload.parent).to eq destination_directorate
+    end
+  end
+
   describe '#active_users' do
     let!(:team) {create :responding_team}
     let!(:user) { team.users.first }

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -636,7 +636,6 @@ RSpec.describe TeamsController, type: :controller do
     end
 
     it 'redirects away from team' do
-      pending "this will work after we are finished"
       patch :update_directorate, params: params
       expect(response).not_to redirect_to(team_path(business_unit))
       expect(flash[:notice]).to have_content 'has been moved to'

--- a/spec/features/admin/moving_teams_spec.rb
+++ b/spec/features/admin/moving_teams_spec.rb
@@ -23,6 +23,6 @@ feature 'moving business units' do
     end
 
     expect(teams_show_page.flash_notice.text).to eq(
-    "#{bu.name} has been moved to Responder Directorate")
+    "#{BusinessUnit.last.name} has been moved to Responder Directorate")
   end
 end

--- a/spec/features/admin/moving_teams_spec.rb
+++ b/spec/features/admin/moving_teams_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+feature 'moving business units' do
+  given(:origin_directorate) { find_or_create :directorate, name: 'Origin Directorate' }
+  given!(:bu) { create :business_unit, directorate: origin_directorate }
+  given(:manager) { create :manager }
+
+  scenario 'manager moves a business unit', :js do
+    login_as manager
+
+    teams_show_page.load(id: origin_directorate.id)
+    expect(teams_show_page.row_for_business_unit(bu.name).name.text).to have_text(bu.name)
+
+    teams_show_page.load(id: bu.id)
+    teams_show_page.move_team_link.click
+    expect(teams_move_page).to be_displayed(id: bu.id)
+
+    teams_move_page.business_groups.links.first.click
+    expect(teams_move_page).to have_content "This is where the team is currently located"
+    teams_move_page.business_groups.links.last.click
+    accept_confirm do
+      teams_move_page.directorates_list.directorates.first.move_to_directorate_link.click
+    end
+
+    expect(teams_show_page.flash_notice.text).to eq(
+    "#{bu.name} has been moved to Responder Directorate")
+  end
+end

--- a/spec/site_prism/page_objects/pages/application.rb
+++ b/spec/site_prism/page_objects/pages/application.rb
@@ -74,6 +74,7 @@ module PageObjects
         teams_edit:                     'Teams::EditPage',
         teams_index:                    'Teams::IndexPage',
         teams_areas:                    'Teams::BusinessAreasCoveredPage',
+        teams_move:                     'Teams::MoveToDirectoratePage',
         teams_show:                     'Teams::ShowPage',
         users_index:                    'Users::IndexPage',
         users_new:                      'Users::NewPage',

--- a/spec/site_prism/page_objects/pages/teams/move_to_directorate_page.rb
+++ b/spec/site_prism/page_objects/pages/teams/move_to_directorate_page.rb
@@ -1,0 +1,35 @@
+module PageObjects
+  module Pages
+    module Teams
+      class MoveToDirectoratePage < SitePrism::Page
+        set_url '/teams/{id}/move_to_directorate'
+
+        section :primary_navigation,
+                PageObjects::Sections::PrimaryNavigationSection, '.global-nav'
+
+        section :page_heading,
+                PageObjects::Sections::PageHeadingSection, '.page-heading'
+
+        element :heading, '.page-heading--primary'
+        element :subhead, '.page-heading--secondary'
+
+        section :business_groups, '.business-groups' do
+          elements :links, 'li a'
+        end
+
+        section :directorates_list, 'ul.teams' do
+          sections :directorates, 'li.team' do
+            element :directorate_details, 'div.team-details'
+            element :move_to_directorate_link, 'div.team-actions a'
+          end
+        end
+
+        def find_row(directorate_name)
+          directorates_list.directorates.find { |item|
+            item.directorate_details.text == directorate_name
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/pages/teams/show_page.rb
+++ b/spec/site_prism/page_objects/pages/teams/show_page.rb
@@ -45,6 +45,7 @@ module PageObjects
 
         element :new_information_officer_button, 'a#action--new-responder-user'
         element :deactivate_team_link, 'a#deactivate-team-link'
+        element :move_team_link, 'a#move-team-link'
 
         def row_for_directorate(name)
           begin

--- a/spec/views/teams/update_directorate_html_slim_spec.rb
+++ b/spec/views/teams/update_directorate_html_slim_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe 'teams/move_to_directorate.html.slim', type: :view do
+  let(:business_group) { find_or_create :business_group, name: "Admin"}
+  let(:origin_directorate) { find_or_create :directorate, name: 'Origin Directorate', business_group: business_group }
+  let(:bu) { create :business_unit, directorate: origin_directorate, name: "Admin team" }
+  let(:manager)      { create :manager }
+  # before(:each) do
+  #   @bg_2 = create :business_group, name: 'HMPPS',
+  #                  lead: create(:team_lead, value: 'John Smith')
+  #   create :directorate, business_group: @bg_2
+  #   create :directorate, business_group: @bg_2
+  #   @bg_3 = create :business_group, name: 'HMCTS',
+  #                  lead: create(:team_lead, value: 'Jane Doe')
+  #   create :directorate, business_group: @bg_3
+  # end
+
+  it 'displays all business groups' do
+    login_as manager
+    assign(:directorates, Directorate.all)
+    assign(:team, bu)
+
+    render
+
+    teams_move_page.load(rendered)
+
+    page = teams_move_page
+
+    expect(page.heading.text).to eq "Move business unit"
+    expect(page.subhead.text).to eq "Business unit: Admin team "
+
+    # check data in table is correct
+    dir = page.find_row("DACU Directorate")
+    expect(dir).to be_present
+    expect(dir.directorate_details.text).to eq "DACU Directorate"
+    expect(dir.move_to_directorate_link.text).to eq "Move to this directorate"
+
+    dir = page.find_row("Origin Directorate")
+    expect(dir).to be_present
+    expect(dir.directorate_details.text).to eq "Origin Directorate"
+    expect(dir.text).to have_content "This is where the team is currently located"
+  end
+end


### PR DESCRIPTION
## Description
Front end work for the "Move a business unit" feature - allows you to select a new directorate and calls the move business unit service. On success it sets the flash and redirects. 

Added a todo and ticket for the "authorise" bit
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/69044306-9bdb6500-09ec-11ea-8a65-c76df559927e.png)

![image](https://user-images.githubusercontent.com/1161161/69044320-a4cc3680-09ec-11ea-943b-1026a1b4ca98.png)

![image](https://user-images.githubusercontent.com/1161161/69044279-8d8d4900-09ec-11ea-9ccb-510b3ce3a7f7.png)
 
![image](https://user-images.githubusercontent.com/1161161/69044346-ae559e80-09ec-11ea-8a41-4a110b7fcda4.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2292
 
### Deployment
Nothing special, just front end stuff
 
### Manual testing instructions
As a manager, sign into the app - go to teams, drill down to find a business unit. Choose Move business unit then find a different directorate and click on "Move to this directorate", confirm and check the flash message reflects the requested move. 
