### PR TITLE
CT-3044 fix time sensitive specs

### DIFF
--- a/spec/features/cases/foi/case_listing/incoming_cases_spec.rb
+++ b/spec/features/cases/foi/case_listing/incoming_cases_spec.rb
@@ -5,44 +5,62 @@ feature 'listing incoming on the system' do
   given(:press_officer) { find_or_create :press_officer }
   given(:private_officer) { find_or_create :private_officer }
 
-  given(:assigned_case) { create :assigned_case,
-                                 created_at: 1.business_days.ago,
-                                 identifier: 'assigned_case' }
-  given(:fresh_assigned_case) { create :assigned_case,
-                                       identifier: 'fresh_assigned_case' }
+  given(:assigned_case) do
+    Timecop.freeze(Date.new(2020, 8, 19)) do
+      create :assigned_case,
+           created_at: 1.business_days.ago,
+           identifier: 'assigned_case'
+    end
+  end
+  given(:fresh_assigned_case) do
+    Timecop.freeze(Date.new(2020, 8, 19)) do
+      create :assigned_case,
+           identifier: 'fresh_assigned_case'
+    end
+  end
   given(:assigned_case_flagged_for_dacu_disclosure) do
-    create :assigned_case,
+    Timecop.freeze(Date.new(2020, 8, 19)) do
+      create :assigned_case,
            :flagged,
            created_at: 2.business_days.ago,
            identifier: 'assigned_case_flagged_for_dacu_disclosure'
+    end
   end
   given(:assigned_case_flagged_for_dacu_disclosure_accepted) do
-    create :assigned_case,
+    Timecop.freeze(Date.new(2020, 8, 19)) do
+      create :assigned_case,
            :flagged_accepted,
            created_at: 2.business_days.ago,
            identifier: 'assigned_case_flagged_for_dacu_disclosure_accepted'
+    end
   end
   given(:assigned_case_flagged_for_press_office_accepted) do
-    create :assigned_case,
+    Timecop.freeze(Date.new(2020, 8, 19)) do
+      create :assigned_case,
            :flagged_accepted,
            :press_office,
            created_at: 2.business_days.ago,
            identifier: 'assigned_case_flagged_for_press_office_accepted'
+    end
   end
   given(:assigned_cr_case_flagged_for_press_office_accepted) do
-    create :awaiting_responder_compliance_review,
+    Timecop.freeze(Date.new(2020, 8, 19)) do
+      create :awaiting_responder_compliance_review,
            :flagged_accepted,
            :press_office,
            created_at: 2.business_days.ago,
            identifier: 'assigned_cr_case_flagged_for_press_office_accepted'
+    end
   end
 
   given(:assigned_case_flagged_for_private_office_accepted) do
-    create :assigned_case,
+    Timecop.freeze(Date.new(2020, 8, 19)) do
+      create :assigned_case,
            :flagged_accepted,
            :private_office,
            created_at: 2.business_days.ago,
            identifier: 'assigned_case_flagged_for_private_office_accepted'
+    end
   end
 
   context 'with cases setup for dacu disclosure' do
@@ -67,9 +85,13 @@ feature 'listing incoming on the system' do
   end
 
   context 'with cases setup for press office' do
-    given(:too_old_assigned_case) { create :assigned_case,
-                                           created_at: 4.business_days.ago,
-                                           identifier: 'too_old_assigned_case' }
+    given(:too_old_assigned_case) do
+      Timecop.freeze(Date.new(2020, 8, 19)) do
+        create(:assigned_case,
+          created_at: 4.business_days.ago,
+          identifier: 'too_old_assigned_case')
+      end
+    end
 
     background do
       too_old_assigned_case
@@ -81,23 +103,29 @@ feature 'listing incoming on the system' do
     end
 
     scenario 'for press office' do
-      login_as press_officer
+      Timecop.freeze(Date.new(2020, 8, 19)) do
+        login_as press_officer
 
