### PR TITLE
CT-2938 change dpa from 1998 to 2018

### DIFF
--- a/db/seeders/letter_template_seeder.rb
+++ b/db/seeders/letter_template_seeder.rb
@@ -253,7 +253,7 @@ class LetterTemplateSeeder
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
                   <br><strong><%= values.subject_full_name&.upcase %> - <%= values.prison_number&.upcase %><% if (values.prison_number.gsub(/[,]/, ' ').squeeze(' ').strip).match?(/[ ]/) %> [DELETE AS APPROPRIATE]<% end %></strong>
                   <br>
-                  <br>I am writing in response to your request for information made under the Data Protection Act 1998 (DPA) for the above person.
+                  <br>I am writing in response to your request for information made under the Data Protection Act 2018 (DPA) for the above person.
                   <br>
                   <br>Enclosed is all the information related to your request that I am able to release. Some information may have been withheld and this is because the information is exempt from disclosure under the DPA. The exemptions within the DPA include information which is processed for the prevention or detection of crime or the apprehension or prosecution of offenders, and information that would identify third parties. Where we have withheld exempt information, you will see items redacted on the documents.
                   <br>

--- a/db/seeders/letter_template_seeder.rb
+++ b/db/seeders/letter_template_seeder.rb
@@ -259,7 +259,7 @@ class LetterTemplateSeeder
                   <br>
                   <br>I can confirm that the personal data contained within these documents is being processed by the MoJ for the purposes of the administration of justice and for the exercise of any functions of the Crown, a Minister of the Crown or a government department. As such we may share or exchange data with other Departments or organisations if it is lawful to do so, for example the Police or the Probation Service.
                   <br>
-                  <br>If you have any queries regarding your request please contact the Data Protection Compliance Team (DPCT), at the address above. It is also open to you to ask the Information Commissioner to look into the case. You can contact the Information Commissioner at this address:
+                  <br>If you have any queries regarding your request please contact the Offender Subject Access Request Team, at the address above. It is also open to you to ask the Information Commissioner to look into the case. You can contact the Information Commissioner at this address:
                   <br>
                   <br>Information Commissioner's Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF
                   <br>Internet: ico.org.uk


### PR DESCRIPTION
## Description
Two very minor changes to the Solicitor dispatch letter:

- changes the reference to the **_"Data Protection Act 1998"_** to **_"Data Protection Act 2018"_** in first paragraph.
- changes **_"please contact the Data Protection Compliance Team (DPCT)"_** to **_"please contact the Offender Subject Access Request Team"_** in fourth paragraph.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
**Before:**
<img width="653" alt="Screenshot 2020-08-12 at 17 28 15" src="https://user-images.githubusercontent.com/13377553/90041778-ac8de280-dcc1-11ea-868d-00d2bb524da1.png">

**After:**
<img width="653" alt="Screenshot 2020-08-12 at 17 28 15" src="https://user-images.githubusercontent.com/13377553/90042005-0098c700-dcc2-11ea-9f64-09ebb5e497ae.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2938

### Deployment
Once deployed run:
 `TRUNCATE TABLE letter_templates RESTART IDENTITY;`
And then reseed with:
`rake db:seed:dev:letter_templates`

### Manual testing instructions
1. log in as Branston user
2. Progress a case so that that "Send dispatch letter" button is available, then click it.
3. Select "Solicitor disclose letter" from the list, click continue.
4. Check that the copy is correct as per the above in the first and fourth paragraphs.
 
