### PR TITLE
Ct 2989 kilo users cases view

### DIFF
--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -83,10 +83,16 @@ class CaseFinderService
   end
 
   def open_cases_scope
-    scope.presented_as_open
-    .joins(:assignments)
-    .where(assignments: { state: ['pending', 'accepted']})
-    .distinct('case.id')
+    open_scope = scope.presented_as_open
+      .joins(:assignments)
+      .where(assignments: { state: ['pending', 'accepted']})
+      .distinct('case.id')
+    if user.responder_only?
+      case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
+      open_scope.where(id: case_ids)
+    else
+      open_scope
+    end
   end
 
   def open_flagged_for_approval_scope

--- a/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
+++ b/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
@@ -43,6 +43,16 @@ feature 'respond to responder assignment' do
     expect(cases_show_page.notice.text).to eq "#{assigned_case.number} has been rejected."
 
     expect(assigned_case.reload.current_state).to eq 'unassigned'
+  end
+
+  scenario 'when kilo rejects assignment, they should not see the rejected case in the "All open cases" tab' do
+    assignments_edit_page.load(case_id: assigned_case.id, id: assignment.id)
+
+    choose 'Reject'
+    expect(page).
+      to have_selector('#assignment_reasons_for_rejection', visible: true)
+    fill_in 'Why are you rejecting this case?', with: 'This is not for me'
+    click_button 'Confirm'
 
     click_on 'Cases'
     expect(page).to_not have_content(assigned_case.number.to_s)

--- a/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
+++ b/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
@@ -43,6 +43,9 @@ feature 'respond to responder assignment' do
     expect(cases_show_page.notice.text).to eq "#{assigned_case.number} has been rejected."
 
     expect(assigned_case.reload.current_state).to eq 'unassigned'
+
+    click_on 'Cases'
+    expect(page).to_not have_content(assigned_case.number.to_s)
   end
 
   scenario 'kilo rejects assignment but provides no reasons for rejection' do


### PR DESCRIPTION
## Description

When Kilo users were assigned cases and then rejected them they were still appearing in their "All open cases" tab when shouldn't have. This was due to a some conditions inside the `open_cases_scope` in the `CaseFinderService` being removed in an earlier PR.

PR adds a test that should fail if this were to happen again 👍 

### Notes for reviewer:
- Was it intentional that this scope was removed? If so why?
- Original PR [here](https://github.com/ministryofjustice/correspondence_tool_staff/commit/a7fac81b0db3c3fc3bc9fd746e90deed613196f1#diff-5be043e2afbbc7e3511081c5e5b7ae86L91)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Related JIRA tickets
- [Ticket CT-2989 here](https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-2989)

### Screenshots

I have created two cases and assigned them to and LAA responder - they see this when they log in:
<img width="783" alt="Screenshot 2020-08-05 at 13 44 36" src="https://user-images.githubusercontent.com/13377553/89414174-e3905100-d721-11ea-8ec5-c48e07330d59.png">

I reject the first case - go back to the cases page you should see this:
<img width="791" alt="Screenshot 2020-08-05 at 13 39 58" src="https://user-images.githubusercontent.com/13377553/89413714-33224d00-d721-11ea-8973-e692eaf2c1b2.png">

Rather than this:
<img width="787" alt="Screenshot 2020-08-05 at 13 46 55" src="https://user-images.githubusercontent.com/13377553/89414361-2b16dd00-d722-11ea-8c04-d7833cadf7d2.png">

### Manual testing instructions
1. Create a case as a dispatcher, say FOI
2. Assign to a business unit, say LAA
3. Log in as that BU's respoder
4. Click on the recently created case
5. Reject it
6. Click back to the 'Cases' view
7. The rejected case should no longer be visible for that user.
