### PR TITLE
CT-3045 Update copy and display alert banner

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -35,6 +35,7 @@
 = content_for :content do
   = csrf_meta_tags
   = render partial: 'layouts/phase_banner'
+  = render partial: 'layouts/alert_banner'
 
   .grid-row
     .column-full

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -575,7 +575,7 @@ en:
       case_cleared: "The response has been cleared and is ready to be sent to the ICO"
 
   common:
-    alert_banner: "This service will be down for essential maintenance during the afternoon of Wednesday 2 September. You will not have access after 13.00 on this day – the site will likely resume service after business hours. Apologies for the inconvenience."
+    alert_banner: "This service will be down for essential maintenance during the afternoon of Wednesday 2 September. You will not have access after 13.00 on this day and the site will resume service after business hours. Apologies for the inconvenience."
     choose: Choose...
     choose_file: Choose a file
     error: error

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -575,7 +575,7 @@ en:
       case_cleared: "The response has been cleared and is ready to be sent to the ICO"
 
   common:
-    alert_banner: "This service will be down for essential maintenance during the afternoon of Wednesday 13 November. You will not have access after 13.00 on this day – the site will likely resume service after business hours. Apologies for the inconvenience."
+    alert_banner: "This service will be down for essential maintenance during the afternoon of Wednesday 2 September. You will not have access after 13.00 on this day – the site will likely resume service after business hours. Apologies for the inconvenience."
     choose: Choose...
     choose_file: Choose a file
     error: error
@@ -624,7 +624,7 @@ en:
       other_subject_ids: "Police national computer number"
       outcome: Outcome
       pages_exempt: Exempt pages
-      pages_final_count: Final page count 
+      pages_final_count: Final page count
       pages_received: Pages received
       postal_address: "Requester’s postal address"
       previous_case_numbers: Previous SAR cases


### PR DESCRIPTION
## Description
We need a banner to inform users of the impending planned downtime. 

We have an existing mechanism; update the copy in the en.yml file and display the alert_banner in the application template.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
<img width="1140" alt="image" src="https://user-images.githubusercontent.com/1161161/91658404-c734c980-eabf-11ea-8a51-4b9e1655d994.png">

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3045

### Deployment
n/a

### Manual testing instructions
n/a