-      visit '/cases/incoming'
+        visit '/cases/incoming'
 
-      cases = incoming_cases_page.case_list
+        cases = incoming_cases_page.case_list
 
-      expect(cases.count).to eq 2
-      expect(cases.first.number).to have_text assigned_case.number
-      expect(cases.second.number)
-        .to have_text assigned_case_flagged_for_dacu_disclosure.number
+        expect(cases.count).to eq 2
+        expect(cases.first.number).to have_text assigned_case.number
+        expect(cases.second.number)
+          .to have_text assigned_case_flagged_for_dacu_disclosure.number
+      end
     end
   end
 
   context 'with cases setup for private office' do
-    given(:too_old_assigned_case) { create :assigned_case,
-                                           created_at: 4.business_days.ago,
-                                           identifier: 'too_old_assigned_case' }
+    given(:too_old_assigned_case) do
+      Timecop.freeze(Date.new(2020, 8, 19)) do
+        create :assigned_case,
+               created_at: 4.business_days.ago,
+               identifier: 'too_old_assigned_case'
+      end
+    end
 
     background do
       too_old_assigned_case
@@ -108,16 +136,18 @@ feature 'listing incoming on the system' do
     end
 
     scenario 'for press office' do
-      login_as private_officer
+      Timecop.freeze(Date.new(2020, 8, 19)) do
+        login_as private_officer
 
-      visit '/cases/incoming'
+        visit '/cases/incoming'
 
-      cases = incoming_cases_page.case_list
+        cases = incoming_cases_page.case_list
 
-      expect(cases.count).to eq 2
-      expect(cases.first.number).to have_text assigned_case.number
-      expect(cases.second.number)
-          .to have_text assigned_case_flagged_for_dacu_disclosure.number
+        expect(cases.count).to eq 2
+        expect(cases.first.number).to have_text assigned_case.number
+        expect(cases.second.number)
+            .to have_text assigned_case_flagged_for_dacu_disclosure.number
+      end
     end
   end
 end

--- a/spec/models/case/foi/standard_spec.rb
+++ b/spec/models/case/foi/standard_spec.rb
@@ -338,37 +338,41 @@ describe Case::FOI::Standard do
         context 'in time' do
           context 'non trigger cases' do
             it 'returns true' do
-              # given
-              kase = create_case(flagged: false,
-                                 assignment_times: [18.business_days.ago])
-              expect(kase).not_to be_flagged
-              responder_assignments = kase.assignments.responding.order(:id)
-              expect(responder_assignments.size).to eq 1
-              expect(responder_assignments.first.state).to eq 'accepted'
+              Timecop.freeze(Date.new(2020, 8, 19)) do
+                # given
+                kase = create_case(flagged: false,
+                                   assignment_times: [18.business_days.ago])
+                expect(kase).not_to be_flagged
+                responder_assignments = kase.assignments.responding.order(:id)
+                expect(responder_assignments.size).to eq 1
+                expect(responder_assignments.first.state).to eq 'accepted'
 
-              expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 18.business_days.ago.to_date
-              expect(kase.transitions.where(event: 'add_responses')).to be_empty
+                expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 18.business_days.ago.to_date
+                expect(kase.transitions.where(event: 'add_responses')).to be_empty
 
-              # then
-              expect(kase.business_unit_already_late?).to be false
+                # then
+                expect(kase.business_unit_already_late?).to be false
+              end
             end
           end
 
           context 'trigger cases' do
             it 'returns true' do
-              # given
-              kase = create_case(flagged: true,
-                                 assignment_times: [8.business_days.ago])
-              expect(kase).to be_flagged
-              responder_assignments = kase.assignments.responding.order(:id)
-              expect(responder_assignments.size).to eq 1
-              expect(responder_assignments.first.state).to eq 'accepted'
+              Timecop.freeze(Date.new(2020, 8, 19)) do
+                # given
+                kase = create_case(flagged: true,
+                                   assignment_times: [8.business_days.ago])
+                expect(kase).to be_flagged
+                responder_assignments = kase.assignments.responding.order(:id)
+                expect(responder_assignments.size).to eq 1
+                expect(responder_assignments.first.state).to eq 'accepted'
 
