### PR TITLE
CT-2645 Add new method to finder service which works with rejected cases

### DIFF
--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -405,6 +405,10 @@ class Case::Base < ApplicationRecord
     TeamFinderService.new(self, user, role).team_for_unassigned_user
   end
 
+  def team_for_user(user, role)
+    TeamFinderService.new(self, user, role).team_for_unassigned_user
+  end
+
   def allow_event?(user, event)
     state_machine.permitted_events(user.id).include?(event)
   end

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -406,7 +406,7 @@ class Case::Base < ApplicationRecord
   end
 
   def team_for_user(user, role)
-    TeamFinderService.new(self, user, role).team_for_unassigned_user
+    TeamFinderService.new(self, user, role).team_for_user
   end
 
   def allow_event?(user, event)

--- a/app/models/case_attachment_upload_group.rb
+++ b/app/models/case_attachment_upload_group.rb
@@ -8,9 +8,8 @@ class CaseAttachmentUploadGroup
     @timestamp = get_time(array_of_time_and_user_id.first)
     @user = User.find(array_of_time_and_user_id.last)
     @collection = collection.to_a
-    team = kase.team_for_unassigned_user(@user, role)
+    team = kase.team_for_user(@user, role)
     @team_name = team.nil? ? '' : team.name
-
   end
 
 

--- a/app/services/team_finder_service.rb
+++ b/app/services/team_finder_service.rb
@@ -34,6 +34,15 @@ class TeamFinderService
     @assignment_role  = translate_role_for_assignment
   end
 
+  # returns the team for the named user on the case. The user must have been an assigned user
+  # on the case, or a TeamFinderService::UserNotFound error is raised
+  #
+  def team_for_user
+    assignments = @kase.assignments.where(user_id: @user.id, role: @assignment_role)
+    raise UserNotFoundError.new(self) if assignments.empty?
+    assignments.singular.team
+  end
+
   # returns the team for the named user on the case. The user must be an accepted assigned user
   # on the case, or a TeamFinderService::UserNotFound error is raised
   #

--- a/app/services/team_finder_service.rb
+++ b/app/services/team_finder_service.rb
@@ -38,13 +38,11 @@ class TeamFinderService
   # on the case, or a TeamFinderService::UserNotFound error is raised
   #
   def team_for_user
-    assignments = @kase.assignments.where(user_id: @user.id, role: @assignment_role)
-    raise UserNotFoundError.new(self) if assignments.empty?
-    assignments.singular.team
+    assigned_teams = @kase.assignments.where(role: @assignment_role).map(&:team)
+    raise UserNotFoundError.new(self) if assigned_teams.empty?
+    user_teams = @user.team_roles.where(role: @team_role).map(&:team)
+    (assigned_teams & user_teams).first
   end
-
-  # returns the team for the named user on the case. The user must be an accepted assigned user
-  # on the case, or a TeamFinderService::UserNotFound error is raised
   #
   def team_for_assigned_user
     assignments = @kase.assignments.accepted.where(user_id: @user.id, role: @assignment_role)

--- a/spec/models/case_attachment_upload_group_collection_spec.rb
+++ b/spec/models/case_attachment_upload_group_collection_spec.rb
@@ -50,7 +50,7 @@ describe CaseAttachmentUploadGroupCollection do
 
     it 'returns a team name for each group' do
       team_names = []
-      expect(@kase).to receive(:team_for_unassigned_user).exactly(2).and_return(create(:business_unit, name: 'Team 1'), create(:business_unit, name: 'Team 2'))
+      expect(@kase).to receive(:team_for_user).exactly(2).and_return(create(:business_unit, name: 'Team 1'), create(:business_unit, name: 'Team 2'))
       @kase.upload_response_groups.each { |ug| team_names << ug.team_name }
       expect(team_names).to match_array [ 'Team 1', 'Team 2']
     end

--- a/spec/services/team_finder_service_spec.rb
+++ b/spec/services/team_finder_service_spec.rb
@@ -79,6 +79,15 @@ describe TeamFinderService do
       end
     end
 
+    context 'any assignment for user with specified role exists' do
+      it 'returns the team even if kase rejected' do
+        responder_assignment = kase.assignments.responding.singular
+        responder_assignment.update!(state: 'rejected', reasons_for_rejection: 'just because')
+        team = TeamFinderService.new(kase, responder, :responder).team_for_user
+        expect(team).to eq team_candi
+      end
+    end
+
     context 'accepted assignment exist for user with multiple roles' do
       it 'returns the correct team for the role' do
         user_assignments = multi_role_managed_case


### PR DESCRIPTION
## Description
"ActionView::Template::ErrorCasesController#show
No accepted assignment with role 'responding' for user 1061 on case 16493" https://sentry.service.dsd.io/mojds/correspondence-tool-staff/issues/39150/

The problem is the case has an attachment uploaded by a user whose team is no longer assigned to the case, because of the case being rejected after upload. 

It uses this method from the TeamFinderService 

 ```
 def team_for_unassigned_user
    assigned_teams = @kase.assignments.where(state: [:accepted, :pending], role: @assignment_role).map(&:team)
    raise UserNotFoundError.new(self) if assigned_teams.empty?
    user_teams = @user.team_roles.where(role: @team_role).map(&:team)
    (assigned_teams & user_teams).first
  end

```
Solution here is create a new method which returns the team whether or not it is currently assigned to the case.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
n/a
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2645
 
### Deployment
n/a
 
### Manual testing instructions
Not massively easy to reproduce locally, but you can reproduce by finding a case which has an attachment uploaded by a user belonging to a particular team. Find the `assignment` for that team on the case, and set the status to "rejected" View the case and it should throw an exception on master. 

On production there is a case which demonstrates the issue; https://track-a-query.service.justice.gov.uk/cases/16493 - if we view this as an admin on Correspondence Tool for Staff Production after deployment it should be viewable instead of giving an error. 

![image](https://user-images.githubusercontent.com/1161161/69795151-8a9c1080-11c3-11ea-8587-39c07a790cb7.png)

