### PR TITLE
CT-3008 dividing lines and conditional business unit show

### DIFF
--- a/app/views/cases/_case_status.html.slim
+++ b/app/views/cases/_case_status.html.slim
@@ -9,7 +9,7 @@
       .case-status__data--large
         = case_details.status
 
-    - if case_details.current_state != 'closed'
+    - if case_details.current_state != 'closed' &&  !case_details.offender_sar?
       .case-status__group.who_its_with
         .case-status__heading
           = t('common.case.who_its_with')

--- a/app/views/cases/shared/_case_deadlines.html.slim
+++ b/app/views/cases/shared/_case_deadlines.html.slim
@@ -8,7 +8,9 @@
   tr.section.case-external-deadline.section-external-deadline
     th = t('common.case.external_deadline')
     td = case_details.external_deadline
-    / note this link is to edit the date responded date after a case is closed 
+    / note this link is to edit the date responded date after a case is closed
     / placed here due to where it needs to sit on page
     - if case_details.closed? && case_details.offender_sar?
       td = link_to t('common.links.change'), edit_step_case_sar_offender_path(case_details, "date_responded")
+    - else
+      td = ' '

--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -9,7 +9,7 @@ tbody.response-details
       th = t('common.case.timeliness')
       td = case_details.timeliness
 
-    - if case_details.responded_late?
+    - if case_details.responded_late? &&  !case_details.offender_sar?
       tr.late-team
         th = t('common.case.late_team')
         td = case_details.late_team_name

--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -17,6 +17,7 @@ tbody.response-details
     tr.time-taken
       th = t('common.case.time_taken')
       td = case_details.time_taken
+      td = ' '
 
   - if case_details.info_held_status.present?
     tr.info-held

--- a/app/views/cases/shared/_responding_team.html.slim
+++ b/app/views/cases/shared/_responding_team.html.slim
@@ -1,8 +1,9 @@
 tbody.responder-details
-  tr.team
-    th = t('common.case.responding_team')
-    td = case_details.responding_team.name
-    td = ' '
+  - if !case_details.offender_sar?
+    tr.team
+      th = t('common.case.responding_team')
+      td = case_details.responding_team.name
+      td = ' '
 
   - if case_details.responder.present?
     tr.responder-name

--- a/spec/site_prism/page_objects/sections/cases/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/case_details_section.rb
@@ -113,7 +113,7 @@ module PageObjects
           end
 
           section :time_taken, '.time-taken' do
-            element :data, 'td'
+            element :data, 'td:nth-child(2)'
           end
 
           section :info_held, '.info-held' do

--- a/spec/site_prism/page_objects/sections/cases/ico/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/ico/case_details_section.rb
@@ -71,7 +71,7 @@ module PageObjects
             end
 
             section :time_taken, '.time-taken' do
-              element :data, 'td'
+              element :data, 'td:nth-child(2)'
             end
 
             section :info_held, '.info-held' do

--- a/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
@@ -126,7 +126,7 @@ module PageObjects
           end
 
           section :time_taken, '.time-taken' do
-            element :data, 'td'
+            element :data, 'td:nth-child(2)'
           end
 
           section :info_held, '.info-held' do

--- a/spec/site_prism/page_objects/sections/cases/overturned_foi/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/overturned_foi/case_details_section.rb
@@ -24,7 +24,7 @@ module PageObjects
 
           element :date_responded, '.date-responded td'
           element :timeliness, '.timeliness td'
-          element :time_taken, '.time-taken td'
+          element :time_taken, '.time-taken td:nth-child(2)'
 
           section :compliance_details, '.compliance-details' do
             section :compliance_date, '.compliance-date' do

--- a/spec/site_prism/page_objects/sections/cases/overturned_sar/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/overturned_sar/case_details_section.rb
@@ -21,7 +21,7 @@ module PageObjects
 
           element :date_responded, '.date-responded td'
           element :timeliness, '.timeliness td'
-          element :time_taken, '.time-taken td'
+          element :time_taken, '.time-taken td:nth-child(2)'
 
           element :edit_case, :xpath, '//a[contains(.,"Edit case details")]'
           element :edit_case_link, :xpath, '//a[contains(.,"Edit case details")]'


### PR DESCRIPTION
## Description
Fix dividing lines and remove Business Unit for Offender SAR Case in three places on case details and in status header (not everywhere)

**NOTE:** - Failing tests should be fixed once CT-2963 is merged and this is rebased.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before Open offender SAR case status: (business unit showing)
![image](https://user-images.githubusercontent.com/22935203/90516539-0b3cdb80-e15c-11ea-9cab-66c1c553a9bf.png)


After Offender SAR case status:
![image](https://user-images.githubusercontent.com/22935203/90516113-75a14c00-e15b-11ea-812f-d747e4c6e993.png)

But still, Non-offender SAR open case status:
![image](https://user-images.githubusercontent.com/22935203/90516852-80a8ac00-e15c-11ea-820f-65e4238d52f3.png)


Before - Offender SAR closed case details part: (Broken line and BU in closed area)
![image](https://user-images.githubusercontent.com/22935203/90516692-44754b80-e15c-11ea-9e5e-c4d68805eafd.png)

After - Offender SAR closed case details part:
![image](https://user-images.githubusercontent.com/22935203/90516792-68389180-e15c-11ea-93be-a4ef7b906843.png)

Before - Offender SAR open case details part (broken line & BU)
![image](https://user-images.githubusercontent.com/22935203/90516571-1a238e00-e15c-11ea-9a89-568bfe7849b6.png)

After - Offender SAR open case details part 
![image](https://user-images.githubusercontent.com/22935203/90516464-eea0a380-e15b-11ea-93c1-4fec69979c4b.png)

But still non-offender SAR open case details part (BU)
![image](https://user-images.githubusercontent.com/22935203/90516940-a03fd480-e15c-11ea-82bc-67068988e9d4.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3008

### Deployment
n/a

### Manual testing instructions
Login in as David Attenborough - and click into any open case. You should see Business unit at the top, and in the case details. Go into any closed case that closed late - you should see the business unit responsible if it was late.

Login as Brian Rix - and click into any open case - business unit shouldn't show. Case details dividing lines should look uniform.
And on the closed case, there shouldn't be a mention of responsible team if it's late.