-              expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 8.business_days.ago.to_date
-              expect(kase.transitions.where(event: 'add_responses')).to be_empty
+                expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 8.business_days.ago.to_date
+                expect(kase.transitions.where(event: 'add_responses')).to be_empty
 
-              # then
-              expect(kase.business_unit_already_late?).to be false
+                # then
+                expect(kase.business_unit_already_late?).to be false
+              end
             end
           end
         end
@@ -416,41 +420,45 @@ describe Case::FOI::Standard do
         context 'in time' do
           context 'non trigger cases' do
             it 'returns true' do
-              # given
-              kase = create_case(flagged: false,
-                                 assignment_times: [30.business_days.ago, 25.business_days.ago, 18.business_days.ago])
-              expect(kase).not_to be_flagged
-              responder_assignments = kase.assignments.responding.order(:id)
-              expect(responder_assignments.size).to eq 3
-              expect(responder_assignments[0].state).to eq 'rejected'
-              expect(responder_assignments[1].state).to eq 'rejected'
-              expect(responder_assignments[2].state).to eq 'accepted'
+              Timecop.freeze(Date.new(2020, 8, 19)) do
+                # given
+                kase = create_case(flagged: false,
+                                   assignment_times: [30.business_days.ago, 25.business_days.ago, 18.business_days.ago])
+                expect(kase).not_to be_flagged
+                responder_assignments = kase.assignments.responding.order(:id)
+                expect(responder_assignments.size).to eq 3
+                expect(responder_assignments[0].state).to eq 'rejected'
+                expect(responder_assignments[1].state).to eq 'rejected'
+                expect(responder_assignments[2].state).to eq 'accepted'
 
-              expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 18.business_days.ago.to_date
-              expect(kase.transitions.where(event: 'add_responses')).to be_empty
+                expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 18.business_days.ago.to_date
+                expect(kase.transitions.where(event: 'add_responses')).to be_empty
 
-              # then
-              expect(kase.business_unit_already_late?).to be false
+                # then
+                expect(kase.business_unit_already_late?).to be false
+              end
             end
           end
 
           context 'trigger cases' do
             it 'returns true' do
-              # given
-              kase = create_case(flagged: true,
-                                 assignment_times: [30.business_days.ago, 25.business_days.ago, 8.business_days.ago])
-              expect(kase).to be_flagged
-              responder_assignments = kase.assignments.responding.order(:id)
-              expect(responder_assignments.size).to eq 3
-              expect(responder_assignments[0].state).to eq 'rejected'
-              expect(responder_assignments[1].state).to eq 'rejected'
-              expect(responder_assignments[2].state).to eq 'accepted'
+              Timecop.freeze(Date.new(2020, 8, 19)) do
+                # given
+                kase = create_case(flagged: true,
+                                   assignment_times: [30.business_days.ago, 25.business_days.ago, 8.business_days.ago])
+                expect(kase).to be_flagged
+                responder_assignments = kase.assignments.responding.order(:id)
+                expect(responder_assignments.size).to eq 3
+                expect(responder_assignments[0].state).to eq 'rejected'
+                expect(responder_assignments[1].state).to eq 'rejected'
+                expect(responder_assignments[2].state).to eq 'accepted'
 
-              expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 8.business_days.ago.to_date
-              expect(kase.transitions.where(event: 'add_responses')).to be_empty
+                expect(kase.transitions.where(event: 'accept_responder_assignment').first.created_at.to_date).to eq 8.business_days.ago.to_date
+                expect(kase.transitions.where(event: 'add_responses')).to be_empty
 
