### PR TITLE
CT-2614 Add liveness / readiness probes to webapp

### DIFF
--- a/config/kubernetes/demo/deployment.yaml
+++ b/config/kubernetes/demo/deployment.yaml
@@ -102,6 +102,28 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
         - name: jobs
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-background-jobs.sh"]

--- a/config/kubernetes/development/deployment.yaml
+++ b/config/kubernetes/development/deployment.yaml
@@ -103,6 +103,28 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
         - name: jobs
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-background-jobs.sh"]

--- a/config/kubernetes/production/deployment.yaml
+++ b/config/kubernetes/production/deployment.yaml
@@ -102,6 +102,28 @@ spec:
               secretKeyRef:
                 name: track-a-query-s3-output
                 key: secret_access_key
+        readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
       - name: jobs
         image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
         command: ["./config/docker/entrypoint-background-jobs.sh"]

--- a/config/kubernetes/production/deployment.yaml
+++ b/config/kubernetes/production/deployment.yaml
@@ -18,91 +18,91 @@ spec:
         app: track-a-query
     spec:
       containers:
-      - name: webapp
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
-        ports:
-        - containerPort: 3000
-        command: ["./config/docker/entrypoint-webapp.sh"]
-        env:
-          - name: ENV
-            value: 'prod'
-          - name: RAILS_ENV
-            value: 'production'
-          - name: PROJECT
-            value: 'correspondence-staff'
-          - name: RAILS_SERVE_STATIC_FILES
-            value: 'true'
-          - name: GA_TRACKING_ID
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: GA_TRACKING_ID
-          - name: SETTINGS__CTS_EMAIL_URL
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__CTS_EMAIL_URL
-          - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__GOVUK_NOTIFY_API_KEY
-          - name: SETTINGS__SMOKE_TESTS__USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__USERNAME
-          - name: SETTINGS__SMOKE_TESTS__PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__PASSWORD
-          - name: SECRET_KEY_BASE
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SECRET_KEY_BASE
-          - name: SENTRY_DSN
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SENTRY_DSN
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: url
-          - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: database_password
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: url
-          - name: REDIS_AUTH_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: auth_token
-          - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: bucket_name
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: secret_access_key
-        readinessProbe:
+        - name: webapp
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
+          ports:
+          - containerPort: 3000
+          command: ["./config/docker/entrypoint-webapp.sh"]
+          env:
+            - name: ENV
+              value: 'prod'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: PROJECT
+              value: 'correspondence-staff'
+            - name: RAILS_SERVE_STATIC_FILES
+              value: 'true'
+            - name: GA_TRACKING_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GA_TRACKING_ID
+            - name: SETTINGS__CTS_EMAIL_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__CTS_EMAIL_URL
+            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
+            - name: SETTINGS__SMOKE_TESTS__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__USERNAME
+            - name: SETTINGS__SMOKE_TESTS__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__PASSWORD
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SECRET_KEY_BASE
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SENTRY_DSN
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: url
+            - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: database_password
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: url
+            - name: REDIS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: auth_token
+            - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: bucket_name
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: secret_access_key
+          readinessProbe:
             httpGet:
               path: /healthcheck
               port: 3000
