### PR TITLE
Ct 2954 Circle CI Performance (part 2) reduce resource size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2
 references:
   defaults: &defaults
     working_directory: ~/track-a-query
-    resource_class: small
 
 # Sets up the docker images and environment variables that we use
   test_container_config: &test_container_config
@@ -26,6 +25,7 @@ references:
           POSTGRES_DB: correspondence_platform_test
 
   deploy_container_config: &deploy_container_config
+    resource_class: small
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2
 references:
   defaults: &defaults
     working_directory: ~/track-a-query
+    resource_class: small
 
 # Sets up the docker images and environment variables that we use
   test_container_config: &test_container_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2
 references:
   defaults: &defaults
     working_directory: ~/track-a-query
+    resource_class: small
 
 # Sets up the docker images and environment variables that we use
   test_container_config: &test_container_config
@@ -25,7 +26,6 @@ references:
           POSTGRES_DB: correspondence_platform_test
 
   deploy_container_config: &deploy_container_config
-    resource_class: small
     docker:
       - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
 


### PR DESCRIPTION
## Description
We can be less greedy on resources. (default is medium, as of now it should be small that we use) - saves Circle CI Credits. See Slack thread https://mojdt.slack.com/archives/CC3A275NU/p1595427526045600

Results: We lost about 6 minutes on Build/Test and 5 minutes on Build image. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before: 
![image](https://user-images.githubusercontent.com/22935203/88684508-def9e600-d0ec-11ea-8c5c-5f93c61ac4c5.png)

![image](https://user-images.githubusercontent.com/22935203/88661624-b663f300-d0d0-11ea-9726-034dc4769d23.png)

After:
![image](https://user-images.githubusercontent.com/22935203/88684572-ede09880-d0ec-11ea-995e-2c64016cfd7e.png)

![image](https://user-images.githubusercontent.com/22935203/88661651-c5e33c00-d0d0-11ea-9e6d-cca2684da327.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2954

### Deployment
Do via Circle CI

### Manual testing instructions
Compare the build performance between master / other PRs and and this PR. Should be more or less similar. 
