### PR TITLE
CT-2913 add data subject location field to subject details

### DIFF
--- a/app/controllers/concerns/offender_sar_cases_params.rb
+++ b/app/controllers/concerns/offender_sar_cases_params.rb
@@ -17,6 +17,7 @@ module OffenderSARCasesParams
       :received_date_dd, :received_date_mm, :received_date_yyyy,
       :requester_type,
       :subject,
+      :subject_address,
       :subject_aliases,
       :subject_full_name,
       :subject_type,

--- a/app/form_models/offender_sar_case_form.rb
+++ b/app/form_models/offender_sar_case_form.rb
@@ -28,6 +28,7 @@ class OffenderSARCaseForm
            :reply_method,
            :send_by_email?,
            :send_by_post?,
+           :subject_address,
            :subject_aliases,
            :subject_full_name,
            :subject_type,

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -38,6 +38,7 @@ class Case::SAR::Offender < Case::Base
                  previous_case_numbers: :string,
                  prison_number: :string,
                  reply_method: :string,
+                 subject_address: :string,
                  subject_aliases: :string,
                  subject_full_name: :string,
                  subject_type: :string,
@@ -81,6 +82,7 @@ class Case::SAR::Offender < Case::Base
 
   validates_presence_of :email,          if: :send_by_email?
   validates_presence_of :postal_address, if: :send_by_post?
+  validates_presence_of :subject_address
 
   validates :subject_full_name, presence: true
   validates :subject_type, presence: true

--- a/app/views/cases/offender_sar/_case_details.html.slim
+++ b/app/views/cases/offender_sar/_case_details.html.slim
@@ -16,6 +16,7 @@
         = render partial: 'cases/offender_sar/other_subject_ids', locals: { case_details: case_details }
         = render partial: 'cases/offender_sar/case_reference_number', locals: { case_details: case_details }
         = render partial: 'cases/sar/subject_type', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar/subject_address', locals: { case_details: case_details }
         = render partial: 'cases/offender_sar/high_profile_subject', locals: { case_details: case_details }
         = render partial: 'cases/offender_sar/third_party', locals: { case_details: case_details }
         - if case_details.third_party?

--- a/app/views/cases/offender_sar/_subject_address.html.slim
+++ b/app/views/cases/offender_sar/_subject_address.html.slim
@@ -1,0 +1,3 @@
+tr.subject-address
+  th = t('common.case.subject_address')
+  td = case_details.subject_address

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -22,7 +22,7 @@
   = f.radio_button_fieldset :subject_type,
     choices: Case::SAR::Offender::subject_types.keys
 
-  = f.text_area :subject_address
+  = f.text_area :subject_address, rows: '4'
 
   = f.radio_button_fieldset(:flag_as_high_profile) do |fieldset|
     - fieldset.radio_input(true, text_method: :humanize)

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -22,6 +22,8 @@
   = f.radio_button_fieldset :subject_type,
     choices: Case::SAR::Offender::subject_types.keys
 
+  = f.text_area :subject_address
+
   = f.radio_button_fieldset(:flag_as_high_profile) do |fieldset|
     - fieldset.radio_input(true, text_method: :humanize)
     - fieldset.radio_input(false, text_method: :humanize)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -460,6 +460,7 @@ en:
         subject: "Case summary"
         subject_aliases: "Subject's alias if applicable"
         subject_full_name: "Full name of data subject"
+        subject_address: "What is the location of the data subject?"
         subject_type:
           detainee: Detainee
           ex_detainee: Ex-detainee
@@ -588,6 +589,7 @@ en:
       requester_type: "Type of requester"
       sar_response_address: Where the information should be sent
       status: Status
+      subject_address: Location of data subject
       subject_aliases: Alias
       third_party: Information requested on someone's behalf?
       third_party_relationship: Relationship

--- a/spec/factories/case/offender_sars.rb
+++ b/spec/factories/case/offender_sars.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     prison_number                   { '123465' }
     other_subject_ids               { 'ABC 123 DEF' }
     case_reference_number { '123 ABC 456' }
