### PR TITLE
CT-2929 improve feature spec coverage

### DIFF
--- a/spec/features/cases/offender_sar/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar/case_creating_spec.rb
@@ -11,44 +11,80 @@ feature 'Offender SAR Case creation by a manager' do
   end
 
   scenario 'creating a case that does not need clearance', js: true do
+    when_navigate_to_offender_sar_subject_page
+
+    and_fill_in_subject_details_page
+
+    and_fill_in_requester_details_page
+
+    and_fill_in_recipient_details_page
+
+    and_fill_in_requested_info_page
+
+    and_fill_in_request_details_page
+
+    and_fill_in_date_received_page
+
+    then_expect_cases_show_page_to_be_correct
+
+    then_expect_open_cases_page_to_be_correct
+  end
+
+  def when_navigate_to_offender_sar_subject_page
     expect(cases_page).to have_new_case_button
     cases_page.new_case_button.click
     expect(cases_new_page).to be_displayed
 
     cases_new_page.create_link_for_correspondence('OFFENDER').click
     expect(cases_new_offender_sar_subject_details_page).to be_displayed
+  end
 
+  def and_fill_in_subject_details_page
     cases_new_offender_sar_subject_details_page.fill_in_case_details
     click_on "Continue"
     expect(cases_new_offender_sar_requester_details_page).to be_displayed
+  end
 
+  def and_fill_in_requester_details_page
     cases_new_offender_sar_requester_details_page.fill_in_case_details
     click_on "Continue"
     expect(cases_new_offender_sar_recipient_details_page).to be_displayed
+  end
 
+  def and_fill_in_recipient_details_page
     cases_new_offender_sar_recipient_details_page.fill_in_case_details
     click_on "Continue"
     expect(cases_new_offender_sar_requested_info_page).to be_displayed
+  end
 
+  def and_fill_in_requested_info_page
     cases_new_offender_sar_requested_info_page.fill_in_case_details
     click_on "Continue"
     expect(cases_new_offender_sar_request_details_page).to be_displayed
-    
+  end
+
+  def and_fill_in_request_details_page
     cases_new_offender_sar_request_details_page.fill_in_case_details
     click_on "Continue"
     expect(cases_new_offender_sar_date_received_page).to be_displayed
+  end
 
+  def and_fill_in_date_received_page
     cases_new_offender_sar_date_received_page.fill_in_case_details
     click_on "Continue"
+  end
 
+  def then_expect_cases_show_page_to_be_correct
     expect(cases_show_page).to be_displayed
     expect(cases_show_page).to have_content "Case created successfully"
     expect(cases_show_page.page_heading).to have_content "Sabrina Adams"
     click_on "Cases"
+  end
 
+  def then_expect_open_cases_page_to_be_correct
     expect(open_cases_page).to be_displayed
     expect(cases_page).to have_content "Branston Registry"
     expect(open_cases_page).to have_content "Sabrina Adams"
-
   end
 end
+

--- a/spec/features/cases/offender_sar/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar/case_creating_spec.rb
@@ -11,7 +11,7 @@ feature 'Offender SAR Case creation by a manager', js: true do
   end
 
   scenario '1 Third party requests data to be sent to the data subject' do
-    when_navigate_to_offender_sar_subject_page
+    when_i_navigate_to_offender_sar_subject_page
     and_fill_in_subject_details_page
     and_fill_in_requester_details_page
     and_fill_in_recipient_details_page
@@ -23,7 +23,7 @@ feature 'Offender SAR Case creation by a manager', js: true do
   end
 
   scenario '2 Third party requests data for themselves' do
-    when_navigate_to_offender_sar_subject_page
+    when_i_navigate_to_offender_sar_subject_page
     and_fill_in_subject_details_page
     and_fill_in_requester_details_page(:third_party)
     and_fill_in_recipient_details_page(recipient: 'requester_recipient')
@@ -35,7 +35,7 @@ feature 'Offender SAR Case creation by a manager', js: true do
   end
 
   scenario '3 Data subject requesting their own data' do
-    when_navigate_to_offender_sar_subject_page
+    when_i_navigate_to_offender_sar_subject_page
     and_fill_in_subject_details_page
     and_fill_in_requester_details_page(:third_party)
     and_fill_in_recipient_details_page(recipient: 'subject_recipient')
@@ -47,11 +47,10 @@ feature 'Offender SAR Case creation by a manager', js: true do
   end
 
   scenario '4 Data subject requesting data to be sent to third party' do
-    when_navigate_to_offender_sar_subject_page
+    when_i_navigate_to_offender_sar_subject_page
     and_fill_in_subject_details_page
     and_fill_in_requester_details_page
     and_fill_in_recipient_details_page(:third_party)
-    
     and_fill_in_requested_info_page
     and_fill_in_request_details_page
     and_fill_in_date_received_page
@@ -59,7 +58,7 @@ feature 'Offender SAR Case creation by a manager', js: true do
     then_expect_open_cases_page_to_be_correct
   end
 
