### PR TITLE
CT-2898 suppress team choice when closing case

### DIFF
--- a/app/views/cases/offender_sar/_closure_outcomes_form.html.slim
+++ b/app/views/cases/offender_sar/_closure_outcomes_form.html.slim
@@ -1,9 +1,6 @@
 - url = defined?(form_url) ? form_url : polymorphic_path(@case, action: :process_closure)
 = form_for kase, as: :"#{@correspondence_type_key}", url: url do |f|
 
-  - if @case.responded_late?
-    = render partial: 'cases/shared/team_caused_late_response', locals: { kase: @case, f: f }
-
   p Coming soon - reasons for late case
 
   / TODO - pending decision on closure outcomes https://dsdmoj.atlassian.net/browse/CT-2502

--- a/spec/features/cases/offender_sar/case_closing_spec.rb
+++ b/spec/features/cases/offender_sar/case_closing_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
+
+feature 'Closing a case' do
+  
+  given(:responder)         { find_or_create :branston_user }
+  given(:responder_team)   { responder.responding_teams.first }
+
+  background do
+    # find_or_create :team_branston
+    login_as responder
+  end
+
+  context 'Reporting timiliness' do
+    Timecop.freeze(Time.local(2017, 11, 23, 13, 13, 56)) do
+      context 'responded-to in time' do
+        given!(:fully_granted_case) { 
+          create :offender_sar_case, 
+          :ready_to_dispatch, 
+          received_date: 5.business_days.ago }
+
+        scenario 'Offender sar team has responded and a responder closes the case', js:true do
+          open_cases_page.load
+          close_case(fully_granted_case)
+
+          cases_close_page.fill_in_date_responded(0.business_days.ago)
+          cases_close_page.click_on 'Continue'
+
+          expect(cases_closure_outcomes_page).to be_displayed
+          expect(cases_closure_outcomes_page).not_to have_content("#{responder_team.name}")
+
+          cases_closure_outcomes_page.submit_button.click
+
+          show_page = cases_show_page.case_details
+
+          expect(show_page.response_details.date_responded.data.text)
+          .to eq 0.business_days.ago.strftime(Settings.default_date_format)
+          expect(show_page.response_details.timeliness.data.text)
+          .to eq 'Answered in time'
+          expect(show_page.response_details.time_taken.data.text)
+          .to eq '6 working days'
+        end
+      end
+
+      context 'responded-to late' do
+        given!(:fully_granted_case) { 
+          create :offender_sar_case,
+          :ready_to_dispatch, 
+          received_date: 35.business_days.ago }
+
+        scenario 'the case is responded-to late', js: true do
+          open_cases_page.load(timeliness: 'late')
+          close_case(fully_granted_case)
+
+          cases_close_page.fill_in_date_responded(0.business_days.ago)
+          cases_close_page.click_on 'Continue'
+
+          expect(cases_closure_outcomes_page).to be_displayed
+          expect(cases_closure_outcomes_page).not_to have_content("#{responder_team.name}")
+          cases_closure_outcomes_page.submit_button.click
+
+          show_page = cases_show_page.case_details
+          expect(show_page.response_details.timeliness.data.text)
+            .to eq 'Answered late'
+          expect(show_page.response_details.time_taken.data.text)
+            .to eq '36 working days'
+        end
+      end
+    end
+  end
+
+
+  private
+
+  def close_case(kase)
+    expect(cases_page.case_list.last.status.text).to eq 'Ready to dispatch'
+    click_link kase.number
+    expect(cases_show_page.actions).
+      to have_link('Close case', href: "/cases/offender_sars/#{kase.id}/close")
+    click_link 'Close case'
+  end
+end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
Don't show the choice for choosing team for late response when closing a case
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
Login as Branston user
choose a case 
Move the flow forwards until to the last step - "Close case"
There should be choice for asking to choose team for late response