### PR TITLE
CT-3114 Cover sheet is available to print once case has passed into Vetting

### DIFF
--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -25,12 +25,14 @@
                   transition_to: vetting_in_progress
                 add_data_received:
                 add_note_to_case:
+                preview_cover_page:
                 edit_case:
               vetting_in_progress:
                 mark_as_ready_to_copy:
                   transition_to: ready_to_copy
                 add_data_received:
                 add_note_to_case:
+                preview_cover_page:
                 edit_case:
               ready_to_copy:
                 mark_as_ready_to_dispatch:

--- a/spec/features/cases/offender_sar/case_progressing_spec.rb
+++ b/spec/features/cases/offender_sar/case_progressing_spec.rb
@@ -27,14 +27,17 @@ feature 'Offender SAR Case creation by a manager' do
     expect(cases_show_page).to be_displayed
     expect(cases_show_page).to have_content "Mark as ready for vetting"
     expect(cases_show_page).to have_content "Send acknowledgement letter"
+    expect(cases_show_page).to have_content "Preview cover page"
     click_on "Mark as ready for vetting"
 
     expect(cases_show_page).to be_displayed
     expect(cases_show_page).to have_content "Mark as vetting in progress"
+    expect(cases_show_page).to have_content "Preview cover page"
     click_on "Mark as vetting in progress"
 
     expect(cases_show_page).to be_displayed
     expect(cases_show_page).to have_content "Mark as ready to copy"
+    expect(cases_show_page).to have_content "Preview cover page"
     click_on "Mark as ready to copy"
 
     expect(cases_show_page).to be_displayed
@@ -45,7 +48,7 @@ feature 'Offender SAR Case creation by a manager' do
     expect(cases_show_page).to have_content "Send dispatch letter"
     expect(cases_show_page).to have_content "Close case"
     click_on "Close case"
-    
+
     expect(cases_close_page).to be_displayed
     cases_close_page.fill_in_date_responded(offender_sar_case.received_date)
     click_on "Continue"

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -14,11 +14,11 @@ describe ConfigurableStateMachine::Machine do
       },
       {
         state: :ready_for_vetting,
-        specific_events: [:mark_as_vetting_in_progress]
+        specific_events: [:mark_as_vetting_in_progress, :preview_cover_page]
       },
       {
         state: :vetting_in_progress,
-        specific_events: [:mark_as_ready_to_copy]
+        specific_events: [:mark_as_ready_to_copy, :preview_cover_page]
       },
       {
         state: :ready_to_copy,


### PR DESCRIPTION

## Description
We discovered the need to print the cover page at other times than just initially once the data requests are sent, so we need to make available “Print cover sheet” button when case passes into “Ready for vetting” and “Vetting in progress” stage.
## Self-review checklist

<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
BEFORE - no button!

AFTER - button!
![image](https://user-images.githubusercontent.com/1161161/95732075-3b928900-0c78-11eb-9d76-ae8c82a77ca5.png)
![image](https://user-images.githubusercontent.com/1161161/95732098-451bf100-0c78-11eb-8c9f-fd10bf91704c.png)



### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3114

### Deployment
none

### Manual testing instructions
Create an Offender SAR case and progress it; the "Preview cover page option should now be available in the three states `waiting_for_data`, `ready_for_vetting`, `vetting_in_progress`
