### PR TITLE
CT-2919 update letter templates

### DIFF
--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -217,7 +217,8 @@ class Case::SAR::Offender < Case::Base
   end
 
   def recipient_name
-    (!subject_recipient?) ? third_party_name : subject_name
+    return subject_name if subject_recipient?
+    third_party_name.present? ? third_party_name : ''
   end
 
   def recipient_address

--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -29,5 +29,23 @@ class Letter
   def template_name
     @letter_template&.name
   end
+
+  def letter_recipient
+    case @letter_template.template_type
+    when "dispatch"
+      values.recipient_name
+    when "acknowledgement"
+      values.requester_name
+    end
+  end
+
+  def letter_address
+    case @letter_template.template_type
+    when "dispatch"
+      values.recipient_address
+    when "acknowledgement"
+      values.requester_address
+    end
+  end
 end
 

--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -30,7 +30,7 @@ class Letter
     @letter_template&.name
   end
 
-  def letter_recipient
+  def name
     case @letter_template.template_type
     when "dispatch"
       values.recipient_name
@@ -39,13 +39,17 @@ class Letter
     end
   end
 
-  def letter_address
+  def address
     case @letter_template.template_type
     when "dispatch"
       values.recipient_address
     when "acknowledgement"
       values.requester_address
     end
+  end
+
+  def company_name
+    values.third_party_company_name if values.third_party_company_name.present?
   end
 end
 

--- a/app/views/cases/letters/show.html.slim
+++ b/app/views/cases/letters/show.html.slim
@@ -25,10 +25,10 @@ section.letter--from-section
     | Date: #{Date.today.strftime('%e %b %Y')}
 
 p
-  | #{@case.name} <br>
+  | #{@letter.letter_recipient} <br>
   - if @case.third_party_company_name.present?
     | #{@case.third_party_company_name} <br>
-  | #{simple_format @case.postal_address, {}, wrapper_tag: 'span'}
+  | #{simple_format @letter.letter_address, {}, wrapper_tag: 'span'}
 
 = raw @letter.body
 

--- a/app/views/cases/letters/show.html.slim
+++ b/app/views/cases/letters/show.html.slim
@@ -25,10 +25,10 @@ section.letter--from-section
     | Date: #{Date.today.strftime('%e %b %Y')}
 
 p
-  | #{@letter.letter_recipient} <br>
-  - if @case.third_party_company_name.present?
-    | #{@case.third_party_company_name} <br>
-  | #{simple_format @letter.letter_address, {}, wrapper_tag: 'span'}
+  | #{@letter.name} <br>
+  - if @letter.company_name
+    | #{@letter.company_name} <br>
+  | #{simple_format @letter.address, {}, wrapper_tag: 'span'}
 
 = raw @letter.body
 

--- a/spec/factories/case/offender_sars.rb
+++ b/spec/factories/case/offender_sars.rb
@@ -46,6 +46,7 @@ FactoryBot.define do
     third_party_company_name { 'Foogle and Sons Solicitors at Law' }
     third_party_name { 'Mr J. Smith' }
     postal_address { '22 High Street' }
+    recipient { 'requester_recipient' }
   end
 
   trait :data_to_be_requested do

--- a/spec/models/case/sar/offender_spec.rb
+++ b/spec/models/case/sar/offender_spec.rb
@@ -314,14 +314,22 @@ describe Case::SAR::Offender do
   end
 
   describe '#recipient_name' do
-    it 'returns third_party_name subject not recipient recipient' do
-      kase = create :offender_sar_case, recipient: "requester_recipient"
+    it 'returns third_party_name when subject not recipient' do
+      kase = create :offender_sar_case, :third_party
+      expect(kase.recipient_name).not_to eq kase.subject_name
       expect(kase.recipient_name).to eq kase.third_party_name
     end
 
     it 'returns subject_name if subject is recipient' do
       kase = create :offender_sar_case
+      expect(kase.recipient_name).not_to eq kase.third_party_name
       expect(kase.recipient_name).to eq kase.subject_name
+    end
+
+    it 'returns nothing if third party and no name supplied' do
+      kase = create :offender_sar_case, :third_party, third_party_name: ''
+
+      expect(kase.recipient_name).to eq ''
     end
   end
 

--- a/spec/models/letter_spec.rb
+++ b/spec/models/letter_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Letter, type: :model do
   describe '#letter_recipient' do
     context 'when letter template is acknowledgement letter' do
       context 'when subject is requester' do
-        it  'returns the subject name' do
+        it 'returns the subject name' do
           letter = Letter.new(letter_template.id, kase)
           expect(letter.letter_recipient).to eq kase.requester_name
           expect(letter.letter_recipient).to eq kase.subject_name
