### PR TITLE
CT-2874 Implement Branston responder roles part 2 - London

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -204,7 +204,7 @@ class CasesController < ApplicationController
       types.delete(CorrespondenceType.ico) unless FeatureSet.ico.enabled?
       types.delete(CorrespondenceType.offender_sar) unless FeatureSet.offender_sars.enabled?
       @permitted_correspondence_types += types
-    elsif current_user.can_manage_offender_sar?
+    elsif policy(Case::Base).can_manage_offender_sar?
       @permitted_correspondence_types << CorrespondenceType.offender_sar
     end
   end

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -590,7 +590,7 @@ class Case::Base < ApplicationRecord
     if responded_transitions.any?
       raise ArgumentError.new("Cannot call ##{__method__} on a case for which the response has been sent")
     else
-      responding_team_assignment_date = assign_responder_transitions.last.created_at.to_date
+      responding_team_assignment_date = assign_responder_transitions.last&.created_at&.to_date || received_date
       internal_deadline = deadline_calculator.business_unit_deadline_for_date(responding_team_assignment_date)
       internal_deadline < Date.today
     end

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -103,6 +103,8 @@ class Case::Base < ApplicationRecord
   scope :non_offender_sar, -> { where(type: 'Case::SAR::Standard') }
   scope :not_offender_sar, -> { where.not(type: ['Case::SAR::Offender'] ) }
 
