### PR TITLE
Remove spacing under hint

### DIFF
--- a/app/assets/stylesheets/moj/_utility.scss
+++ b/app/assets/stylesheets/moj/_utility.scss
@@ -1,3 +1,8 @@
 .display-none {
   display: none;
 }
+
+.no-space {
+  margin: 0;
+  padding: 0;
+}

--- a/app/views/cases/offender_sar/_requested_info_step.html.slim
+++ b/app/views/cases/offender_sar/_requested_info_step.html.slim
@@ -4,7 +4,7 @@
 = render partial: 'layouts/header'
 
 = form_for @case, url: url, as: :offender_sar do |f|
-  p.form-hint
+  p.form-hint.no-space
     = t('helpers.hint.offender_sar.message_hint')
   = f.text_area :message, { rows: 12, label_options: { class: 'visually-hidden' } }
 


### PR DESCRIPTION
## Description
Remove the space under the form hint as per Slack discussion https://mojdt.slack.com/archives/CC3A275NU/p1594720712002600

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/22935203/87570917-35b0fa00-c6c1-11ea-91a6-2aa95e140d71.png)


After:

![image](https://user-images.githubusercontent.com/22935203/87570850-22059380-c6c1-11ea-965b-c6e923d758cd.png)



### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2927

### Deployment
n/a

### Manual testing instructions
Create offender sar case, check hint format on Other Relevant Info page.
