### PR TITLE
CT-2973 Suppress late business unit

### DIFF
--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -9,7 +9,7 @@ tbody.response-details
       th = t('common.case.timeliness')
       td = case_details.timeliness
 
-    - if case_details.responded_late? &&  !case_details.offender_sar?
+    - if case_details.responded_late? && !case_details.offender_sar?
       tr.late-team
         th = t('common.case.late_team')
         td = case_details.late_team_name

--- a/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/offender_sar/case_details_section.rb
@@ -125,6 +125,10 @@ module PageObjects
             element :data, 'td'
           end
 
+          section :late_team, '.late-team' do
+            element :data, 'td'
+          end
+
           section :time_taken, '.time-taken' do
             element :data, 'td:nth-child(2)'
           end

--- a/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
@@ -60,5 +60,22 @@ describe 'cases/sar/case_details.html.slim', type: :view do
       expect(partial.requester_reference.data.text).to eq 'FOOG1234'
       expect(partial.third_party_company_name.data.text).to eq 'Foogle and Sons Solicitors at Law'
     end
+
+    it 'does not display Business unit responsible for late response when case closed' do
+      late_closed_case = (
+        create :offender_sar_case,
+        current_state: 'closed',
+        received_date: 40.days.ago,
+        date_responded: 1.days.ago,
+        external_deadline: 40.days.ago).decorate
+      assign(:case, late_closed_case)
+      render partial: 'cases/offender_sar/case_details.html.slim', locals: {
+        case_details: late_closed_case,
+        link_type: nil
+      }
+      partial = offender_sar_case_details_section(rendered).response_details
+
+      expect(partial).not_to have_selector(".late-team")
+    end
   end
 end


### PR DESCRIPTION
CT-2973 Suppress business unit responsible for late case from case page

## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
* Add condition to hide late business unit field in offender SAR cases.
* Add test to check field is not displayed.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
Before:
![Un-suppressed](https://user-images.githubusercontent.com/6988369/91154669-acc2b080-e6b9-11ea-8c63-57596ab3a24c.png)

After:
![Suppressed](https://user-images.githubusercontent.com/6988369/91154698-b5b38200-e6b9-11ea-9564-ad4c93c6d023.png)

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-2973
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
Create a late close case and the "Suppress business unit responsible for late case" will be missing from the case details page.