### PR TITLE
CT-3042 style changes to cover sheet

### DIFF
--- a/app/assets/stylesheets/moj/component/_page_headings.scss
+++ b/app/assets/stylesheets/moj/component/_page_headings.scss
@@ -14,7 +14,6 @@
 .cover-sheet-heading {
   margin: 15px 0 40px;
   font-family: "nta", Arial, sans-serif;
-  text-transform: uppercase;
   font-weight: bold;
 
   &__name {

--- a/app/assets/stylesheets/moj/component/_page_headings.scss
+++ b/app/assets/stylesheets/moj/component/_page_headings.scss
@@ -10,3 +10,20 @@
   @include core-27();
   color: $secondary-text-colour;
 }
+
+.cover-sheet-heading {
+  margin: 40px 0 60px;
+  font-family: "nta", Arial, sans-serif;
+  text-transform: uppercase;
+  font-weight: bold;
+
+  &__name {
+    font-size: 90px;
+    line-height: 100px;
+  }
+
+  &__detail {
+    font-size: 45px;
+    line-height: 60px;
+  }
+}

--- a/app/assets/stylesheets/moj/component/_page_headings.scss
+++ b/app/assets/stylesheets/moj/component/_page_headings.scss
@@ -12,7 +12,7 @@
 }
 
 .cover-sheet-heading {
-  margin: 40px 0 60px;
+  margin: 15px 0 40px;
   font-family: "nta", Arial, sans-serif;
   text-transform: uppercase;
   font-weight: bold;

--- a/app/assets/stylesheets/print.css.scss
+++ b/app/assets/stylesheets/print.css.scss
@@ -1,5 +1,5 @@
 @page {
-  margin: 2cm;
+  margin: 1cm 1.5cm;
 }
 
 #skiplink-container,

--- a/app/views/cases/cover_pages/_data_requests.html.slim
+++ b/app/views/cases/cover_pages/_data_requests.html.slim
@@ -1,7 +1,5 @@
 .grid-row
   .column-full.data-requests
-    h2.request--heading.data-requests__title
-      = t('cases.data_requests.index.heading')
 
     - if case_details.data_requests.empty?
       p.data-requests__none

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -18,9 +18,6 @@ section.case-info
   = render partial: 'cases/cover_pages/data_requests', locals: { case_details: @case }
 
 section.case-info.section--vetting
-  h2.request--heading
-    = t('cases.cover_sheet.vetting')
-
   table
     thead
       th width="50%"

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -3,11 +3,16 @@
 
 = link_to "Back", case_path(@case), class: 'govuk-back-link'
 
-h1.page-heading
-  span.page-heading--secondary
-    = @case.number
-  span.page-heading--primary
-    = "#{@case.subject_full_name&.upcase}-#{@case.prison_number}"
+h1.cover-sheet-heading
+  ul
+    li.cover-sheet-heading__detail
+      = @case.number
+    li.cover-sheet-heading__name
+      = @case.subject_full_name&.upcase
+    li.cover-sheet-heading__detail
+      = @case.subject_aliases
+    li.cover-sheet-heading__detail
+      = @case.prison_number
 
 section.case-info
   = render partial: 'cases/cover_pages/data_requests', locals: { case_details: @case }

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -10,9 +10,9 @@ h1.cover-sheet-heading
     li.cover-sheet-heading__name
       = @case.subject_full_name&.upcase
     li.cover-sheet-heading__detail
-      = @case.subject_aliases
+      = @case.subject_aliases&.upcase
     li.cover-sheet-heading__detail
-      = @case.prison_number
+      = @case.prison_number&.upcase
 
 section.case-info
   = render partial: 'cases/cover_pages/data_requests', locals: { case_details: @case }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -792,7 +792,6 @@ en:
             <li>sent the response to the person who made the request</li>
           </ul>
     cover_sheet:
-      vetting: Vetting
       vet_date: Vet date
       vet_by: By
       vetter_name: 'Name:'

--- a/spec/site_prism/page_objects/pages/cases/cover_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/cover_page.rb
@@ -8,15 +8,15 @@ module PageObjects
                 PageObjects::Sections::PrimaryNavigationSection, '.global-nav'
 
         section :page_heading,
-          PageObjects::Sections::PageHeadingSection, '.cover-sheet-heading'
+          PageObjects::Sections::PageHeadingSection, '.cover-sheet-heading' do
+          element :case_number, 'li:first-child'
+          element :subject_full_name, '.cover-sheet-heading__name'
+          element :aliases, 'li:nth-child(3)'
+          element :prison_number, 'li:nth-child(4)'
+        end
 
         section :data_requests,
-          PageObjects::Sections::Cases::DataRequestsSection, '.data-requests' do |variable|
-            element :case_number, 'li:first-child'
-            element :subject_full_name, '.cover-sheet-heading__name'
-            element :aliases, 'li:nth-child(3)'
-            element :prison_number, 'li:nth-child(4)'
-          end
+          PageObjects::Sections::Cases::DataRequestsSection, '.data-requests'
 
         element :final_deadline, '.heading--final-deadline'
       end

--- a/spec/site_prism/page_objects/pages/cases/cover_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/cover_page.rb
@@ -8,10 +8,15 @@ module PageObjects
                 PageObjects::Sections::PrimaryNavigationSection, '.global-nav'
 
         section :page_heading,
-          PageObjects::Sections::PageHeadingSection, '.page-heading'
+          PageObjects::Sections::PageHeadingSection, '.cover-sheet-heading'
 
         section :data_requests,
-          PageObjects::Sections::Cases::DataRequestsSection, '.data-requests'
+          PageObjects::Sections::Cases::DataRequestsSection, '.data-requests' do |variable|
+            element :case_number, 'li:first-child'
+            element :subject_full_name, '.cover-sheet-heading__name'
+            element :aliases, 'li:nth-child(3)'
+            element :prison_number, 'li:nth-child(4)'
+          end
 
         element :final_deadline, '.heading--final-deadline'
       end

--- a/spec/views/cases/cover_pages/show_html_slim_spec.rb
+++ b/spec/views/cases/cover_pages/show_html_slim_spec.rb
@@ -25,7 +25,10 @@ describe 'cases/cover_pages/show', type: :view do
     end
 
     it 'has required content' do
-      expect(@page.page_heading.heading.text).to eq "#{data_request.kase.subject_full_name&.upcase}-#{data_request.kase.prison_number}"
+      expect(@page.page_heading.subject_full_name.text).to eq "#{data_request.kase.subject_full_name&.upcase}"
+      expect(@page.page_heading.case_number.text).to eq data_request.kase.case_number
+      expect(@page.page_heading.aliases.text).to eq "#{data_request.kase.aliases&.upcase}"
+      expect(@page.page_heading.prison_number.text).to eq data_request.kase.prison_number
 
       row = @page.data_requests.rows[0]
       expect(row.location).to have_text 'HMP Leicester'

--- a/spec/views/cases/cover_pages/show_html_slim_spec.rb
+++ b/spec/views/cases/cover_pages/show_html_slim_spec.rb
@@ -26,8 +26,8 @@ describe 'cases/cover_pages/show', type: :view do
 
     it 'has required content' do
       expect(@page.page_heading.subject_full_name.text).to eq "#{data_request.kase.subject_full_name&.upcase}"
-      expect(@page.page_heading.case_number.text).to eq data_request.kase.case_number
-      expect(@page.page_heading.aliases.text).to eq "#{data_request.kase.aliases&.upcase}"
+      expect(@page.page_heading.case_number.text).to eq data_request.kase.number
+      expect(@page.page_heading.aliases.text).to eq "#{data_request.kase.subject_aliases&.upcase}"
       expect(@page.page_heading.prison_number.text).to eq data_request.kase.prison_number
 
       row = @page.data_requests.rows[0]


### PR DESCRIPTION
## Description
Update style of cover sheet header to make it more bigger/clearer from far

- Notes: easily goes to 2 pages with this style if some data requests (see PDF):
[preview2.pdf](https://github.com/ministryofjustice/correspondence_tool_staff/files/5219816/preview2.pdf)
Latest iteration: (fits on 1 page)
[cover4.pdf](https://github.com/ministryofjustice/correspondence_tool_staff/files/5224234/cover4.pdf)


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Old: 
![image](https://user-images.githubusercontent.com/22935203/93113438-1890ab80-f6b1-11ea-8247-fd15bd0de345.png)


New:

![image](https://user-images.githubusercontent.com/22935203/93199339-2cd2b800-f746-11ea-8439-52462844fa14.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3042

### Deployment
n/a

### Manual testing instructions
Start a new Offender SAR case and on show page:
Click green button until Blue Preview cover page button shows
Click it and see the difference
Click on Print button and preview