-  def when_navigate_to_offender_sar_subject_page
+  def when_i_navigate_to_offender_sar_subject_page
     expect(cases_page).to have_new_case_button
     cases_page.new_case_button.click
     expect(cases_new_page).to be_displayed

--- a/spec/features/cases/offender_sar/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar/case_creating_spec.rb
@@ -10,7 +10,7 @@ feature 'Offender SAR Case creation by a manager', js: true do
     cases_page.load
   end
 
-  scenario '1 Third party requests data to be sent to the data subject' do
+  scenario '1 Data subject requesting own record' do
     when_i_navigate_to_offender_sar_subject_page
     and_fill_in_subject_details_page
     and_fill_in_requester_details_page
@@ -22,7 +22,19 @@ feature 'Offender SAR Case creation by a manager', js: true do
     then_expect_open_cases_page_to_be_correct
   end
 
-  scenario '2 Third party requests data for themselves' do
+  scenario '2 Data subject requesting data to be sent to third party' do
+    when_i_navigate_to_offender_sar_subject_page
+    and_fill_in_subject_details_page
+    and_fill_in_requester_details_page
+    and_fill_in_recipient_details_page(:third_party)
+    and_fill_in_requested_info_page
+    and_fill_in_request_details_page
+    and_fill_in_date_received_page
+    then_expect_cases_show_page_to_be_correct
+    then_expect_open_cases_page_to_be_correct
+  end
+
+  scenario '3 Solicitor requesting data subject record' do
     when_i_navigate_to_offender_sar_subject_page
     and_fill_in_subject_details_page
     and_fill_in_requester_details_page(:third_party)
@@ -34,7 +46,7 @@ feature 'Offender SAR Case creation by a manager', js: true do
     then_expect_open_cases_page_to_be_correct
   end
 
-  scenario '3 Data subject requesting their own data' do
+  scenario '4 Solicitor requesting record to be sent to data subject' do
     when_i_navigate_to_offender_sar_subject_page
     and_fill_in_subject_details_page
     and_fill_in_requester_details_page(:third_party)
@@ -46,17 +58,6 @@ feature 'Offender SAR Case creation by a manager', js: true do
     then_expect_open_cases_page_to_be_correct
   end
 
-  scenario '4 Data subject requesting data to be sent to third party' do
-    when_i_navigate_to_offender_sar_subject_page
-    and_fill_in_subject_details_page
-    and_fill_in_requester_details_page
-    and_fill_in_recipient_details_page(:third_party)
-    and_fill_in_requested_info_page
-    and_fill_in_request_details_page
-    and_fill_in_date_received_page
-    then_expect_cases_show_page_to_be_correct
-    then_expect_open_cases_page_to_be_correct
-  end
 
   def when_i_navigate_to_offender_sar_subject_page
     expect(cases_page).to have_new_case_button

--- a/spec/features/cases/offender_sar/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar/case_creating_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Offender SAR Case creation by a manager' do
+feature 'Offender SAR Case creation by a manager', js: true do
   given(:manager)         { find_or_create :branston_user }
   given(:managing_team)   { create :managing_team, managers: [manager] }
 
@@ -10,23 +10,52 @@ feature 'Offender SAR Case creation by a manager' do
     cases_page.load
   end
 
-  scenario 'creating a case that does not need clearance', js: true do
+  scenario '1 Third party requests data to be sent to the data subject' do
     when_navigate_to_offender_sar_subject_page
-
     and_fill_in_subject_details_page
-
     and_fill_in_requester_details_page
-
     and_fill_in_recipient_details_page
-
     and_fill_in_requested_info_page
-
     and_fill_in_request_details_page
-
     and_fill_in_date_received_page
-
     then_expect_cases_show_page_to_be_correct
+    then_expect_open_cases_page_to_be_correct
+  end
 
+  scenario '2 Third party requests data for themselves' do
+    when_navigate_to_offender_sar_subject_page
+    and_fill_in_subject_details_page
+    and_fill_in_requester_details_page(:third_party)
+    and_fill_in_recipient_details_page(recipient: 'requester_recipient')
+    and_fill_in_requested_info_page
+    and_fill_in_request_details_page
+    and_fill_in_date_received_page
+    then_expect_cases_show_page_to_be_correct
+    then_expect_open_cases_page_to_be_correct
+  end
+
+  scenario '3 Data subject requesting their own data' do
+    when_navigate_to_offender_sar_subject_page
+    and_fill_in_subject_details_page
+    and_fill_in_requester_details_page(:third_party)
+    and_fill_in_recipient_details_page(recipient: 'subject_recipient')
+    and_fill_in_requested_info_page
+    and_fill_in_request_details_page
+    and_fill_in_date_received_page
+    then_expect_cases_show_page_to_be_correct
+    then_expect_open_cases_page_to_be_correct
+  end
+
+  scenario '4 Data subject requesting data to be sent to third party' do
+    when_navigate_to_offender_sar_subject_page
+    and_fill_in_subject_details_page
+    and_fill_in_requester_details_page
+    and_fill_in_recipient_details_page(:third_party)
+    
+    and_fill_in_requested_info_page
+    and_fill_in_request_details_page
+    and_fill_in_date_received_page
+    then_expect_cases_show_page_to_be_correct
     then_expect_open_cases_page_to_be_correct
   end
 
