### PR TITLE
Ct 2678 hide deactivated directories

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -174,6 +174,7 @@ class TeamsController < ApplicationController
   def set_directorates
       @directorates = Directorate
         .where(parent_id: params[:business_group_id])
+        .active
         .order(:name)
   end
 

--- a/spec/controllers/teams_controller_spec.rb
+++ b/spec/controllers/teams_controller_spec.rb
@@ -601,8 +601,8 @@ RSpec.describe TeamsController, type: :controller do
             business_group_id: bg.id
         }
       }
-
-      it 'assigns @directorates' do
+      let!(:deactivated_directorate)     { find_or_create :deactivated_directorate }
+      it 'assigns @directorates, but not deactivated ones' do
         get :move_to_directorate, params: params
         expect(assigns(:directorates)).to match_array [directorate]
       end

--- a/spec/factories/directorates.rb
+++ b/spec/factories/directorates.rb
@@ -52,4 +52,11 @@ FactoryBot.define do
     email          { 'private_office@localhost' }
     business_group { find_or_create :operations_business_group }
   end
+
+  factory :deactivated_directorate, parent: :directorate do
+    name           { 'Deactivated Directorate' }
+    email          { 'deactivated-dir@localhost' }
+    business_group { find_or_create :responder_business_group }
+    deleted_at     { Time.now }
+  end
 end


### PR DESCRIPTION
## Description
When moving business units, deactivated directorates should be visible as targets to move to.
We do not want to allow a business unit to move into a deactivated directorate
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2678?atlOrigin=eyJpIjoiMTUzMjZmMzlmM2MyNDAzNmExZjI3ODc2NTdlMzM4YjEiLCJwIjoiaiJ9
 

 
### Manual testing instructions
For a given Business group, deactivate a directorate.
Attempt to move a business unit to that directorate.
The directorate should not be visible in the list of possible directorates to move to.