-              # then
-              expect(kase.business_unit_already_late?).to be false
+                # then
+                expect(kase.business_unit_already_late?).to be false
+              end
             end
           end
         end

--- a/spec/models/concerns/case_states_spec.rb
+++ b/spec/models/concerns/case_states_spec.rb
@@ -149,16 +149,20 @@ RSpec.describe Case, type: :model do
     describe '#within_external_deadline?' do
       let(:foi) { find_or_create :foi_correspondence_type }
       let(:responded_case) do
-        create :responded_case,
-               received_date: days_taken.business_days.ago,
-               date_responded: Time.first_business_day(Date.today)
+        Timecop.freeze(Date.new(2020, 8, 19)) do
+          create :responded_case,
+                 received_date: days_taken.business_days.ago,
+                 date_responded: Time.first_business_day(Date.today)
+        end
       end
 
       context 'the date responded is before the external deadline' do
         let(:days_taken) { foi.external_time_limit - 1 }
 
         it 'returns true' do
-          expect(responded_case.within_external_deadline?).to eq true
+          Timecop.freeze(Date.new(2020, 8, 19)) do
+            expect(responded_case.within_external_deadline?).to eq true
+          end
         end
       end
 
@@ -166,7 +170,9 @@ RSpec.describe Case, type: :model do
         let(:days_taken) { foi.external_time_limit - 1 }
 
         it 'returns true' do
-          expect(responded_case.within_external_deadline?).to eq true
+          Timecop.freeze(Date.new(2020, 8, 19)) do
+            expect(responded_case.within_external_deadline?).to eq true
+          end
         end
       end
 
@@ -174,7 +180,9 @@ RSpec.describe Case, type: :model do
         let(:days_taken) { foi.external_time_limit + 1 }
 
         it 'returns false' do
-          expect(responded_case.within_external_deadline?).to eq false
+          Timecop.freeze(Date.new(2020, 8, 19)) do
+            expect(responded_case.within_external_deadline?).to eq false
+          end
         end
       end
     end

--- a/spec/services/case_finder_service_spec.rb
+++ b/spec/services/case_finder_service_spec.rb
@@ -600,19 +600,21 @@ describe CaseFinderService do
       @team_dacu_disclosure = find_or_create :team_dacu_disclosure
       @managing_team        = find_or_create :managing_team
 
-      @foi_case_1                       = create :assigned_case,
-                                                 creation_time: 2.business_days.ago,
-                                                 identifier: 'foi 1 case'
-      @foi_case_2                       = create :assigned_case,
-                                                 creation_time: 1.business_days.ago,
-                                                 identifier: 'foi 2 case'
-      @foi_cr_case                      = create :accepted_compliance_review,
-                                                 creation_time: 1.business_days.ago
-      @foi_tr_case                      = create :accepted_timeliness_review,
-                                                 creation_time: 1.business_days.ago
-      @awaiting_responder_ot_ico_foi    = create :awaiting_responder_ot_ico_foi,
-                                                 creation_time: 1.business_days.ago
-      @awaiting_responder_ot_ico_foi.update(escalation_deadline: 3.days.from_now)
+      Timecop.freeze(Date.new(2020, 8, 19)) do
+        @foi_case_1                       = create :assigned_case,
+                                                   creation_time: 2.business_days.ago,
+                                                   identifier: 'foi 1 case'
+        @foi_case_2                       = create :assigned_case,
+                                                   creation_time: 1.business_days.ago,
+                                                   identifier: 'foi 2 case'
+        @foi_cr_case                      = create :accepted_compliance_review,
+                                                   creation_time: 1.business_days.ago
+        @foi_tr_case                      = create :accepted_timeliness_review,
+                                                   creation_time: 1.business_days.ago
+        @awaiting_responder_ot_ico_foi    = create :awaiting_responder_ot_ico_foi,
+                                                   creation_time: 1.business_days.ago
+        @awaiting_responder_ot_ico_foi.update(escalation_deadline: 3.days.from_now)
+      end
     end
 
     after(:all) {DbHousekeeping.clean}