@@ -45,14 +74,14 @@ feature 'Offender SAR Case creation by a manager' do
     expect(cases_new_offender_sar_requester_details_page).to be_displayed
   end
 
-  def and_fill_in_requester_details_page
-    cases_new_offender_sar_requester_details_page.fill_in_case_details
+  def and_fill_in_requester_details_page(params = nil)
+    cases_new_offender_sar_requester_details_page.fill_in_case_details(params)
     click_on "Continue"
     expect(cases_new_offender_sar_recipient_details_page).to be_displayed
   end
 
-  def and_fill_in_recipient_details_page
-    cases_new_offender_sar_recipient_details_page.fill_in_case_details
+  def and_fill_in_recipient_details_page(params = nil)
+    cases_new_offender_sar_recipient_details_page.fill_in_case_details(params)
     click_on "Continue"
     expect(cases_new_offender_sar_requested_info_page).to be_displayed
   end

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_recipient_details.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_recipient_details.rb
@@ -20,17 +20,17 @@ module PageObjects
           def fill_in_case_details(params={})
             kase = FactoryBot.build :offender_sar_case, params
 
-            if kase.recipient == 'subject_recipient'
-              choose('offender_sar_recipient_subject_recipient', visible: false)
+            if kase.third_party?
+              choose('offender_sar_recipient_third_party_recipient', visible: false)
+              third_party_relationship.set kase.third_party_relationship
+              third_party_name.set kase.third_party_name
+              third_party_company_name.set kase.third_party_company_name
+              postal_address.set kase.postal_address
             else
-              if kase.third_party?
-                choose('offender_sar_recipient_requester_recipient', visible: false)
-              else
-                choose('offender_sar_recipient_third_party_recipient', visible: false)
-                third_party_relationship.set kase.third_party_relationship
-                third_party_name.set kase.third_party_name
-                third_party_company_name.set kase.third_party_company_name
-                postal_address.set kase.postal_address
+              if kase.recipient == 'subject_recipient'
+                choose('offender_sar_recipient_subject_recipient', visible: false)
+              elsif kase.recipient == 'requester_recipient'
+                  choose('offender_sar_recipient_requester_recipient', visible: false)
               end
             end
           end

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_requester_details.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_requester_details.rb
@@ -23,7 +23,6 @@ module PageObjects
 
             if kase.third_party?
               choose('offender_sar_third_party_true', visible: false)
-              requester_full_name.set kase.name
               third_party_relationship.set kase.third_party_relationship
               third_party_name.set kase.third_party_name
               third_party_company_name.set kase.third_party_company_name

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
@@ -22,6 +22,8 @@ module PageObjects
 
           element :other_subject_ids, '#offender_sar_other_subject_ids'
 
+          element :case_reference_number, '#offender_sar_case_reference_number'
+
           element :date_of_birth_dd, '#offender_sar_date_of_birth_dd'
 
           element :date_of_birth_mm, '#offender_sar_date_of_birth_mm'
@@ -41,6 +43,8 @@ module PageObjects
             subject_aliases.set kase.subject_aliases
             previous_case_numbers.set kase.previous_case_numbers
             set_date_of_birth kase.date_of_birth
+            other_subject_ids.set kase.other_subject_ids
+            case_reference_number.set kase.case_reference_number
 
             choose('offender_sar_subject_type_offender', visible: false)
             choose('offender_sar_flag_as_high_profile_false', visible: false)


### PR DESCRIPTION
## Description
Refactors and adds to the Offender SAR case `case_creation_spec.rb` to reflect the four "happy path" journeys for creating Offender SARs. These are:

<img width="1033" alt="Screenshot 2020-07-20 at 11 03 54" src="https://user-images.githubusercontent.com/13377553/87925944-ebd96280-ca78-11ea-877f-41163baaeca1.png">


## Notes for reviewer
- I haven't changed any off the expectations for the case summary page at the end of the journey. I am wondering if this should be covered by  `rspec/views/cases/offender_sar/_case_details_html_slim_spec.rb` would be good to get your opinion on this.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
- N/A tests only

### Related JIRA tickets
[CT-2929](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-2929)

### Deployment
- N/A

### Manual testing instructions
- go through each scenario as above
- alternatively add some `sleep(5)` into the methods in the spec and run the following command to use Chrome to inspect the specs visually as the run:

`CHROME_DEBUG=1 bundle exec rspec spec/features/cases/offender_sar/case_creating_spec.rb`
