### PR TITLE
CT-2881 Fix offender-sar case details table styling

### DIFF
--- a/app/assets/stylesheets/moj/_layout.scss
+++ b/app/assets/stylesheets/moj/_layout.scss
@@ -74,6 +74,22 @@
       margin-right: .5em;
     }
   }
+
+  .case-details table {
+    border-bottom: 1px solid #bfc1c3;
+
+    th {
+      font-weight: bold;
+    }
+
+    tr, th, td {
+      border: none;
+    }
+
+    .section {
+      border-top: 1px solid #bfc1c3;
+    }
+  }
 }
 
 .request--heading {
@@ -109,7 +125,6 @@
 .closed-case-heading {
   width: 80%;
 }
-
 
 .case-info {
   margin-bottom : $gutter * 2.5;
@@ -162,22 +177,4 @@
 
 td.clearance-actions {
   text-align: right;
-}
-
-#case-offender_sar {
-  table {
-    border-bottom: 1px solid #bfc1c3;
-
-    th {
-      font-weight: bold;
-    }
-
-    tr, th, td {
-      border: none;
-    }
-
-    .section {
-      border-top: 1px solid #bfc1c3;
-    }
-  }
 }

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -11,7 +11,7 @@
 
 = render partial: 'shared/components/case_page_heading', locals: {kase: @case}
 
-div id="case-#{@correspondence_type_key == nil ? 'nil' : @correspondence_type_key.gsub('_', '-')}" class="case"
+div id="case-#{@correspondence_type_key}" class="case"
   section.case-info.has-actions
     h2.visually-hidden
       = "Actions you can take on this case"


### PR DESCRIPTION
## Description
CT-2881 Fix offender-sar case details table styling.
- Condense request and case details table styling under one rule (#case-offender_sar).
- Removed line dynamically changing id case-offender_sar to case-offender-sar.
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
 Before:

![before](https://user-images.githubusercontent.com/6988369/83278772-ffc8bc80-a1cb-11ea-84a5-29a835599fd6.png)

After:

![after](https://user-images.githubusercontent.com/6988369/83278822-14a55000-a1cc-11ea-8740-4955e699e13d.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-2881
 
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
 
### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
