### PR TITLE
CT-2602 Add reusable alert banner into application as partial for migration notice

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -42,6 +42,7 @@
 
 //project specific
 @import "moj/alerts";
+@import "moj/alert-banner";
 @import "moj/buttons";
 @import "moj/dropzonejs";
 @import "moj/feedback";

--- a/app/assets/stylesheets/moj/alert-banner.scss
+++ b/app/assets/stylesheets/moj/alert-banner.scss
@@ -1,0 +1,24 @@
+.alert-banner {
+  @extend %site-width-container;
+  border: 4px solid $govuk-blue;
+  padding: 2rem 2rem 1rem;
+  margin-top: 2em;
+  margin-bottom: 2em;
+  box-sizing: border-box;
+  position: relative;
+
+  &__icon {
+    color: $govuk-blue;
+    position: absolute;
+    left: 2rem;
+    top: 2rem;
+  }
+
+  &__info {
+    padding: 5px 0 0 55px;
+
+    @include media(tablet) {
+      font-size: 19px;
+    }
+  }
+}

--- a/app/views/layouts/_alert_banner.html.slim
+++ b/app/views/layouts/_alert_banner.html.slim
@@ -1,0 +1,6 @@
+.alert-banner
+  svg.alert-banner__icon fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="40" width="40"
+    path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z  M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"
+  p.alert-banner__info
+    = t('common.alert_banner')

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -35,6 +35,7 @@
 = content_for :content do
   = csrf_meta_tags
   = render partial: 'layouts/phase_banner'
+  = render partial: 'layouts/alert_banner'
 
   .grid-row
     .column-full

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -513,7 +513,7 @@ en:
       case_cleared: "The response has been cleared and is ready to be sent to the ICO"
 
   common:
-    alert_banner: "We are planning run a migration soon, services may be disrupted. Date: TBC"
+    alert_banner: "This service will be down for essential maintenance during the afternoon of Wednesday 13 November. You will not have access after 13.00 on this day – the site will likely resume service after business hours. Apologies for the inconvenience."
     choose_file: Choose a file
     error: error
     greeting: Hello %{user}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -513,6 +513,7 @@ en:
       case_cleared: "The response has been cleared and is ready to be sent to the ICO"
 
   common:
+    alert_banner: "We are planning run a migration soon, services may be disrupted. Date: TBC"
     choose_file: Choose a file
     error: error
     greeting: Hello %{user}


### PR DESCRIPTION
## Description
Add a banner to warn people about the upcoming migration. (can re-use banner for anything though by changing translation text)
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
Banner added to all pages, as with beta banner
![image](https://user-images.githubusercontent.com/22935203/68463797-527a6100-0207-11ea-93a4-f3d7c8f47eac.png)
![image](https://user-images.githubusercontent.com/22935203/68463864-7178f300-0207-11ea-9455-f8fdc9ca06be.png)
![image](https://user-images.githubusercontent.com/22935203/68463913-86558680-0207-11ea-9948-28789d7566df.png)

 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2602
 
### Deployment
n/a
 
### Manual testing instructions
view homepage and check what banner says