@@ -36,7 +36,7 @@ RSpec.describe Letter, type: :model do
 
       context 'when third party is requester' do
         let(:kase) { build(:offender_sar_case, :third_party, third_party_name: "Bob") }
-        it  'returns the third_party name' do
+        it 'returns the third_party name' do
           letter = Letter.new(letter_template.id, kase)
           expect(letter.letter_recipient).to eq kase.requester_name
           expect(letter.letter_recipient).to eq kase.third_party_name
@@ -48,7 +48,7 @@ RSpec.describe Letter, type: :model do
       let(:letter_template) { create(:letter_template, template_type: "dispatch", name: "Letter to Recipient") }
 
       context 'when subject is recipient' do
-        it  'returns the subject name' do
+        it 'returns the subject name' do
           letter = Letter.new(letter_template.id, kase)
           expect(letter.letter_recipient).to eq kase.recipient_name
           expect(letter.letter_recipient).to eq kase.subject_name
@@ -58,7 +58,7 @@ RSpec.describe Letter, type: :model do
       context 'when third party is recipient' do
         let(:kase) { build(:offender_sar_case, :third_party, third_party_name: "Bob") }
 
-        it  'returns the third_party name' do
+        it 'returns the third_party name' do
           letter = Letter.new(letter_template.id, kase)
           expect(letter.letter_recipient).to eq kase.recipient_name
           expect(letter.letter_recipient).to eq kase.third_party_name

--- a/spec/models/letter_spec.rb
+++ b/spec/models/letter_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe Letter, type: :model do
     expect(letter.template_name).to eq 'Letter to Requester'
   end
 
-  describe '#letter_recipient' do
+  describe '#name' do
     context 'when letter template is acknowledgement letter' do
       context 'when subject is requester' do
         it 'returns the subject name' do
           letter = Letter.new(letter_template.id, kase)
-          expect(letter.letter_recipient).to eq kase.requester_name
-          expect(letter.letter_recipient).to eq kase.subject_name
+          expect(letter.name).to eq kase.requester_name
+          expect(letter.name).to eq kase.subject_name
         end
       end
 
@@ -38,8 +38,8 @@ RSpec.describe Letter, type: :model do
         let(:kase) { build(:offender_sar_case, :third_party, third_party_name: "Bob") }
         it 'returns the third_party name' do
           letter = Letter.new(letter_template.id, kase)
-          expect(letter.letter_recipient).to eq kase.requester_name
-          expect(letter.letter_recipient).to eq kase.third_party_name
+          expect(letter.name).to eq kase.requester_name
+          expect(letter.name).to eq kase.third_party_name
         end
       end
     end
@@ -50,8 +50,8 @@ RSpec.describe Letter, type: :model do
       context 'when subject is recipient' do
         it 'returns the subject name' do
           letter = Letter.new(letter_template.id, kase)
-          expect(letter.letter_recipient).to eq kase.recipient_name
-          expect(letter.letter_recipient).to eq kase.subject_name
+          expect(letter.name).to eq kase.recipient_name
+          expect(letter.name).to eq kase.subject_name
         end
       end
 
@@ -60,9 +60,78 @@ RSpec.describe Letter, type: :model do
 
         it 'returns the third_party name' do
           letter = Letter.new(letter_template.id, kase)
-          expect(letter.letter_recipient).to eq kase.recipient_name
-          expect(letter.letter_recipient).to eq kase.third_party_name
+          expect(letter.name).to eq kase.recipient_name
+          expect(letter.name).to eq kase.third_party_name
         end
+      end
+    end
+  end
+
+  describe '#address' do
+    context 'when letter template is acknowledgement letter' do
+      context 'when subject is requester' do
+        it 'returns the subject address' do
+          letter = Letter.new(letter_template.id, kase)
+          expect(letter.address).to eq kase.requester_address
+          expect(letter.address).to eq kase.subject_address
+        end
+      end
+
+      context 'when third party is requester' do
+        let(:kase) { build(:offender_sar_case, :third_party, postal_address: "33 High Street") }
+        it 'returns the third_party address' do
+          letter = Letter.new(letter_template.id, kase)
+          expect(letter.address).to eq kase.requester_address
+          expect(letter.address).to eq kase.third_party_address
+        end
+      end
+    end
+
+    context 'when letter template is dispatch letter' do
+      let(:letter_template) { create(:letter_template, template_type: "dispatch", name: "Letter to Recipient") }
+
+      context 'when subject is recipient' do
+        it 'returns the subject address' do
+          letter = Letter.new(letter_template.id, kase)
+          expect(letter.address).to eq kase.recipient_address
+          expect(letter.address).to eq kase.subject_address
+        end
+      end
+
+      context 'when third party is recipient' do
+        let(:kase) { build(:offender_sar_case, :third_party, postal_address: "33 High Street") }
+
+        it 'returns the third_party address' do
+          letter = Letter.new(letter_template.id, kase)
+          expect(letter.address).to eq kase.recipient_address
+          expect(letter.address).to eq kase.third_party_address
+        end
+      end
+    end
+  end
+
+  describe '#company_name' do
+    context 'when no company_name is present' do
+     let(:kase) { build(:offender_sar_case) }
+      it 'returns nil' do
+        letter = Letter.new(letter_template.id, kase)
+        expect(letter.company_name).to be_nil
+      end
+    end
+
+    context 'when company_name is blank' do
+     let(:kase) { build(:offender_sar_case, :third_party, third_party_company_name: '') }
+      it 'returns nil' do
+        letter = Letter.new(letter_template.id, kase)
+        expect(letter.company_name).to be_nil
+      end
+    end
+
+    context 'when company_name is present' do
+     let(:kase) { build(:offender_sar_case, :third_party, third_party_company_name: 'Wibble') }
+      it 'returns the company name' do
+        letter = Letter.new(letter_template.id, kase)
+        expect(letter.company_name).to eq "Wibble"
       end
     end
   end

