### PR TITLE
CT-2292 remove feature flag

### DIFF
--- a/app/helpers/teams_helper.rb
+++ b/app/helpers/teams_helper.rb
@@ -10,7 +10,7 @@ module TeamsHelper
   def show_deactivate_link_or_info(current_user, team)
     team_name = team.class.name.underscore
     if Pundit.policy(current_user, team).destroy?
-      link_to "Deactivate #{team.pretty_type}", team_path(team.id),
+      link_to "Deactivate #{team.pretty_type&.downcase}", team_path(team.id),
                             data: {:confirm => I18n.t(".teams.#{team_name}_detail.destroy")},
                             method: :delete,
                             id: 'deactivate-team-link'

--- a/app/views/teams/_business_unit_detail.html.slim
+++ b/app/views/teams/_business_unit_detail.html.slim
@@ -77,7 +77,6 @@ p
                 class: 'button')
 hr
 
-- if FeatureSet.move_business_unit.enabled?
-  p = link_to "Move business unit", move_to_directorate_team_path(team.id), id: 'move-team-link'
+p = link_to "Move business unit", move_to_directorate_team_path(team.id), id: 'move-team-link'
 
 p = show_deactivate_link_or_info(current_user, @team)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -260,12 +260,6 @@ enabled_features:
     Host-demo: true
     Host-staging: true
     Host-prod: true
-  move_business_unit:
-    Local: true
-    Host-dev: true
-    Host-demo: false
-    Host-staging: true
-    Host-prod: false
   overturned_trigger_sars:
     Local: true
     Host-dev: true

--- a/spec/helpers/teams_helper_spec.rb
+++ b/spec/helpers/teams_helper_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe TeamsHelper, type: :helper do
     context "deactivatig directorate" do
       it 'returns a link for a team with no active children' do
         expect(show_deactivate_link_or_info(manager, empty_dir)).to eq(
-          link_to "Deactivate Directorate", team_path(empty_dir.id),
+          link_to "Deactivate directorate", team_path(empty_dir.id),
                                 data: {:confirm => I18n.t('.teams.directorate_detail.destroy')},
                                 method: :delete,
                                 id: 'deactivate-team-link'
@@ -52,7 +52,7 @@ RSpec.describe TeamsHelper, type: :helper do
     context "deactivating business unit" do
       it 'returns a link for a team with no active children' do
         expect(show_deactivate_link_or_info(manager, bu)).to eq(
-          link_to "Deactivate Business unit", team_path(bu.id),
+          link_to "Deactivate business unit", team_path(bu.id),
                                 data: {:confirm => I18n.t('.teams.business_unit_detail.destroy')},
                                 method: :delete,
                                 id: 'deactivate-team-link'


### PR DESCRIPTION
## Description
1. Remove the feature flag and allow production users to use the new "Move business unit" feature
2. Alex noticed the case of the business unit was different 
![image](https://user-images.githubusercontent.com/1161161/70616898-639ffe80-1c07-11ea-9ac1-6584b281a5e7.png)
So make the entity being deactivated lower case, no spurious initial cap

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
BEFORE:
![image](https://user-images.githubusercontent.com/1161161/70616922-71ee1a80-1c07-11ea-986d-9958eacbe9e6.png)

AFTER:
![image](https://user-images.githubusercontent.com/1161161/70616956-8205fa00-1c07-11ea-95a1-7584713ac73b.png)
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2292
 
### Deployment
nope

### Manual testing instructions
Nothing to test until it hits production or demo
