### PR TITLE
Add deferred garbage collection to application

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,15 @@ RSpec.configure do |config|
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
 
+  # defer garbage collection to speed up test runs
+  config.before(:all) do
+    DeferredGarbageCollection.start
+  end
+
+  config.after(:all) do
+    DeferredGarbageCollection.reconsider
+  end
+
   # # Many RSpec users commonly either run the entire suite or an individual
   # # file, and it's useful to allow more verbose output when running an
   # # individual spec file.

--- a/spec/support/deferred_garbage_collection.rb
+++ b/spec/support/deferred_garbage_collection.rb
@@ -1,0 +1,19 @@
+class DeferredGarbageCollection
+
+  DEFERRED_GC_THRESHOLD = (ENV['DEFER_GC'] || 15.0).to_f
+
+  @@last_gc_run = Time.now
+
+  def self.start
+    GC.disable if DEFERRED_GC_THRESHOLD > 0
+  end
+
+  def self.reconsider
+    if DEFERRED_GC_THRESHOLD > 0 && Time.now - @@last_gc_run >= DEFERRED_GC_THRESHOLD
+      GC.enable
+      GC.start
+      GC.disable
+      @@last_gc_run = Time.now
+    end
+  end
+end


### PR DESCRIPTION
## Description
- see this article: https://www.devroom.io/2011/09/24/rspec-speed-up-by-tweaking-ruby-garbage-collection/
- I was interested to see if this speeds up our current test suite at all, given the low overhead of implementation I thought it was worth looking into.


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`


