### PR TITLE
CT-2728 give user roles to new team member

### DIFF
--- a/app/models/business_unit.rb
+++ b/app/models/business_unit.rb
@@ -76,6 +76,7 @@ class BusinessUnit < Team
   scope :managing, -> { where(role: 'manager') }
   scope :approving, -> { where(role: 'approver') }
   scope :responding, -> { where(role: 'responder') }
+  scope :active, -> { where(deleted_at: nil) }
 
   after_save :update_search_index
 

--- a/app/models/business_unit.rb
+++ b/app/models/business_unit.rb
@@ -148,7 +148,21 @@ class BusinessUnit < Team
     users.any?
   end
 
+  def previous_teams
+    previous_team_ids = []
+    previous_team = previous_incarnation(id)
+    while previous_team do
+      previous_team_ids << previous_team.id
+      previous_team = previous_incarnation(previous_team.id)
+    end
+    previous_team_ids
+  end
+
   private
+
+  def previous_incarnation(id)
+    Team.find_by_moved_to_unit_id(id)
+  end
 
   def update_search_index
     if changed.include?('name')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,7 +166,7 @@ class User < ApplicationRecord
   end
 
   def multiple_team_member?
-    team_roles.size > 1
+    teams.active.size > 1
   end
 
   def password_blacklist

--- a/app/services/user_creation_service.rb
+++ b/app/services/user_creation_service.rb
@@ -58,5 +58,10 @@ class UserCreationService
 
   def add_user_to_teams
     @team.__send__(@role.pluralize) << @user
+    @team.previous_teams.each do |team_id|
+      if team = Team.find_by_id(team_id)
+        team.__send__(@role.pluralize) << @user
+      end
+    end
   end
 end

--- a/app/services/user_creation_service.rb
+++ b/app/services/user_creation_service.rb
@@ -59,7 +59,7 @@ class UserCreationService
   def add_user_to_teams
     @team.__send__(@role.pluralize) << @user
     @team.previous_teams.each do |team_id|
-      if team = Team.find_by_id(team_id)
+      if (team = Team.find_by_id(team_id))
         team.__send__(@role.pluralize) << @user
       end
     end

--- a/app/services/user_creation_service.rb
+++ b/app/services/user_creation_service.rb
@@ -27,7 +27,7 @@ class UserCreationService
   def update_existing_user
     if full_names_match
       # Add user to the teams
-      @team.__send__(@role.pluralize) << @user
+      add_user_to_teams
       @team.save!
 
       # Remove soft delete if their account was previously deleted
@@ -47,12 +47,16 @@ class UserCreationService
     @user.password = SecureRandom.random_number(36**13).to_s(36)
     @user.password_confirmation = @user.password
     if @user.valid? && @team.present?
-      @team.__send__(@role.pluralize) << @user
+      add_user_to_teams
       @result = :ok
     end
   end
 
   def full_names_match
     @user.full_name.downcase == @params[:full_name].downcase
+  end
+
+  def add_user_to_teams
+    @team.__send__(@role.pluralize) << @user
   end
 end

--- a/app/services/user_deletion_service.rb
+++ b/app/services/user_deletion_service.rb
@@ -26,7 +26,10 @@ class UserDeletionService
   private
 
   def delete_memberships_of_team
-    roles = TeamsUsersRole.where(user_id: @target_user.id, team_id: @team.id)
+    team_ids = @team.previous_teams
+    team_ids << @team.id
+
+    roles = TeamsUsersRole.where(user_id: @target_user.id, team_id: team_ids)
     roles.destroy_all
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,5 @@
 case_uploads_s3_bucket: "correspondence-staff-case-uploads-testing"
+
 case_uploads_accepted_types:
 - application/pdf
 - application/msword

--- a/spec/models/business_unit_spec.rb
+++ b/spec/models/business_unit_spec.rb
@@ -133,6 +133,14 @@ RSpec.describe BusinessUnit, type: :model do
                                           ]
       end
     end
+
+    describe 'active scope' do
+      it 'returns only teams that are not deactivated' do
+        expect(BusinessUnit.responding.active.count).to eq 2
+        foi_responding_team.update_attribute(:deleted_at, Time.now)
+        expect(BusinessUnit.responding.active).to match_array [sar_responding_team]
+      end
+    end
   end
 
   it 'has a working factory' do

--- a/spec/models/business_unit_spec.rb
+++ b/spec/models/business_unit_spec.rb
@@ -317,5 +317,60 @@ RSpec.describe BusinessUnit, type: :model do
 
   end
 