+  scope :default_for_non_responders, -> { not_offender_sar }
+
   scope :with_teams, -> (teams) do
     includes(:assignments)
       .where(assignments: { team: teams,

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -33,7 +33,7 @@
 class Case::Base < ApplicationRecord
 
   TRIGGER_WORKFLOWS = ['trigger', 'full_approval'].freeze
-  CREATE_EVENT = 'create'.freeze 
+  CREATE_EVENT = 'create'.freeze
 
   def self.searchable_fields_and_ranks
     {
@@ -97,7 +97,11 @@ class Case::Base < ApplicationRecord
   scope :overturned_ico, -> { where(type: ['Case::OverturnedICO::FOI',
                                            'Case::OverturnedICO::SAR'])}
 
+  # TODO - This is really confusing naming - one is a SAR that's not Offender
+  # The other is a Case that's not an Offender SAR
+  # Change the name of the first one to :sar_non_offender to make it clearer
   scope :non_offender_sar, -> { where(type: 'Case::SAR::Standard') }
+  scope :not_offender_sar, -> { where.not(type: ['Case::SAR::Offender'] ) }
 
   scope :with_teams, -> (teams) do
     includes(:assignments)
@@ -351,7 +355,7 @@ class Case::Base < ApplicationRecord
   before_update :update_deadlines
   before_save :prevent_number_change,
               :trigger_reindexing
-  
+
   after_create :create_init_transition
 
   # before_save do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,10 +106,6 @@ class User < ApplicationRecord
     approving_team.present?
   end
 
-  def can_manage_offender_sar?
-    permitted_correspondence_types.include?(CorrespondenceType.offender_sar)
-  end
-
   def disclosure_specialist?
     approving_team == BusinessUnit.dacu_disclosure
   end

--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -143,8 +143,7 @@ class Case::BasePolicy < ApplicationPolicy
 
   def can_add_case?
     clear_failed_checks
-
-    user.manager? || user.can_manage_offender_sar?
+    check_user_is_a_manager || check_user_can_manage_offender_sar
   end
 
   def can_assign_case?
@@ -302,6 +301,10 @@ class Case::BasePolicy < ApplicationPolicy
     false
   end
 
+  def can_manage_offender_sar?
+    check_user_can_manage_offender_sar
+  end
+
   private
 
   check :user_in_responding_team do
@@ -321,6 +324,9 @@ class Case::BasePolicy < ApplicationPolicy
     check_escalation_deadline_has_expired && check_case_is_in_attachable_state && check_user_is_a_responder_for_case
   end
 
+  check :user_can_manage_offender_sar do
+    user.permitted_correspondence_types.include?(CorrespondenceType.offender_sar)
+  end
 
   check :user_is_assigned_manager_for_case do
     user == self.case.manager

--- a/app/policies/case/sar/offender_policy.rb
+++ b/app/policies/case/sar/offender_policy.rb
@@ -1,33 +1,33 @@
 class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
   def transition?
     clear_failed_checks
-    user_can_manage_offender_sar_cases
+    check_user_can_manage_offender_sar
   end
 
   def can_add_note_to_case?
     clear_failed_checks
-    user_can_manage_offender_sar_cases
+    check_user_can_manage_offender_sar
   end
 
   def close?
     clear_failed_checks
-    user_can_manage_offender_sar_cases
+    check_user_can_manage_offender_sar
   end
 
   def can_close_case?
     clear_failed_checks
-    user_can_manage_offender_sar_cases
+    check_user_can_manage_offender_sar
   end
 
   def show?
     clear_failed_checks
 
-    user_can_manage_offender_sar_cases
+    check_user_can_manage_offender_sar
   end
 
   def respond_and_close?
     clear_failed_checks
-    user_can_manage_offender_sar_cases
+    check_user_can_manage_offender_sar
   end
 
   def can_record_data_request?
@@ -37,15 +37,11 @@ class Case::SAR::OffenderPolicy < Case::SAR::StandardPolicy
 
   def can_send_acknowledgement_letter?
     clear_failed_checks
-    user_can_manage_offender_sar_cases
+    check_user_can_manage_offender_sar
   end
 
   def can_send_dispatch_letter?
     clear_failed_checks
-    user_can_manage_offender_sar_cases
-  end
-
-  def user_can_manage_offender_sar_cases
-    user.permitted_correspondence_types.include?(CorrespondenceType.offender_sar)
+    check_user_can_manage_offender_sar
   end
 end

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -46,7 +46,7 @@ class CaseFinderService
       case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
       closed_scope.where(id: case_ids).most_recent_first
     else
-      closed_scope.most_recent_first
+      closed_scope.most_recent_first.not_offender_sar
     end
   end
 
@@ -97,7 +97,7 @@ class CaseFinderService
       case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
       open_scope.where(id: case_ids)
     else
-      open_scope
+      open_scope.not_offender_sar
     end
   end
 

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -54,7 +54,7 @@ class CaseFinderService
 
   def index_cases_scope
     # effectively a nop; just return all the cases the user can view
-    scope
+    scope.not_offender_sar
   end
 
   def incoming_approving_cases_scope
@@ -109,7 +109,11 @@ class CaseFinderService
   end
 
   def in_time_cases_scope
-    scope.in_time
+    if user.responder_only?
+      scope.in_time
+    else
+      scope.in_time.not_offender_sar
+    end
   end
 
   def late_cases_scope

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -46,7 +46,7 @@ class CaseFinderService
       case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
       closed_scope.where(id: case_ids).most_recent_first
     else
-      closed_scope.most_recent_first.not_offender_sar
+      closed_scope.most_recent_first.default_for_non_responders
     end
   end
 
@@ -54,7 +54,7 @@ class CaseFinderService
 
   def index_cases_scope
     # effectively a nop; just return all the cases the user can view
-    scope.not_offender_sar
+    scope.default_for_non_responders
   end
 
   def incoming_approving_cases_scope
@@ -97,7 +97,7 @@ class CaseFinderService
       case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
       open_scope.where(id: case_ids)
     else
-      open_scope.not_offender_sar
+      open_scope.default_for_non_responders
     end
   end
 
@@ -112,7 +112,7 @@ class CaseFinderService
     if user.responder_only?
       scope.in_time
     else
-      scope.in_time.not_offender_sar
+      scope.in_time.default_for_non_responders
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -112,7 +112,9 @@ global_navigation:
   pages:
     create_case:
       path: /cases/new
-      visibility: manager
+      visibility:
+        - manager
+        - BRANSTON
 
     incoming_cases:
       path: /cases/incoming

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Description
 <!-- Description of the changes. High level overview of the requirements and the attempted solution -->
- 
+
 ## Self-review checklist
 <!-- Action these things before requesting reviews -->
 * [ ] (1) Quick stakeholder demo done OR
@@ -9,15 +9,16 @@
 * [ ] (4) Branch ready to be merged (not work in progress)
 * [ ] (5) No superfluous changes in diff
 * [ ] (6) No TODO's without new ticket numbers
- 
+* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
+
 ### Screenshots
 <!-- Screenshots of the new changes if appropriate -->
- 
+
 ### Related JIRA tickets
 <!-- A link or list of links to relevant issues in Jira -->
- 
+
 ### Deployment
 <!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->
- 
+
 ### Manual testing instructions
 <!-- Step-by-step instructions for the reviewer to manually test the changes -->

--- a/spec/factories/case/offender_sars.rb
+++ b/spec/factories/case/offender_sars.rb
@@ -63,6 +63,7 @@ FactoryBot.define do
     end
 
     after(:create) do |kase|
+      create :case_transition_waiting_for_data, case: kase
       create :case_transition_ready_for_vetting, case: kase
       kase.reload
     end
@@ -74,6 +75,8 @@ FactoryBot.define do
     end
 
     after(:create) do |kase|
+      create :case_transition_waiting_for_data, case: kase
+      create :case_transition_ready_for_vetting, case: kase
       create :case_transition_vetting_in_progress, case: kase
       kase.reload
     end
@@ -85,6 +88,9 @@ FactoryBot.define do
     end
 
     after(:create) do |kase|
+      create :case_transition_waiting_for_data, case: kase
+      create :case_transition_ready_for_vetting, case: kase
+      create :case_transition_vetting_in_progress, case: kase
       create :case_transition_ready_to_copy, case: kase
       kase.reload
     end
@@ -98,6 +104,10 @@ FactoryBot.define do
     end
 
     after(:create) do |kase|
+      create :case_transition_waiting_for_data, case: kase
+      create :case_transition_ready_for_vetting, case: kase
+      create :case_transition_vetting_in_progress, case: kase
+      create :case_transition_ready_to_copy, case: kase
       create :case_transition_ready_to_dispatch, case: kase
       kase.reload
     end
@@ -112,6 +122,11 @@ FactoryBot.define do
     date_responded { 4.business_days.ago }
 
     after(:create) do |kase|
+      create :case_transition_waiting_for_data, case: kase
+      create :case_transition_ready_for_vetting, case: kase
+      create :case_transition_vetting_in_progress, case: kase
+      create :case_transition_ready_to_copy, case: kase
+      create :case_transition_ready_to_dispatch, case: kase
       create :case_transition_close, case: kase
       kase.reload
     end

--- a/spec/services/case_finder_service_spec.rb
+++ b/spec/services/case_finder_service_spec.rb
@@ -432,7 +432,7 @@ describe CaseFinderService do
       }
 
       context 'non-responder' do
-        let(:finder) { finder = CaseFinderService.new(@manager) }
+        let(:finder) { CaseFinderService.new(@manager) }
 
         it 'returns all open cases except offender sar' do
           expect(finder.__send__(:open_cases_scope))
@@ -446,7 +446,7 @@ describe CaseFinderService do
       end
 
       context 'normal responder' do
-        let(:finder) { finder = CaseFinderService.new(@responder) }
+        let(:finder) { CaseFinderService.new(@responder) }
 
         it 'returns all correct cases for user' do
           expect(finder.__send__(:open_cases_scope))
@@ -467,7 +467,7 @@ describe CaseFinderService do
       end
 
       context 'branston-responder' do
-        let(:finder) { finder = CaseFinderService.new(@branston_responder) }
+        let(:finder) { CaseFinderService.new(@branston_responder) }
 
         it 'returns all open offender sar cases' do
           expect(finder.__send__(:open_cases_scope))

--- a/spec/services/case_finder_service_spec.rb
+++ b/spec/services/case_finder_service_spec.rb
@@ -207,9 +207,11 @@ describe CaseFinderService do
                original_ico_appeal: @accepted_overturned_ico_foi_original_appeal,
                identifier: '25-closed overturned ico foi'
       @offender_sar =
-        create :offender_sar_case
+        create :offender_sar_case,
+               identifier: '26-offender sar'
       @closed_offender_sar =
-        create :offender_sar_case, :closed
+        create :offender_sar_case, :closed,
+               identifier: '27-closed offender sar'
       end
     end
 
@@ -328,6 +330,8 @@ describe CaseFinderService do
                 @responded_ico,
                 @responded_ico.original_case,
               ]
+        expect(finder.__send__(:index_cases_scope))
+          .not_to include @offender_sar
       end
     end
 
@@ -514,6 +518,9 @@ describe CaseFinderService do
                   @accepted_overturned_ico_foi_original,
                   @closed_overturned_ico_foi
                 ]