@@ -124,163 +124,163 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
-      - name: jobs
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
-        command: ["./config/docker/entrypoint-background-jobs.sh"]
-        env:
-          - name: ENV
-            value: 'prod'
-          - name: RAILS_ENV
-            value: 'production'
-          - name: PROJECT
-            value: 'correspondence-staff-jobs'
-          - name: GA_TRACKING_ID
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: GA_TRACKING_ID
-          - name: SETTINGS__CTS_EMAIL_URL
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__CTS_EMAIL_URL
-          - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__GOVUK_NOTIFY_API_KEY
-          - name: SETTINGS__SMOKE_TESTS__USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__USERNAME
-          - name: SETTINGS__SMOKE_TESTS__PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__PASSWORD
-          - name: SECRET_KEY_BASE
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SECRET_KEY_BASE
-          - name: SENTRY_DSN
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SENTRY_DSN
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: url
-          - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: database_password
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: url
-          - name: REDIS_AUTH_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: auth_token
-          - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: bucket_name
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: secret_access_key
-      - name: uploads
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
-        command: ["./config/docker/entrypoint-uploads.sh"]
-        env:
-          - name: ENV
-            value: 'prod'
-          - name: RAILS_ENV
-            value: 'production'
-          - name: PROJECT
-            value: 'correspondence-staff-uploads'
-          - name: GA_TRACKING_ID
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: GA_TRACKING_ID
-          - name: SETTINGS__CTS_EMAIL_URL
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__CTS_EMAIL_URL
-          - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__GOVUK_NOTIFY_API_KEY
-          - name: SETTINGS__SMOKE_TESTS__USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__USERNAME
-          - name: SETTINGS__SMOKE_TESTS__PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__PASSWORD
-          - name: SECRET_KEY_BASE
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SECRET_KEY_BASE
-          - name: SENTRY_DSN
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SENTRY_DSN
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: url
-          - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: database_password
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: url
-          - name: REDIS_AUTH_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: auth_token
-          - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: bucket_name
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: secret_access_key
+        - name: jobs
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
+          command: ["./config/docker/entrypoint-background-jobs.sh"]
+          env:
+            - name: ENV
+              value: 'prod'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: PROJECT
+              value: 'correspondence-staff-jobs'
+            - name: GA_TRACKING_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GA_TRACKING_ID
+            - name: SETTINGS__CTS_EMAIL_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__CTS_EMAIL_URL
+            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
+            - name: SETTINGS__SMOKE_TESTS__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__USERNAME
+            - name: SETTINGS__SMOKE_TESTS__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__PASSWORD
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SECRET_KEY_BASE
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SENTRY_DSN
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: url
+            - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: database_password
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: url
+            - name: REDIS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: auth_token
+            - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: bucket_name
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: secret_access_key
+        - name: uploads
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
+          command: ["./config/docker/entrypoint-uploads.sh"]
+          env:
+            - name: ENV
+              value: 'prod'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: PROJECT
+              value: 'correspondence-staff-uploads'
+            - name: GA_TRACKING_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GA_TRACKING_ID
+            - name: SETTINGS__CTS_EMAIL_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__CTS_EMAIL_URL
+            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
+            - name: SETTINGS__SMOKE_TESTS__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__USERNAME
+            - name: SETTINGS__SMOKE_TESTS__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__PASSWORD
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SECRET_KEY_BASE
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SENTRY_DSN
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: url
+            - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: database_password
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: url
+            - name: REDIS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: auth_token
+            - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: bucket_name
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: secret_access_key

--- a/config/kubernetes/qa/deployment.yaml
+++ b/config/kubernetes/qa/deployment.yaml
@@ -18,91 +18,91 @@ spec:
         app: track-a-query
     spec:
       containers:
-      - name: webapp
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
-        ports:
-        - containerPort: 3000
-        command: ["./config/docker/entrypoint-webapp.sh"]
-        env:
-          - name: ENV
-            value: 'qa'
-          - name: RAILS_ENV
-            value: 'production'
-          - name: PROJECT
-            value: 'correspondence-staff'
-          - name: RAILS_SERVE_STATIC_FILES
-            value: 'true'
-          - name: GA_TRACKING_ID
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: GA_TRACKING_ID
-          - name: SETTINGS__CTS_EMAIL_URL
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__CTS_EMAIL_URL
-          - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__GOVUK_NOTIFY_API_KEY
-          - name: SETTINGS__SMOKE_TESTS__USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__USERNAME
-          - name: SETTINGS__SMOKE_TESTS__PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__PASSWORD
-          - name: SECRET_KEY_BASE
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SECRET_KEY_BASE
-          - name: SENTRY_DSN
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SENTRY_DSN
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: url
-          - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: database_password
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: url
-          - name: REDIS_AUTH_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: auth_token
-          - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: bucket_name
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: secret_access_key
-        readinessProbe:
+        - name: webapp
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
+          ports:
+          - containerPort: 3000
+          command: ["./config/docker/entrypoint-webapp.sh"]
+          env:
+            - name: ENV
+              value: 'qa'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: PROJECT
+              value: 'correspondence-staff'
+            - name: RAILS_SERVE_STATIC_FILES
+              value: 'true'
+            - name: GA_TRACKING_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GA_TRACKING_ID
+            - name: SETTINGS__CTS_EMAIL_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__CTS_EMAIL_URL
+            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
+            - name: SETTINGS__SMOKE_TESTS__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__USERNAME
+            - name: SETTINGS__SMOKE_TESTS__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__PASSWORD
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SECRET_KEY_BASE
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SENTRY_DSN
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: url
+            - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: database_password
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: url
+            - name: REDIS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: auth_token
+            - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: bucket_name
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: secret_access_key
+          readinessProbe:
             httpGet:
               path: /healthcheck
               port: 3000
@@ -124,163 +124,163 @@ spec:
                   value: "on"
             initialDelaySeconds: 40
             periodSeconds: 60
