### PR TITLE
CT-2899 & CT-2875 Display "Send dispatch letter" button after case is closed

### DIFF
--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -46,7 +46,6 @@
                 send_dispatch_letter:
                 edit_case:
               closed:
-                add_data_received:
                 add_note_to_case:
                 send_dispatch_letter:
                 edit_case:

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -48,5 +48,6 @@
               closed:
                 add_data_received:
                 add_note_to_case:
+                send_dispatch_letter:
                 edit_case:
 

--- a/spec/features/cases/offender_sar/case_progressing_spec.rb
+++ b/spec/features/cases/offender_sar/case_progressing_spec.rb
@@ -16,15 +16,17 @@ feature 'Offender SAR Case creation by a manager' do
     CaseClosure::MetadataSeeder.unseed!
   end
 
-  scenario 'creating a case that does not need clearance' do
+  scenario 'progressing an offender sar case' do
     cases_show_page.load(id: offender_sar_case.id)
 
     expect(cases_show_page).to have_content "Mark as waiting for data"
     expect(cases_show_page).to have_content "Data to be requested"
+    expect(cases_show_page).to have_content "Send acknowledgement letter"
     click_on "Mark as waiting for data"
 
     expect(cases_show_page).to be_displayed
     expect(cases_show_page).to have_content "Mark as ready for vetting"
+    expect(cases_show_page).to have_content "Send acknowledgement letter"
     click_on "Mark as ready for vetting"
 
     expect(cases_show_page).to be_displayed
@@ -40,6 +42,7 @@ feature 'Offender SAR Case creation by a manager' do
     click_on "Mark as ready to dispatch"
 
     expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content "Send dispatch letter"
     expect(cases_show_page).to have_content "Close case"
     click_on "Close case"
 
@@ -54,6 +57,7 @@ feature 'Offender SAR Case creation by a manager' do
 
     expect(cases_show_page).to be_displayed
     expect(cases_show_page).to have_content "Closed"
+    expect(cases_show_page).to have_content "Send dispatch letter"
     # TODO - pending decision on closure outcomes https://dsdmoj.atlassian.net/browse/CT-2502
     # expect(cases_show_page).to have_content "Was the information held?"
     # expect(cases_show_page).to have_content "Yes"


### PR DESCRIPTION

## Description
Currently the "Send dispatch letter" is only available in "Ready to dispatch" state

For flexibility, to support different workflows, we need to allow users to send letters on Closed cases too

This PR adds the relevant option to the Closed state in the state machine workflow.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/88198536-b5981080-cc3b-11ea-98ef-4d271c280fd5.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2899

### Deployment
none

### Manual testing instructions
As Branston responder, take a case through to "Ready to dispatch" state
Verify the "Send dispatch letter" button is available
Move the case through to "Closed", entering the date and following the steps until you return to the case details page
Verify that the "Send dispatch letter" button is still available even now the case is closed
NOTE - You'll need to restart your local development server to see this; the State Machine configs are loaded on server startup and changes during runtime aren't picked up.