+
+          expect(finder.__send__(:in_time_cases_scope))
+              .not_to include @offender_sar
         end
       end
     end
@@ -536,6 +543,8 @@ describe CaseFinderService do
                   @awaiting_responder_overturned_ico_foi_original_appeal,
                   @accepted_overturned_ico_foi_original_appeal
                 ]
+          expect(finder.__send__(:late_cases_scope))
+              .not_to include @offender_sar
         end
       end
     end
@@ -582,6 +591,8 @@ describe CaseFinderService do
               @awaiting_responder_overturned_ico_foi,
               @accepted_overturned_ico_foi
           ]
+          expect(finder.__send__(:open_cases_scope))
+              .not_to include @offender_sar
         end
       end
     end

--- a/spec/services/case_finder_service_spec.rb
+++ b/spec/services/case_finder_service_spec.rb
@@ -205,6 +205,10 @@ describe CaseFinderService do
                original_case: @accepted_overturned_ico_foi_original,
                original_ico_appeal: @accepted_overturned_ico_foi_original_appeal,
                identifier: '25-closed overturned ico foi'
+      @offender_sar =
+        create :offender_sar_case
+      @closed_offender_sar =
+        create :offender_sar_case, :closed
       end
     end
 
@@ -351,6 +355,8 @@ describe CaseFinderService do
                 @accepted_overturned_ico_foi_original_appeal,
                 @closed_overturned_ico_foi,
               ]
