### PR TITLE
Add new scope including responded cases

### DIFF
--- a/app/models/business_unit.rb
+++ b/app/models/business_unit.rb
@@ -71,6 +71,7 @@ class BusinessUnit < Team
            source: :case
 
   has_many :open_cases, -> { in_open_state }, through: :pending_accepted_assignments, source: :case
+  has_many :assigned_open_cases, -> { in_open_or_responded_state }, through: :pending_accepted_assignments, source: :case
 
 
   scope :managing, -> { where(role: 'manager') }

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -116,6 +116,7 @@ class Case::Base < ApplicationRecord
   end
 
   scope :in_open_state, -> { where. not(current_state: %w[responded closed] ) }
+  scope :in_open_or_responded_state, -> { where. not(current_state: %w[closed] ) }
 
   scope :accepted, -> { joins(:assignments)
                           .where(assignments: {state: ['accepted']} ) }

--- a/app/services/team_join_service.rb
+++ b/app/services/team_join_service.rb
@@ -94,7 +94,7 @@ class TeamJoinService
   end
 
   def move_associations_to_new_team
-    Assignment.where(case_id: @team.open_cases.ids, team_id: @team.id).update_all(team_id: @target_team.id)
+    Assignment.where(case_id: @team.assigned_open_cases.ids, team_id: @team.id).update_all(team_id: @target_team.id)
     CaseTransition.where(acting_team: @team).update_all(acting_team_id: @target_team.id)
     CaseTransition.where(target_team: @team).update_all(target_team_id: @target_team.id)
   end

--- a/app/services/team_move_service.rb
+++ b/app/services/team_move_service.rb
@@ -74,7 +74,7 @@ class TeamMoveService
   end
 
   def move_associations_to_new_team
-    Assignment.where(case_id: @team.open_cases.ids, team_id: @team.id).update_all(team_id: @new_team.id)
+    Assignment.where(case_id: @team.assigned_open_cases.ids, team_id: @team.id).update_all(team_id: @new_team.id)
     CaseTransition.where(acting_team: @team).update_all(acting_team_id: @new_team.id)
     CaseTransition.where(target_team: @team).update_all(target_team_id: @new_team.id)
   end

--- a/spec/services/team_join_service_spec.rb
+++ b/spec/services/team_join_service_spec.rb
@@ -129,6 +129,30 @@ describe TeamJoinService do
         end
       end
 
+      context 'when the team being moved has responded cases' do
+        let(:responded_kase) {
+          create(
+            :responded_case,
+              responding_team: business_unit,
+              responder: joining_team_user
+          )
+        }
+
+        it 'moves the open and responded cases' do
+          expect(business_unit.cases).to match_array [
+            kase,
+            klosed_kase,
+            responded_kase
+          ]
+          service.call
+          expect(business_unit.cases.reload).to match_array [klosed_kase]
+          expect(service.target_team.cases).to match_array [
+            kase,
+            responded_kase
+          ]
+        end
+      end
+
       context 'when the team being moved has trigger cases' do
         let(:kase) {
           create(

--- a/spec/services/team_move_service_spec.rb
+++ b/spec/services/team_move_service_spec.rb
@@ -193,6 +193,30 @@ describe TeamMoveService do
         end
       end
 
+      context 'when the team being moved has responded cases' do
+        let(:responded_kase) {
+          create(
+            :responded_case,
+              responding_team: business_unit,
+              responder: responder
+          )
+        }
+
+        it 'moves the open and responded cases' do
+          expect(business_unit.cases).to match_array [
+            kase,
+            klosed_kase,
+            responded_kase
+          ]
+          service.call
+          expect(business_unit.cases.reload).to match_array [klosed_kase]
+          expect(service.new_team.cases).to match_array [
+            kase,
+            responded_kase
+          ]
+        end
+      end
+
       context 'when the team being moved is an approver team' do
         let(:kase) { build(:responded_ico_foi_case) }
         let(:disclosure_team) { BusinessUnit.dacu_disclosure }


### PR DESCRIPTION
## Description
When joining or moving teams that had open cases in the responded state, these were getting left behind during the change. Screenshot shows the problem :) 

Add new scope including responded cases and ensure these are moved when joining and moving teams. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/79583590-35569200-80c5-11ea-9cfd-9f149c888537.png)

 
### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
 
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
 
### Manual testing instructions
Create an FOI::Standard in "responded" state then move or join from the team it belongs to. The case should belong to the new team, not the deactivated old team. 
