### PR TITLE
CT-3013 Move data requests button

### DIFF
--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -123,11 +123,10 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
               id: 'action--remove-extended-deadline-for-sar',
               class: 'button-secondary', method: :delete
     when :record_data_request
-      btn_type = @case.current_state == 'data_to_be_requested' ? 'secondary' : 'tertiary'
       link_to 'Record data request',
               new_case_data_request_path(@case),
               id: 'action--record-data-request',
-              class: "button-#{btn_type}"
+              class: "button-tertiary"
     when :send_acknowledgement_letter
       link_to 'Send acknowledgement letter',
               new_case_letters_path(@case.id, "acknowledgement"),

--- a/app/views/cases/offender_sar/_data_requests.html.slim
+++ b/app/views/cases/offender_sar/_data_requests.html.slim
@@ -38,7 +38,8 @@
 
           - if case_details.data_requests.many?
             = render partial: 'shared/table_total_row', locals: { total: case_details.data_requests.sum(:cached_num_pages), label_span: '4', value_span: '2' }
-- if case_details.current_state != 'closed'
-  = action_button_for(:record_data_request)
-= link_to 'Update exempt pages', edit_step_case_sar_offender_path(case_details, 'exempt_pages'), class: 'button-tertiary'
-= link_to 'Update pages for dispatch', edit_step_case_sar_offender_path(case_details, 'pages_for_dispatch'), class: 'button-tertiary'
+.data-request-buttons
+  - if case_details.current_state != 'closed'
+    = action_button_for(:record_data_request)
+  = link_to 'Update exempt pages', edit_step_case_sar_offender_path(case_details, 'exempt_pages'), class: 'button-tertiary'
+  = link_to 'Update pages for dispatch', edit_step_case_sar_offender_path(case_details, 'pages_for_dispatch'), class: 'button-tertiary'

--- a/app/views/cases/offender_sar/_data_requests.html.slim
+++ b/app/views/cases/offender_sar/_data_requests.html.slim
@@ -38,7 +38,7 @@
 
           - if case_details.data_requests.many?
             = render partial: 'shared/table_total_row', locals: { total: case_details.data_requests.sum(:cached_num_pages), label_span: '4', value_span: '2' }
-
-= action_button_for(:record_data_request)
+- if case_details.current_state != 'closed'
+  = action_button_for(:record_data_request)
 = link_to 'Update exempt pages', edit_step_case_sar_offender_path(case_details, 'exempt_pages'), class: 'button-tertiary'
 = link_to 'Update pages for dispatch', edit_step_case_sar_offender_path(case_details, 'pages_for_dispatch'), class: 'button-tertiary'

--- a/app/views/cases/offender_sar/_data_requests.html.slim
+++ b/app/views/cases/offender_sar/_data_requests.html.slim
@@ -39,5 +39,6 @@
           - if case_details.data_requests.many?
             = render partial: 'shared/table_total_row', locals: { total: case_details.data_requests.sum(:cached_num_pages), label_span: '4', value_span: '2' }
 
+= action_button_for(:record_data_request)
 = link_to 'Update exempt pages', edit_step_case_sar_offender_path(case_details, 'exempt_pages'), class: 'button-tertiary'
 = link_to 'Update pages for dispatch', edit_step_case_sar_offender_path(case_details, 'pages_for_dispatch'), class: 'button-tertiary'

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -43,8 +43,7 @@ div id="case-#{@correspondence_type_key}" class="case"
         - if policy(@case).assignments_execute_reassign_user?
           = action_button_for(:reassign_user)
 
-        - if policy(@case).can_record_data_request?
-          = action_button_for(:record_data_request)
+
 
       = action_buttons_for_allowed_events(@case, :extend_for_pit, :remove_pit_extension).join(' ').html_safe
 

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -43,8 +43,6 @@ div id="case-#{@correspondence_type_key}" class="case"
         - if policy(@case).assignments_execute_reassign_user?
           = action_button_for(:reassign_user)
 
-
-
       = action_buttons_for_allowed_events(@case, :extend_for_pit, :remove_pit_extension).join(' ').html_safe
 
       - if (@filtered_permitted_events - [:edit_case, :destroy_case]).any?

--- a/spec/site_prism/page_objects/pages/cases/show_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/show_page.rb
@@ -32,7 +32,6 @@ module PageObjects
           element :progress_to_disclosure, '#action--progress-for-clearance'
           element :extend_sar_deadline, '#action--extend-deadline-for-sar'
           element :remove_sar_deadline_extension, '#action--remove-extended-deadline-for-sar'
-          element :record_data_request, '#action--record-data-request'
           element :mark_as_waiting_for_data, '#action--mark-as-waiting-for-data'
           element :mark_as_ready_for_vetting, '#action--mark-as-ready-for-vetting'
           element :mark_as_vetting_in_progress, '#action--mark-as-vetting-in-progress'
@@ -47,6 +46,10 @@ module PageObjects
 
         section :data_requests,
           PageObjects::Sections::Cases::DataRequestsSection, '.data-requests'
+
+        section :data_request_actions, '.data-request-buttons' do
+          element :record_data_request, '#action--record-data-request'
+        end
 
         section :link_case,
                 PageObjects::Sections::Cases::LinkedCasesSection, '.case-linking'

--- a/spec/views/cases/show_html_slim_spec.rb
+++ b/spec/views/cases/show_html_slim_spec.rb
@@ -580,15 +580,7 @@ describe 'cases/show.html.slim', type: :view do
         it 'shows record data request button' do
           render
           cases_show_page.load(rendered)
-          expect(cases_show_page.actions.record_data_request['class']).to match(/button-secondary/)
-        end
-
-        # Grey button once one or more data requests have been recorded
-        it 'shows tertiary button after data request is recorded' do
-          offender_sar_case.current_state = 'ready_for_vetting'
-          render
-          cases_show_page.load(rendered)
-          expect(cases_show_page.actions.record_data_request['class']).to match(/button-tertiary/)
+          expect(cases_show_page.data_request_actions.record_data_request['class']).to match(/button-tertiary/)
         end
       end
 


### PR DESCRIPTION
## Description
Move Data Requests button with other grey buttons under Data Requests. 1. Moved button in view. 2. Mucked with controller to make it only show one class for the button. 3. Updated tests to reflect both of these things.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Was:
![image](https://user-images.githubusercontent.com/22935203/90909939-755cb700-e3ce-11ea-9fc3-de87d2ca46d7.png)
Now:
![image](https://user-images.githubusercontent.com/22935203/90909965-7f7eb580-e3ce-11ea-91d9-49131759cbec.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3013

### Deployment
n/a

### Manual testing instructions
See Offender SAR Show case page and look at button for adding Data Requests. Make sure it's below the data requests table only.
