### PR TITLE
CT-3033 Update cover page to display request type properly

### DIFF
--- a/app/views/cases/cover_pages/_data_requests.html.slim
+++ b/app/views/cases/cover_pages/_data_requests.html.slim
@@ -14,6 +14,7 @@
             th Location
             th Data
             th Date requested
+            th Pages received
             th Date received
         tbody
           - case_details.data_requests.order(date_requested: :asc).each do |data_request|
@@ -21,10 +22,14 @@
               td
                 = data_request.location
               td
-                = truncate(data_request.request_type, length: 140)
+                = render "cases/offender_sar/data_request_request_type", data_request: data_request
+
               td
                 time datetime="#{data_request.date_requested}"
                   = l data_request.date_requested, format: :default
+              td
+
+
               td
                 - if data_request.cached_date_received.present?
                   time datetime="#{data_request.cached_date_received}"

--- a/app/views/cases/cover_pages/_data_requests.html.slim
+++ b/app/views/cases/cover_pages/_data_requests.html.slim
@@ -28,7 +28,7 @@
                 time datetime="#{data_request.date_requested}"
                   = l data_request.date_requested, format: :default
               td
-
+                / this td left intentionally empty
 
               td
                 - if data_request.cached_date_received.present?

--- a/app/views/cases/offender_sar/_data_request_request_type.html.slim
+++ b/app/views/cases/offender_sar/_data_request_request_type.html.slim
@@ -1,0 +1,20 @@
+                = t :"cases.data_requests.index.request_type.#{data_request.request_type}"
+                - if data_request.other? && data_request.request_type_note.present?
+                  = ": #{data_request.request_type_note}"
+                - if data_request.request_dates_either_present?
+                  span.data-detail<
+                    br
+                    - if data_request.date_from.present?
+                        time datetime="#{data_request.date_from}"
+                          = l data_request.date_from, format: :default
+                    - if data_request.request_dates_both_present?
+                      = " - "
+                    - if data_request.request_date_from_only?
+                      span<
+                        = t('cases.data_requests.onwards')
+                    - if data_request.request_date_to_only?
+                      span<
+                        = t('cases.data_requests.upto')
+                    - if data_request.date_to.present?
+                        time< datetime="#{data_request.date_to}"
+                          = l data_request.date_to, format: :default

--- a/app/views/cases/offender_sar/_data_requests.html.slim
+++ b/app/views/cases/offender_sar/_data_requests.html.slim
@@ -23,26 +23,7 @@
               td
                 = data_request.location
               td
-                = t :"cases.data_requests.index.request_type.#{data_request.request_type}"
-                - if data_request.other? && data_request.request_type_note.present?
-                  = ": #{data_request.request_type_note}"
-                - if data_request.request_dates_either_present?
-                  span.data-detail<
-                    br
-                    - if data_request.date_from.present?
-                        time datetime="#{data_request.date_from}"
-                          = l data_request.date_from, format: :default
-                    - if data_request.request_dates_both_present?
-                      = " - "
-                    - if data_request.request_date_from_only?
-                      span<
-                        = t('cases.data_requests.onwards')
-                    - if data_request.request_date_to_only?
-                      span<
-                        = t('cases.data_requests.upto')
-                    - if data_request.date_to.present?
-                        time< datetime="#{data_request.date_to}"
-                          = l data_request.date_to, format: :default
+                = render "cases/offender_sar/data_request_request_type", data_request: data_request
               td
                 - if data_request.date_requested.present?
                   time datetime="#{data_request.date_requested}"

--- a/spec/site_prism/page_objects/pages/cases/cover_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/cover_page.rb
@@ -7,6 +7,9 @@ module PageObjects
         section :primary_navigation,
                 PageObjects::Sections::PrimaryNavigationSection, '.global-nav'
 
+        section :page_heading,
+          PageObjects::Sections::PageHeadingSection, '.page-heading'
+
         section :data_requests,
           PageObjects::Sections::Cases::DataRequestsSection, '.data-requests'
 

--- a/spec/site_prism/page_objects/sections/cases/data_requests_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/data_requests_section.rb
@@ -14,6 +14,7 @@ module PageObjects
           element :date_requested_time, 'td:nth-child(3) time'
           element :pages, 'td:nth-child(4)'
           element :status, 'td:nth-child(5)'
+          element :date_received, 'td:nth-child(5)'
           element :action, '.data-requests__action'
           element :total_label, 'td:nth-child(1)'
           element :total_value, 'td:nth-child(2)'

--- a/spec/views/cases/cover_pages/show_html_slim_spec.rb
+++ b/spec/views/cases/cover_pages/show_html_slim_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe 'cases/cover_pages/show', type: :view do
+  context '#show' do
+    let(:data_request) {
+      create(
+        :data_request,
+        location: 'HMP Leicester',
+        request_type: 'all_prison_records',
+        date_from: Date.new(2018, 8, 15),
+        date_to: Date.new(2019, 8, 15),
+        cached_num_pages: 32,
+        cached_date_received: Date.new(1972, 9, 25),
+      )
+    }
+
+    before do
+      assign(:data_request, data_request)
+      assign(:case, data_request.kase)
+
+      render
+      cases_cover_page.load(rendered)
+      @page = cases_cover_page
+    end
+
+    it 'has required content' do
+      expect(@page.page_heading.heading.text).to eq 'SUBJECT 1-123465'
+
+      row = @page.data_requests.rows[0]
+      expect(row.location).to have_text 'HMP Leicester'
+      expect(row.request_type).to have_text 'All prison records 15 Aug 2018 -  15 Aug 2019'
+      expect(row.date_requested).to have_text '28 Aug 2020'
+      expect(row.pages.text).to eq ''
+      expect(row.date_received).to have_text '25 Sep 1972'
+    end
+  end
+end

--- a/spec/views/cases/cover_pages/show_html_slim_spec.rb
+++ b/spec/views/cases/cover_pages/show_html_slim_spec.rb
@@ -24,7 +24,7 @@ describe 'cases/cover_pages/show', type: :view do
     end
 
     it 'has required content' do
-      expect(@page.page_heading.heading.text).to eq 'SUBJECT 1-123465'
+      expect(@page.page_heading.heading.text).to eq "#{data_request.kase.subject_full_name&.upcase}-#{data_request.kase.prison_number}"
 
       row = @page.data_requests.rows[0]
       expect(row.location).to have_text 'HMP Leicester'


### PR DESCRIPTION
## Description
Small change to output the request type consistently on the data requests table both on the case show page and on the cover page for printing. Split out a partial which is referenced from both places. 

We added a pages received column which is intended to be empty on the cover page even when there is a value for the data request - this is a space for the vetters to write in during the vetting process, as the cover page is printed off only once after the case and data requests have been logged on the system. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
BEFORE
![image](https://user-images.githubusercontent.com/1161161/91541965-02df6000-e915-11ea-8345-90a45001a04f.png)

AFTER
![image](https://user-images.githubusercontent.com/1161161/91534491-872be600-e909-11ea-83d2-0c408daec383.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3033
### Deployment
None
### Manual testing instructions
On an Offender SAR case with some data requests that have from and/or to dates populated, view the cover page using the Preview Cover Page button and verify the appearance of the request type is the same as on the request table entry on the show page
