### PR TITLE
CT-2938 Updated Dispatch letters

### DIFF
--- a/db/seeders/letter_template_seeder.rb
+++ b/db/seeders/letter_template_seeder.rb
@@ -259,7 +259,7 @@ class LetterTemplateSeeder
       rec = LetterTemplate.find_by(abbreviation: 'solicitor-disclosed-covid')
       rec = LetterTemplate.new if rec.nil?
       rec.update!(name: 'Solicitor disclosed letter (COVID-19)',
-                  abbreviation: 'Solicitor-disclosed-covid',
+                  abbreviation: 'solicitor-disclosed-covid',
                   template_type: 'dispatch',
                   body: <<~EOF
                     <p>Dear Sirs

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -20,7 +20,7 @@ namespace :db do
     end
 
     desc 'seeds live team and user data'
-    task :prod => [ 'db:seed:clear', 'db:seed:prod:misc', 'db:seed:prod:teams', 'db:seed:prod:users' ] do
+    task :prod => [ 'db:seed:clear', 'db:seed:prod:misc', 'db:seed:prod:teams', 'db:seed:prod:users', 'db:seed:prod:letter_templates' ] do
     end
 
     namespace :prod do
@@ -33,9 +33,6 @@ namespace :db do
         require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
         puts 'Seeding Case closure metadata'
         CaseClosure::MetadataSeeder.seed!
-        require File.join(Rails.root, 'db', 'seeders', 'letter_template_seeder')
-        puts 'Seeding Letter Templates'
-        LetterTemplateSeeder.new.seed!
       end
 
       desc 'Seed teams for production environment'
@@ -55,6 +52,12 @@ namespace :db do
       task :group_emails => :environment do
         require File.join(Rails.root, 'db', 'seeders', 'group_email_seeder')
         GroupEmailSeeder.new.seed!
+      end
+
+      desc 'Seed letter templates for production environment'
+      task letter_templates: :environment do
+        require File.join(Rails.root, 'db', 'seeders', 'letter_template_seeder')
+        LetterTemplateSeeder.new.seed!
       end
     end
 


### PR DESCRIPTION
This task was failing due to an erroneous capital letter in the
`LetterTemplateSeeder.rb` for a template abbreviation.

Also updates the prod rake tasks so that `:letter_templates` can be run independently rather than bundled with other tasks under the `:misc` task as is the case currently.

## Description
Updates script so it can be run on demo to update the data there.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Related JIRA tickets
[CT-2938](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-2938)

### Manual testing instructions
- run `rake db:seed:dev:letter_templates` locally and see if the templates are correct in your local copy.
