### PR TITLE
redirect all requests and display a maintenance page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
   private
 
   def check_maintenance_mode
-    if maintenance_mode_on? and request.fullpath != '/maintenance'
+    if maintenance_mode_on? && request.fullpath != '/maintenance'
       redirect_to '/maintenance' and return
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,17 +30,21 @@ class ApplicationController < ActionController::Base
   end
 
   def maintenance_mode
+    redirect_to '/' and return unless maintenance_mode_on?
     render layout: nil, file: "layouts/maintenance"
   end
 
   private
 
   def check_maintenance_mode
-    if request.fullpath != '/maintenance'
+    if maintenance_mode_on? and request.fullpath != '/maintenance'
       redirect_to '/maintenance' and return
     end
   end
 
+  def maintenance_mode_on?
+    File.exist? Rails.root.join('maintenance.txt')
+  end
 
   def download_csv_request?
     uri = URI(request.fullpath)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_action :check_maintenance_mode
+
   before_action :set_paper_trail_whodunnit
   before_action :authenticate_user!, :set_user, except: [:ping, :healthcheck]
   before_action :set_global_nav, if: -> { current_user.present?  && global_nav_required? }
@@ -27,7 +29,18 @@ class ApplicationController < ActionController::Base
     @user = current_user
   end
 
+  def maintenance_mode
+    render layout: nil, file: "layouts/maintenance"
+  end
+
   private
+
+  def check_maintenance_mode
+    if request.fullpath != '/maintenance'
+      redirect_to '/maintenance' and return
+    end
+  end
+
 
   def download_csv_request?
     uri = URI(request.fullpath)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   before_action :check_maintenance_mode
 
   before_action :set_paper_trail_whodunnit
-  before_action :authenticate_user!, :set_user, except: [:ping, :healthcheck]
+  before_action :authenticate_user!, :set_user, except: [:ping, :healthcheck, :maintenance_mode]
   before_action :set_global_nav, if: -> { current_user.present?  && global_nav_required? }
   before_action :add_security_headers
   before_action :set_hompepage_nav, if: -> { current_user.present?  && global_nav_required? }

--- a/app/views/layouts/maintenance.html.slim
+++ b/app/views/layouts/maintenance.html.slim
@@ -1,0 +1,56 @@
+- content_for :logo_link_title do
+  = "Return to home page"
+
+- content_for :homepage_url do
+  = root_path
+
+- content_for :header_class do
+ = "with-proposition"
+- content_for :global_header_text do
+  = t('common.service_name')
+
+- content_for :head do
+  meta name="format-detection" content="telephone=no" /
+
+  = stylesheet_link_tag "application", media: "all"
+  = stylesheet_link_tag "print", media: "print"
+
+  /[if lte IE 9]
+    = stylesheet_link_tag "ie_shame", media: "all"
+
+  - content_for :body_classes do
+    = "controller-" + controller.controller_name
+
+
+
+
+= content_for :content do
+  = csrf_meta_tags
+  = render partial: 'layouts/phase_banner'
+
+  .grid-row
+    .column-full
+      main#content
+        = render partial: 'layouts/flashes' unless flash.empty?
+        h1 This is maintenance mode
+        p.lede  Site down for maintenance
+
+- content_for :body_end do
+  = javascript_include_tag "application"
+  - unless Rails.env.test?
+    javascript:
+      (function (i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r;
+        i[r] = i[r] || function () {
+                  (i[r].q = i[r].q || []).push(arguments)
+                }, i[r].l = 1 * new Date();
+        a = s.createElement(o), m = s.getElementsByTagName(o)[0];
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m)
+      })
+      (window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+      ga('create', '#{Rails.configuration.ga_tracking_id}', 'auto');
+      ga('send', 'pageview');
+
+= render template: 'layouts/govuk_template'

--- a/app/views/layouts/maintenance.html.slim
+++ b/app/views/layouts/maintenance.html.slim
@@ -32,8 +32,9 @@
     .column-full
       main#content
         = render partial: 'layouts/flashes' unless flash.empty?
-        h1 This is maintenance mode
-        p.lede  Site down for maintenance
+        h1.page-heading style="border-bottom: 1px solid #000"
+          = "Service down for planned maintenance"
+        p.lede  This service will be down for essential maintenance during the afternoon of Wednesday 13 November. You will not have access after 13.00 on this day – the site will likely resume service after business hours. Apologies for the inconvenience.
 
 - content_for :body_end do
   = javascript_include_tag "application"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,5 +236,7 @@ Rails.application.routes.draw do
   get 'healthcheck',    to: 'heartbeat#healthcheck',  as: 'healthcheck', format: :json
   post '/feedback' => 'feedback#create'
 
+  get '/maintenance', to: 'application#maintenance_mode'
+
   root to: redirect('/users/sign_in')
 end


### PR DESCRIPTION
## Description
In order to prevent users from editing the database or uploading files - or changing any sort of state, in fact - during our migration to Cloud Platform, this PR introduces "Maintenance mode"

When a file is present in the rails root directory named `maintenance.txt` then the app redirects all HTTP requests to maintenance page. 

When the file is not present, the app functions as normal. 

Can't do a feature spec for this because it will break parallel tests - as soon as we write the file for the test in one thread to check the app behaviour, any other tests will break. 

But as long as the test suite passes otherwise, I think we should be good. 
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
 
### Screenshots


![image](https://user-images.githubusercontent.com/1161161/68671129-81197400-0546-11ea-956d-7fe77c3dd08c.png)

![image](https://user-images.githubusercontent.com/1161161/68671112-7a8afc80-0546-11ea-88d6-14d672db288a.png)
 
![image](https://user-images.githubusercontent.com/1161161/68671152-8bd40900-0546-11ea-893d-7b7b95bed49b.png)

![image](https://user-images.githubusercontent.com/1161161/68671170-97273480-0546-11ea-99d2-480b2a358af4.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2602
 
### Deployment
This has no migrations. 
 
### Manual testing instructions
In the Rails app root, create a file called 'maintenance.txt'

```touch maintenance.txt```

Verify all requests hit the maintenance page by going to various urls such as '/cases/open', '/users/sign_in/' 

Remove the file 

``` rm maintenance.txt```

And verify that all requests work as usual. 