--- a/spec/models/letter_spec.rb
+++ b/spec/models/letter_spec.rb
@@ -11,19 +11,59 @@ RSpec.describe Letter, type: :model do
 
   it 'delegates values to a case' do
     letter = Letter.new(letter_template.id, kase)
-
     expect(letter.values.name).to eq "Waylon Smithers"
   end
 
   it 'renders a case' do
     letter = Letter.new(letter_template.id, kase)
-
     expect(letter.body).to eq 'Thank you for your offender subject access request, Waylon Smithers'
   end
 
   it 'displays the template name' do
     letter = Letter.new(letter_template.id, kase)
-
     expect(letter.template_name).to eq 'Letter to Requester'
+  end
+
+  describe '#letter_recipient' do
+    context 'when letter template is acknowledgement letter' do
+      context 'when subject is requester' do
+        it  'returns the subject name' do
+          letter = Letter.new(letter_template.id, kase)
+          expect(letter.letter_recipient).to eq kase.requester_name
+          expect(letter.letter_recipient).to eq kase.subject_name
+        end
+      end
+
+      context 'when third party is requester' do
+        let(:kase) { build(:offender_sar_case, :third_party, third_party_name: "Bob") }
+        it  'returns the third_party name' do
+          letter = Letter.new(letter_template.id, kase)
+          expect(letter.letter_recipient).to eq kase.requester_name
+          expect(letter.letter_recipient).to eq kase.third_party_name
+        end
+      end
+    end
+
+    context 'when letter template is dispatch letter' do
+      let(:letter_template) { create(:letter_template, template_type: "dispatch", name: "Letter to Recipient") }
+
+      context 'when subject is recipient' do
+        it  'returns the subject name' do
+          letter = Letter.new(letter_template.id, kase)
+          expect(letter.letter_recipient).to eq kase.recipient_name
+          expect(letter.letter_recipient).to eq kase.subject_name
+        end
+      end
+
+      context 'when third party is recipient' do
+        let(:kase) { build(:offender_sar_case, :third_party, third_party_name: "Bob") }
+
+        it  'returns the third_party name' do
+          letter = Letter.new(letter_template.id, kase)
+          expect(letter.letter_recipient).to eq kase.recipient_name
+          expect(letter.letter_recipient).to eq kase.third_party_name
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
The reason for doing all this was so that we could support cases where the requester and the recipient were different people and we needed to send the acknowledgement letter to one and the dispatch letter to the other. 

This PR adds support for `letter_recipient` which is a convenience method on the Letter object which calls either "requester_name" or "recipient_name" depending on whether it is an acknowledgement letter or a dispatch letter, and the same for `letter_address`. This allows us to keep logic out of the letter templates themselves and have simple method calls in the ERB templates for those.

There was a bug where it displayed the offender name for third party recipient, when it should have output either the representative name or nothing. Think this is fixed, but worth keeping an eye on

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
For example, prisoner requests own data to send to solicitor

Acknowledgement letter addressed to prisoner
![image](https://user-images.githubusercontent.com/1161161/87439680-fa42fc80-c5e8-11ea-963f-fc36533043c5.png)

Dispatch letter addressed to solicitor
![image](https://user-images.githubusercontent.com/1161161/87441264-d2549880-c5ea-11ea-93a1-7c3edaf14d51.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2919

### Deployment
nope

### Manual testing instructions
For each scenario, you need to make sure you choose the relevant template at the letter stage - solicirtor or offender template for example - but otherwise it should "do the right thing" in terms of putting in subject name/address or third party name/address as appropriate depending on subject/requester/recipient settings for the case
