### PR TITLE
CT-2974 Add ex-probation user to subject type

### DIFF
--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -56,6 +56,7 @@ class Case::SAR::Offender < Case::Base
     detainee: 'detainee',
     ex_detainee: 'ex_detainee',
     probation_service_user: 'probation_service_user',
+    ex_probation_service_user: "ex_probation_service_user"
   }
 
   enum recipient: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -487,6 +487,7 @@ en:
           ex_offender: Ex-offender
           offender: Offender
           probation_service_user: "Probation service user"
+          ex_probation_service_user: "Ex-probation service user"
         recipient:
           subject_recipient: The data subject
           requester_recipient: The person making the request

--- a/spec/models/case/sar/offender_spec.rb
+++ b/spec/models/case/sar/offender_spec.rb
@@ -59,6 +59,7 @@ describe Case::SAR::Offender do
         expect(build(:offender_sar_case, subject_type: 'ex_offender')).to be_valid
         expect(build(:offender_sar_case, subject_type: 'offender')).to be_valid
         expect(build(:offender_sar_case, subject_type: 'probation_service_user')).to be_valid
+        expect(build(:offender_sar_case, subject_type: 'ex_probation_service_user')).to be_valid
       end
     end
 
@@ -84,10 +85,10 @@ describe Case::SAR::Offender do
       it 'does not error' do
         expect(build(:offender_sar_case, recipient: 'subject_recipient')).to be_valid
         expect(build(:offender_sar_case, recipient: 'requester_recipient')).to be_valid
-        expect(build(:offender_sar_case, 
-                    recipient: 'third_party_recipient', 
-                    third_party: false, 
-                    third_party_name: 'test', 
+        expect(build(:offender_sar_case,
+                    recipient: 'third_party_recipient',
+                    third_party: false,
+                    third_party_name: 'test',
                     third_party_relationship: 'test'
                     )).to be_valid
       end
@@ -189,7 +190,7 @@ describe Case::SAR::Offender do
       end
     end
   end
-  
+
   describe '#request_dated' do
     context 'invalid value' do
       it 'errors' do
@@ -218,7 +219,7 @@ describe Case::SAR::Offender do
       end
 
       it 'validates third party names when recipient is third party' do
-        kase = build :offender_sar_case, third_party: false, third_party_name: '', 
+        kase = build :offender_sar_case, third_party: false, third_party_name: '',
                       third_party_company_name: '', recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
         expect(kase.errors[:third_party_name]).to eq ["can't be blank if company name not given"]
@@ -226,7 +227,7 @@ describe Case::SAR::Offender do
       end
 
       it 'does not validate third_party names when ecipient is not third party too' do
-        kase = build :offender_sar_case, third_party: false, third_party_name: '', 
+        kase = build :offender_sar_case, third_party: false, third_party_name: '',
                       third_party_company_name: '', recipient: 'subject_recipient'
         expect(kase).to be_valid
       end
@@ -241,14 +242,14 @@ describe Case::SAR::Offender do
       end
 
       it 'must be present when third party is false but recipient is third party' do
-        kase = build :offender_sar_case, third_party: false, third_party_relationship: '', 
+        kase = build :offender_sar_case, third_party: false, third_party_relationship: '',
                       recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
         expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
       end
 
       it 'does not validates presence of third party relationship when recipient is not third party' do
-        kase = build :offender_sar_case, third_party: false, third_party_relationship: '', 
+        kase = build :offender_sar_case, third_party: false, third_party_relationship: '',
                       recipient: 'subject_recipient'
         expect(kase).to be_valid
       end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
CT-2974 Add "ex-probation user" subject type

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots

![CT-2974 add ex-probation user to subject type](https://user-images.githubusercontent.com/6988369/89545605-7bae3900-d7fb-11ea-8ebb-2f416324e05d.png)

### Related JIRA tickets

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-2974

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions

On the "Who is the subject?" page of the case creation journey you should see "Ex-probation service user" as a "Subject type" option.