+    subject_address                 { '22 Sample Address, Test Lane, Testingington, TE57ST' }
     subject_type                    { 'offender' }
     third_party                     { false }
     flag_as_high_profile            { false }

--- a/spec/models/case/sar/offender_spec.rb
+++ b/spec/models/case/sar/offender_spec.rb
@@ -483,4 +483,12 @@ describe Case::SAR::Offender do
       expect(kase.allow_waiting_for_data_state?).to be false
     end
   end
+
+  describe '#subject_address' do
+    it 'validates presence of subject address' do
+      kase = build :offender_sar_case, subject_address: ''
+      expect(kase).not_to be_valid
+      expect(kase.errors[:subject_address]).to eq ["can't be blank"]
+    end
+  end
 end

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
@@ -26,6 +26,8 @@ module PageObjects
 
           element :date_of_birth_mm, '#offender_sar_date_of_birth_mm'
 
+          element :subject_address, '#offender_sar_subject_address'
+
           element :date_of_birth_yyyy, '#offender_sar_date_of_birth_yyyy'
 
           element :submit_button, '.button'
@@ -35,6 +37,7 @@ module PageObjects
 
             subject_full_name.set 'Sabrina Adams'
             prison_number.set kase.prison_number
+            subject_address.set kase.subject_address
             subject_aliases.set kase.subject_aliases
             previous_case_numbers.set kase.previous_case_numbers
             set_date_of_birth kase.date_of_birth

--- a/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
@@ -58,6 +58,10 @@ module PageObjects
             element :data, 'td'
           end
 
+          section :subject_address, 'tr.subject-address' do
+            element :data, 'td'
+          end
+
           section :date_received, 'tr.date-received' do
             element :data, 'td:first'
           end

--- a/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
@@ -40,6 +40,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
       expect(partial.previous_case_numbers.data.text).to eq '54321'
       expect(partial.other_subject_ids.data.text).to eq 'ABC 123 DEF'
       expect(partial.case_reference_number.data.text).to eq '123 ABC 456'
+      expect(partial.subject_address.data.text).to eq '22 Sample Address, Test Lane, Testingington, TE57ST'
       expect(partial.date_of_birth.data.text).to eq '1 Sep 2019'
     end
 


### PR DESCRIPTION
## Description

Adds subject address to Offender SAR case creation.

## Notes for reviewer
- Note that the implementation changed slightly from the design by having a single field for `subject_address` rather than a 'pop-out' address field per subject type. This was agreed with Designers and the PM before going down this path.
- I haven't amended feature specs for the initial case creation - some rationalising of this is part of a wider ticket in the backlog already.
- Tests for model validation and Case details page. I think this is sufficient as the case creation is backed by the model and therefore that page will not be able to be completed without adding data into the subject address field. Happy to discuss this approach to see if it's right though.


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots

**Before:**
_new_case:_
<img width="439" alt="Screenshot 2020-07-07 at 11 14 36" src="https://user-images.githubusercontent.com/13377553/86766924-1bcd4280-c043-11ea-86b4-53e4631bd024.png">

_case_details:_
<img width="991" alt="Screenshot 2020-06-30 at 17 37 20" src="https://user-images.githubusercontent.com/13377553/86767069-59ca6680-c043-11ea-8c56-c37a7662f192.png">


**After:**
_new_case:_
<img width="536" alt="Screenshot 2020-07-07 at 11 13 01" src="https://user-images.githubusercontent.com/13377553/86766761-e45e9600-c042-11ea-86ac-87762b862275.png">

_case details:_
<img width="991" alt="Screenshot 2020-06-30 at 17 37 20" src="https://user-images.githubusercontent.com/13377553/86766252-32bf6500-c042-11ea-8aa1-dfa4240ce186.png">

### Related JIRA tickets
[CT-2913](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-2913)

### Deployment
- NA

### Manual testing instructions
1) Log in as Brian Rix
2) Create an Offender SAR
3) Check validations work on subject address (i.e. submit with this field blank).
4) Complete rest of form
5) Ensure address is viewable in case details summary page.