@@ -620,14 +622,18 @@ describe CaseFinderService do
     describe '#incoming_cases_press_office_scope' do
       it 'returns incoming non-review cases ordered by creation date descending' do
         finder = CaseFinderService.new(@press_officer)
-        expect(finder.__send__ :incoming_cases_press_office_scope)
-          .to match_array [@foi_case_2, @foi_case_1, @awaiting_responder_ot_ico_foi]
+        Timecop.freeze(Date.new(2020, 8, 19)) do
+          expect(finder.__send__ :incoming_cases_press_office_scope)
+            .to match_array [@foi_case_2, @foi_case_1, @awaiting_responder_ot_ico_foi]
+        end
       end
 
       it 'does not return internal review cases' do
         finder = CaseFinderService.new(@press_officer)
-        expect(finder.__send__ :incoming_cases_press_office_scope)
-          .to match_array [ @foi_case_1, @foi_case_2, @awaiting_responder_ot_ico_foi ]
+        Timecop.freeze(Date.new(2020, 8, 19)) do
+          expect(finder.__send__ :incoming_cases_press_office_scope)
+            .to match_array [ @foi_case_1, @foi_case_2, @awaiting_responder_ot_ico_foi ]
+        end
       end
 
       context 'internal review case has received request for further clearance' do
@@ -648,8 +654,10 @@ describe CaseFinderService do
 
         it 'does return the case' do
           finder = CaseFinderService.new(@press_officer)
-          expect(finder.__send__ :incoming_cases_press_office_scope)
-            .to match_array [ @foi_case_1, @foi_case_2, @foi_cr_case, @foi_tr_case, @awaiting_responder_ot_ico_foi ]
+          Timecop.freeze(Date.new(2020, 8, 19)) do
+            expect(finder.__send__ :incoming_cases_press_office_scope)
+              .to match_array [ @foi_case_1, @foi_case_2, @foi_cr_case, @foi_tr_case, @awaiting_responder_ot_ico_foi ]
+          end
         end
       end
     end

--- a/spec/views/cases/cover_pages/show_html_slim_spec.rb
+++ b/spec/views/cases/cover_pages/show_html_slim_spec.rb
@@ -7,10 +7,11 @@ describe 'cases/cover_pages/show', type: :view do
         :data_request,
         location: 'HMP Leicester',
         request_type: 'all_prison_records',
+        date_requested: Date.new(2020, 8, 15),
         date_from: Date.new(2018, 8, 15),
         date_to: Date.new(2019, 8, 15),
         cached_num_pages: 32,
-        cached_date_received: Date.new(1972, 9, 25),
+        cached_date_received: Date.new(2020, 8, 15),
       )
     }
 
@@ -29,9 +30,9 @@ describe 'cases/cover_pages/show', type: :view do
       row = @page.data_requests.rows[0]
       expect(row.location).to have_text 'HMP Leicester'
       expect(row.request_type).to have_text 'All prison records 15 Aug 2018 -  15 Aug 2019'
-      expect(row.date_requested).to have_text '28 Aug 2020'
+      expect(row.date_requested).to have_text '15 Aug 2020'
       expect(row.pages.text).to eq ''
-      expect(row.date_received).to have_text '25 Sep 1972'
+      expect(row.date_received).to have_text '15 Aug 2020'
     end
   end
 end


### PR DESCRIPTION
## Description
When we run our specs early in the morning, in the evening, or at the weekend, certain specs fail because they make assumptions about the date or time of day that the specs are to be run. 

This causes a great deal of friction and delay since we work flexible hours and often need to run tests outside the normal 9-5. Also, we have automated PRs generated by dependabot which suffer from the same problems if they're triggered in these time windows. We need to make our test suite so it can be run any time of day or on any day successfully without reporting false positives.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3044

### Deployment
n/a

### Manual testing instructions
n/a