+  describe '#previous_teams' do
+    context 'when a team has never moved' do
+      it 'returns empty array' do
+        current_team = create :business_unit
+        expect(current_team.previous_teams).to be_empty
+      end
+    end
 
+    context 'when a team has been moved once' do
+      let(:original_dir) { find_or_create :directorate }
+      let(:target_dir) { find_or_create :directorate }
+
+      let(:previous_team) {
+        find_or_create(
+          :business_unit,
+          directorate: original_dir,
+        )
+      }
+
+      it 'returns team moved-from' do
+        service = TeamMoveService.new(previous_team, target_dir)
+        service.call
+        current_team = service.new_team
+        expect(current_team.previous_teams).to match_array [previous_team.id]
+      end
+    end
+
+    context 'when a team has been moved twice' do
+      let(:original_dir) { find_or_create :directorate }
+      let(:first_target_dir) { find_or_create :directorate }
+      let(:second_target_dir) { find_or_create :directorate }
+      let(:business_unit_to_move) {
+        find_or_create(
+          :business_unit,
+          directorate: original_dir,
+        )
+      }
+
+      it 'tracks all history' do
+        first_team = business_unit_to_move
+        service = TeamMoveService.new(first_team, first_target_dir)
+        service.call
+        second_team = service.new_team
+
+        # pause momentarily to let the database catch up
+        sleep 1
+
+        service = TeamMoveService.new(second_team, second_target_dir)
+        service.call
+
+        third_team = service.new_team
+
+        expect(third_team.previous_teams).to match_array [first_team.id, second_team.id]
+      end
+    end
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -180,7 +180,6 @@ RSpec.describe Team, type: :model do
   end
 
   describe '#enable_allocation' do
-
     let(:foi) { create :foi_correspondence_type }
 
     it 'creates a team property record' do
@@ -254,7 +253,6 @@ RSpec.describe Team, type: :model do
   end
 
   describe 'paper_trail versions', versioning: true do
-
     it 'has versions' do
       it { is_expected.to be_versioned }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -221,18 +221,16 @@ RSpec.describe User, type: :model do
   end
 
   describe '#multiple_team_member?' do
+    let(:foi_responding_team) { find_or_create :foi_responding_team }
 
     it 'returns false for a user with one team' do
       expect(responder.multiple_team_member?).to be false
     end
-    it 'returns true for a user with mulitple teams' do
-      team = create :responding_team, name: 'User Creation Team'
-      existing_user = User.new(full_name: 'danny driver', email: 'dd@moj.com', password: 'theresamaynotlast')
-      existing_user.team_roles << TeamsUsersRole.new(team: team, role: 'responder')
-      team_2 = BusinessUnit.create(name: 'UCT 2', parent_id: team.parent_id, role: 'responder')
-      existing_user.team_roles << TeamsUsersRole.new(team: team_2, role: 'responder')
-      existing_user.save!
-      expect(existing_user.multiple_team_member?).to be true
+
+    it 'returns true for a user with multiple teams' do
+      expect(responder.multiple_team_member?).to be false
+      responder.team_roles << TeamsUsersRole.new(team: foi_responding_team, role: 'responder')
+      expect(responder.multiple_team_member?).to be true
     end
   end
 

--- a/spec/services/user_creation_service_spec.rb
+++ b/spec/services/user_creation_service_spec.rb
@@ -185,7 +185,22 @@ describe UserCreationService do
         end
       end
     end
+
+    context 'when the team has previous incarnations' do
+      let(:target_dir) { find_or_create :directorate }
+      let(:team_move_service) { TeamMoveService.new(@team, target_dir) }
+
+      it 'joins the user to both the current and previous teams' do
+        # move the team being joined first
+        team_move_service.call
+        new_team = team_move_service.new_team
+
+        # add a new user to the new team
+        service = UserCreationService.new(team: new_team, params: params)
+        service.call
+        expect(service.result).to eq :ok
+        expect(User.last.teams).to match_array [@team, new_team]
+      end
+    end
   end
-
-
 end


### PR DESCRIPTION
## Description
When a team is moved all the current team members of that team will be given permissions on the previous team.

But when new team members are assigned to the moved team, they won’t have user_roles defined on the previous incarnations of the team, so we need to ensure that when a new member joins an existing team that they also “join” all previous incarnations of that team.

When a user is “deactivated” from a team, we need to remove their user_role from the previous teams as well.
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2728
 
### Deployment
none
 
### Manual testing instructions
Move a team that has closed cases
Create a new user to join the new team
Ensure they can see the old closed cases from the previous team incarnation

Remove the user from the team
Ensure they can no longer see those closed cases
