### PR TITLE
CT-2623 Change dev ingress url to development.track-a-query

### DIFF
--- a/config/kubernetes/development/ingress.yaml
+++ b/config/kubernetes/development/ingress.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - dev.track-a-query.service.justice.gov.uk
+        - development.track-a-query.service.justice.gov.uk
       secretName: track-a-query-certificate
   rules:
-    - host: dev.track-a-query.service.justice.gov.uk
+    - host: development.track-a-query.service.justice.gov.uk
       http:
         paths:
           - path: /


### PR DESCRIPTION
## Description
Renames `https://dev.track-a-query.service.justice.gov.uk/` to `https://development.track-a-query.service.justice.gov.uk/` for consistency with new namespace and environment names.
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [X] (1) Quick stakeholder demo done OR
* [X] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
 
### Screenshots
N/A
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2623
 
### Deployment
Deploy as usual.
 
### Manual testing instructions
Browse `https://development.track-a-query.service.justice.gov.uk/` and ensure no domain or certificate issues