+        expect(finder.__send__(:closed_cases_scope))
+          .not_to include @offender_sar
       end
     end
 
@@ -418,8 +424,10 @@ describe CaseFinderService do
                 @accepted_overturned_ico_sar,
                 @overturned_ico_foi,
                 @awaiting_responder_overturned_ico_foi,
-                @accepted_overturned_ico_foi
+                @accepted_overturned_ico_foi,
               ]
+        expect(finder.__send__(:open_cases_scope))
+          .not_to include @offender_sar
       end
     end
 

--- a/spec/services/stats/r205_offender_sar_monthly_performance_report_spec.rb
+++ b/spec/services/stats/r205_offender_sar_monthly_performance_report_spec.rb
@@ -50,7 +50,7 @@ module Stats
       context 'unassigned cases' do
         it 'is calculated as an open case' do
           Timecop.freeze Time.new(2019, 6, 30, 12, 0, 0) do
-            pending "This fails when the analyzer runs because assign_responder_transitions is nil in business_unit_already_late?"
+            # pending "This fails when the analyzer runs because assign_responder_transitions is nil in business_unit_already_late?"
             late_unassigned_trigger_sar_case = create(
               :offender_sar_case,
               flag_as_high_profile: true,


### PR DESCRIPTION
## Description
Second go adding responder+ role for Branston 

Branston users can the Create Case button in the main nav now
London Disclosure users cannot see, add, edit or progress Offender SAR cases
 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
 
### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/83424064-cdb19780-a423-11ea-99d6-de6f9530ab32.png)

 
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2874
 
### Deployment
The Branston team and user need to be modified to be "responder"
 
### Manual testing instructions
Log in as Desi Arnaz - no offender SAR cases

Log in as Brian Rix (provided he's a responder in Branston Responders) and see the Create Case button and no FOI/SAR/ICO etc

If you use "rails db:reseed" it will reset your local DB and the above will just work, otherwise you need to modify the objects for Branston team and Brian Rix's roles yourself
