### PR TITLE
CT-2971 Measure case length in calendar days

### DIFF
--- a/app/decorators/case/sar/offender_decorator.rb
+++ b/app/decorators/case/sar/offender_decorator.rb
@@ -16,6 +16,11 @@ class Case::SAR::OffenderDecorator < Case::BaseDecorator
     "#{step_name}_step"
   end
 
+  def time_taken
+    days = (date_responded - received_date).to_i
+    I18n.t('common.case.offender_sar.time_taken_result', count: days)
+  end
+
   def back_link(mode, previous_step)
     url = if mode == :edit
             h.case_path(id)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -613,6 +613,8 @@ en:
       ico_officer_name: ICO information officer handling this case
       late_team: Business unit responsible for late response
       name: Requester
+      offender_sar:
+        time_taken_result: "%{count} days"
       original-case-details: Original case details
       other_subject_ids: "Police national computer number"
       outcome: Outcome

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -614,7 +614,9 @@ en:
       late_team: Business unit responsible for late response
       name: Requester
       offender_sar:
-        time_taken_result: "%{count} days"
+        time_taken_result:
+          one: "%{count} day"
+          other: "%{count} days"
       original-case-details: Original case details
       other_subject_ids: "Police national computer number"
       outcome: Outcome

--- a/spec/decorators/case/offender_sar_decorator_spec.rb
+++ b/spec/decorators/case/offender_sar_decorator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe Case::SAR::OffenderDecorator do
-  let(:offender_sar_case) {create(:offender_sar_case).decorate }
+  let(:offender_sar_case) {build_stubbed(:offender_sar_case, date_responded: Date.new(2020,1,10), received_date: Date.new(2020,1,1)).decorate}
 
   it 'instantiates the correct decorator' do
     expect(Case::SAR::Offender.new.decorate).to be_instance_of Case::SAR::OffenderDecorator
@@ -38,6 +38,12 @@ describe Case::SAR::OffenderDecorator do
       expect(offender_sar_case.get_step_partial).to eq "request_details_step"
       offender_sar_case.next_step
       expect(offender_sar_case.get_step_partial).to eq "date_received_step"
+    end
+  end
+
+  describe "#time_taken" do
+    it "returns total number of days between date received and date responded" do
+      expect(offender_sar_case.time_taken).to eq "9 days"
     end
   end
 

--- a/spec/features/cases/offender_sar/case_closing_spec.rb
+++ b/spec/features/cases/offender_sar/case_closing_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
 
 feature 'Closing a case' do
-  
+
   given(:responder)         { find_or_create :branston_user }
   given(:responder_team)   { responder.responding_teams.first }
 
@@ -14,16 +14,16 @@ feature 'Closing a case' do
   context 'Reporting timiliness' do
     Timecop.freeze(Time.local(2017, 11, 23, 13, 13, 56)) do
       context 'responded-to in time' do
-        given!(:fully_granted_case) { 
-          create :offender_sar_case, 
-          :ready_to_dispatch, 
-          received_date: 5.business_days.ago }
+        given!(:fully_granted_case) {
+          create :offender_sar_case,
+          :ready_to_dispatch,
+          received_date: 5.days.ago }
 
         scenario 'Offender sar team has responded and a responder closes the case', js:true do
           open_cases_page.load
           close_case(fully_granted_case)
 
-          cases_close_page.fill_in_date_responded(0.business_days.ago)
+          cases_close_page.fill_in_date_responded(0.days.ago)
           cases_close_page.click_on 'Continue'
 
           expect(cases_closure_outcomes_page).to be_displayed
@@ -34,25 +34,25 @@ feature 'Closing a case' do
           show_page = cases_show_page.case_details
 
           expect(show_page.response_details.date_responded.data.text)
-          .to eq 0.business_days.ago.strftime(Settings.default_date_format)
+          .to eq 0.days.ago.strftime(Settings.default_date_format)
           expect(show_page.response_details.timeliness.data.text)
           .to eq 'Answered in time'
           expect(show_page.response_details.time_taken.data.text)
-          .to eq '6 working days'
+          .to eq '5 days'
         end
       end
 
       context 'responded-to late' do
-        given!(:fully_granted_case) { 
+        given!(:fully_granted_case) {
           create :offender_sar_case,
-          :ready_to_dispatch, 
-          received_date: 35.business_days.ago }
+          :ready_to_dispatch,
+          received_date: 35.days.ago }
 
         scenario 'the case is responded-to late', js: true do
           open_cases_page.load(timeliness: 'late')
           close_case(fully_granted_case)
 
-          cases_close_page.fill_in_date_responded(0.business_days.ago)
+          cases_close_page.fill_in_date_responded(0.days.ago)
           cases_close_page.click_on 'Continue'
 
           expect(cases_closure_outcomes_page).to be_displayed
@@ -63,7 +63,7 @@ feature 'Closing a case' do
           expect(show_page.response_details.timeliness.data.text)
             .to eq 'Answered late'
           expect(show_page.response_details.time_taken.data.text)
-            .to eq '36 working days'
+            .to eq '35 days'
         end
       end
     end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->

CT-2971 Measure case length in calendar days
The “time taken” field appears on the case page when a case has been closed - currently counting in working days, but should be calendar days as SARs are not counted in working days

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
Before:

![Before](https://user-images.githubusercontent.com/6988369/90892653-8c42df80-e3b5-11ea-95a8-24b6e8169b40.png)

After

![After](https://user-images.githubusercontent.com/6988369/90892669-94028400-e3b5-11ea-9592-f7bf0b8c1471.png)

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-2971

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
go to the case details page of any closed Offender SAR case and click on "Chage" opposite "Final Deadline". Change this 'Date response sent' to X number of days after the "Date request received at MOJ" date.  The "Time taken" should display the X number of days.