-      - name: jobs
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
-        command: ["./config/docker/entrypoint-background-jobs.sh"]
-        env:
-          - name: ENV
-            value: 'qa'
-          - name: RAILS_ENV
-            value: 'production'
-          - name: PROJECT
-            value: 'correspondence-staff-jobs'
-          - name: GA_TRACKING_ID
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: GA_TRACKING_ID
-          - name: SETTINGS__CTS_EMAIL_URL
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__CTS_EMAIL_URL
-          - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__GOVUK_NOTIFY_API_KEY
-          - name: SETTINGS__SMOKE_TESTS__USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__USERNAME
-          - name: SETTINGS__SMOKE_TESTS__PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__PASSWORD
-          - name: SECRET_KEY_BASE
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SECRET_KEY_BASE
-          - name: SENTRY_DSN
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SENTRY_DSN
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: url
-          - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: database_password
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: url
-          - name: REDIS_AUTH_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: auth_token
-          - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: bucket_name
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: secret_access_key
-      - name: uploads
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
-        command: ["./config/docker/entrypoint-uploads.sh"]
-        env:
-          - name: ENV
-            value: 'qa'
-          - name: RAILS_ENV
-            value: 'production'
-          - name: PROJECT
-            value: 'correspondence-staff-uploads'
-          - name: GA_TRACKING_ID
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: GA_TRACKING_ID
-          - name: SETTINGS__CTS_EMAIL_URL
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__CTS_EMAIL_URL
-          - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__GOVUK_NOTIFY_API_KEY
-          - name: SETTINGS__SMOKE_TESTS__USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__USERNAME
-          - name: SETTINGS__SMOKE_TESTS__PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SETTINGS__SMOKE_TESTS__PASSWORD
-          - name: SECRET_KEY_BASE
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SECRET_KEY_BASE
-          - name: SENTRY_DSN
-            valueFrom:
-              secretKeyRef:
-                name: app-secrets
-                key: SENTRY_DSN
-          - name: DATABASE_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: url
-          - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-rds-output
-                key: database_password
-          - name: REDIS_URL
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: url
-          - name: REDIS_AUTH_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-elasticache-redis-output
-                key: auth_token
-          - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: bucket_name
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: track-a-query-s3-output
-                key: secret_access_key
+        - name: jobs
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
+          command: ["./config/docker/entrypoint-background-jobs.sh"]
+          env:
+            - name: ENV
+              value: 'qa'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: PROJECT
+              value: 'correspondence-staff-jobs'
+            - name: GA_TRACKING_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GA_TRACKING_ID
+            - name: SETTINGS__CTS_EMAIL_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__CTS_EMAIL_URL
+            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
+            - name: SETTINGS__SMOKE_TESTS__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__USERNAME
+            - name: SETTINGS__SMOKE_TESTS__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__PASSWORD
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SECRET_KEY_BASE
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SENTRY_DSN
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: url
+            - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: database_password
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: url
+            - name: REDIS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: auth_token
+            - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: bucket_name
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: secret_access_key
+        - name: uploads
+          image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
+          command: ["./config/docker/entrypoint-uploads.sh"]
+          env:
+            - name: ENV
+              value: 'qa'
+            - name: RAILS_ENV
+              value: 'production'
+            - name: PROJECT
+              value: 'correspondence-staff-uploads'
+            - name: GA_TRACKING_ID
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: GA_TRACKING_ID
+            - name: SETTINGS__CTS_EMAIL_URL
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__CTS_EMAIL_URL
+            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
+            - name: SETTINGS__SMOKE_TESTS__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__USERNAME
+            - name: SETTINGS__SMOKE_TESTS__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SETTINGS__SMOKE_TESTS__PASSWORD
+            - name: SECRET_KEY_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SECRET_KEY_BASE
+            - name: SENTRY_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: app-secrets
+                  key: SENTRY_DSN
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: url
+            - name: CORRESPONDENCE_PLATFORM_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-rds-output
+                  key: database_password
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: url
+            - name: REDIS_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-elasticache-redis-output
+                  key: auth_token
+            - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: bucket_name
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: track-a-query-s3-output
+                  key: secret_access_key

--- a/config/kubernetes/qa/deployment.yaml
+++ b/config/kubernetes/qa/deployment.yaml
@@ -102,6 +102,28 @@ spec:
               secretKeyRef:
                 name: track-a-query-s3-output
                 key: secret_access_key
+        readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
       - name: jobs
         image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
         command: ["./config/docker/entrypoint-background-jobs.sh"]

--- a/config/kubernetes/staging/deployment.yaml
+++ b/config/kubernetes/staging/deployment.yaml
@@ -102,6 +102,28 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: 3000
+              httpHeaders:
+                - name: X-Forwarded-Proto
+                  value: https
+                - name: X-Forwarded-Ssl
+                  value: "on"
+            initialDelaySeconds: 40
+            periodSeconds: 60
         - name: jobs
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-background-jobs.sh"]


### PR DESCRIPTION
## Description
Add liveness and readiness probes for Kubernetes to deployment files only.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2614

### Deployment
Need to deploy to all envs, prod last after satisfactory testing on other envs.

### Manual testing instructions
deploy last tag, or build a new one then deploy to development. Check if site is working. Need to do same for other envs.
