### PR TITLE
CT-2989 kilo users cases view

### DIFF
--- a/app/policies/case/foi/standard_policy.rb
+++ b/app/policies/case/foi/standard_policy.rb
@@ -13,6 +13,7 @@ class Case::FOI::StandardPolicy < Case::BasePolicy
           team_restriction = Assignment
               .joins('join teams_users_roles on assignments.team_id=teams_users_roles.team_id')
               .where('teams_users_roles': {user_id: @user.id, role: :responder.to_s})
+              .where.not(state: [ :rejected ] )
               .select(:case_id).distinct       
           @scope.where(id: team_restriction)
         else

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -83,10 +83,16 @@ class CaseFinderService
   end
 
   def open_cases_scope
-    scope.presented_as_open
-    .joins(:assignments)
-    .where(assignments: { state: ['pending', 'accepted']})
-    .distinct('case.id')
+    open_scope = scope.presented_as_open
+      .joins(:assignments)
+      .where(assignments: { state: ['pending', 'accepted']})
+      .distinct('case.id')
+    if user.responder_only?
+      case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
+      open_scope.where(id: case_ids)
+    else
+      open_scope
+    end
   end
 
   def open_flagged_for_approval_scope

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -83,16 +83,10 @@ class CaseFinderService
   end
 
   def open_cases_scope
-    open_scope = scope.presented_as_open
-      .joins(:assignments)
-      .where(assignments: { state: ['pending', 'accepted']})
-      .distinct('case.id')
-    if user.responder_only?
-      case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
-      open_scope.where(id: case_ids)
-    else
-      open_scope
-    end
+    scope.presented_as_open
+    .joins(:assignments)
+    .where(assignments: { state: ['pending', 'accepted']})
+    .distinct('case.id')
   end
 
   def open_flagged_for_approval_scope

--- a/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
+++ b/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
@@ -43,6 +43,16 @@ feature 'respond to responder assignment' do
     expect(cases_show_page.notice.text).to eq "#{assigned_case.number} has been rejected."
 
     expect(assigned_case.reload.current_state).to eq 'unassigned'
+  end
+
+  scenario 'when kilo rejects assignment, they should not see the rejected case in the "All open cases" tab' do
+    assignments_edit_page.load(case_id: assigned_case.id, id: assignment.id)
+
+    choose 'Reject'
+    expect(page).
+      to have_selector('#assignment_reasons_for_rejection', visible: true)
+    fill_in 'Why are you rejecting this case?', with: 'This is not for me'
+    click_button 'Confirm'
 
     click_on 'Cases'
     expect(page).to_not have_content(assigned_case.number.to_s)

--- a/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
+++ b/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
@@ -43,6 +43,9 @@ feature 'respond to responder assignment' do
     expect(cases_show_page.notice.text).to eq "#{assigned_case.number} has been rejected."
 
     expect(assigned_case.reload.current_state).to eq 'unassigned'
+
+    click_on 'Cases'
+    expect(page).to_not have_content(assigned_case.number.to_s)
   end
 
   scenario 'kilo rejects assignment but provides no reasons for rejection' do

--- a/spec/policies/base_policy_scope_spec.rb
+++ b/spec/policies/base_policy_scope_spec.rb
@@ -51,7 +51,8 @@ describe Case::BasePolicy::Scope do
                                                         @unassigned_case, 
                                                         @drafting_sar_case_other_team,
                                                         @accepted_case_r2, 
-                                                        @ico_foi_case, 
+                                                        @ico_foi_case,
+                                                        @rejected_case, 
                                                         @ico_sar_case]
 
       @responder.reload


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->

The issue was because when the restriction of responder role was moved from service level into policy level,  the way of construction sub_query was different from the original one due to the bad performance of old way, 
old way

-----
  case_ids = Assignment.with_teams(user.responding_teams).pluck(:case_id)
  open_scope.where(id: case_ids)


new way 
--------
          team_restriction = Assignment
              .joins('join teams_users_roles on assignments.team_id=teams_users_roles.team_id')
              .where('teams_users_roles': {user_id: @user.id, role: :responder.to_s})
              .select(:case_id).distinct       
          @scope.where(id: team_restriction)
there were some extra conditions from "with_teams" from old way,  which were related to the state of assignments,  the "rejected" has been excluded in the allowed state.  The new way didn't take such state condition into account, this fix is to add this state condition back

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [X] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

I have created two cases and assigned them to and LAA responder - they see this when they log in:
<img width="783" alt="Screenshot 2020-08-05 at 13 44 36" src="https://user-images.githubusercontent.com/13377553/89414174-e3905100-d721-11ea-8ec5-c48e07330d59.png">

I reject the first case - go back to the cases page you should see this:
<img width="791" alt="Screenshot 2020-08-05 at 13 39 58" src="https://user-images.githubusercontent.com/13377553/89413714-33224d00-d721-11ea-8973-e692eaf2c1b2.png">

Rather than this:
<img width="787" alt="Screenshot 2020-08-05 at 13 46 55" src="https://user-images.githubusercontent.com/13377553/89414361-2b16dd00-d722-11ea-8c04-d7833cadf7d2.png">

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
1. Create a case as a dispatcher, say FOI
2. Assign to a business unit, say LAA
3. Log in as that BU's respoder
4. Click on the recently created case
5. Reject it
6. Click back to the 'Cases' view
7. The rejected case should no longer be visible for that user.
