### PR TITLE
CT-3119 further cover sheet improvements

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -58,6 +58,7 @@
 @import "moj/component/page_headings";
 @import "moj/component/global_navigation";
 @import "moj/component/case_status";
+@import "moj/component/cover_sheet";
 @import "moj/component/ellipsis";
 @import "moj/component/filter_crumbs";
 @import "moj/component/filters";

--- a/app/assets/stylesheets/moj/component/_cover_sheet.scss
+++ b/app/assets/stylesheets/moj/component/_cover_sheet.scss
@@ -1,0 +1,19 @@
+.cover-sheet {
+
+  &__heading {
+    margin: 15px 0 20px;
+    font-family: "nta", Arial, sans-serif;
+    font-weight: bold;
+    font-size: 80px;
+    line-height: 80px;
+  }
+
+  &__address {
+    font-size: 28px;
+    line-height: 28px;
+  }
+
+  &__section {
+    margin: 20px 0 0;
+  }
+}

--- a/app/assets/stylesheets/moj/component/_page_headings.scss
+++ b/app/assets/stylesheets/moj/component/_page_headings.scss
@@ -10,20 +10,3 @@
   @include core-27();
   color: $secondary-text-colour;
 }
-
-.cover-sheet-heading {
-  margin: 15px 0 40px;
-  font-family: "nta", Arial, sans-serif;
-  font-weight: bold;
-
-  &__name,
-  &__case-number {
-    font-size: 90px;
-    line-height: 100px;
-  }
-
-  &__detail {
-    font-size: 45px;
-    line-height: 60px;
-  }
-}

--- a/app/assets/stylesheets/moj/component/_page_headings.scss
+++ b/app/assets/stylesheets/moj/component/_page_headings.scss
@@ -16,7 +16,8 @@
   font-family: "nta", Arial, sans-serif;
   font-weight: bold;
 
-  &__name {
+  &__name,
+  &__case-number {
     font-size: 90px;
     line-height: 100px;
   }

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -3,46 +3,47 @@
 
 = link_to "Back", case_path(@case), class: 'govuk-back-link'
 
-h1.cover-sheet-heading
-  ul
-    li.cover-sheet-heading__case-number
-      = @case.number
-    li.cover-sheet-heading__name
-      = @case.subject_full_name&.upcase
-    li.cover-sheet-heading__detail
-      = @case.first_prison_number&.upcase
-    li.cover-sheet-heading__detail
-      - if @case.recipient == 'subject_recipient'
-      - else
-        = @case.third_party_relationship + ' - '
-      = @case.recipient_address
+article.cover-sheet
+  h1.cover-sheet__heading
+    ul
+      li
+        = @case.number
+      li
+        = @case.subject_full_name&.upcase
+      li
+        = @case.first_prison_number&.upcase
 
+  p.cover-sheet__address
+    - if @case.recipient == 'subject_recipient'
+    - else
+      = @case.third_party_relationship + ' - '
+    = @case.recipient_address
 
-section.case-info
-  = render partial: 'cases/cover_pages/data_requests', locals: { case_details: @case }
+  section.cover-sheet__section
+    = render partial: 'cases/cover_pages/data_requests', locals: { case_details: @case }
 
-section.case-info.section--vetting
-  table
-    thead
-      th width="50%"
-        = t('cases.cover_sheet.vet_date')
-      th
-        = t('cases.cover_sheet.vet_by')
-    tbody
-      tr
-        td
-          = t('cases.cover_sheet.first_vet_date')
-        td
-          = t('cases.cover_sheet.vetter_name')
-      tr
-        td
-          = t('cases.cover_sheet.second_vet_date')
-        td
-          = t('cases.cover_sheet.vetter_name')
+  section.cover-sheet__section
+    table
+      thead
+        th width="50%"
+          = t('cases.cover_sheet.vet_date')
+        th
+          = t('cases.cover_sheet.vet_by')
+      tbody
+        tr
+          td
+            = t('cases.cover_sheet.first_vet_date')
+          td
+            = t('cases.cover_sheet.vetter_name')
+        tr
+          td
+            = t('cases.cover_sheet.second_vet_date')
+          td
+            = t('cases.cover_sheet.vetter_name')
 
-section.case-info.final-deadline
-  h2.request--heading.heading--final-deadline.print-large
-    = t('cases.cover_sheet.final_deadline')
-    span  #{l @case.external_deadline, format: :default}
+  section.cover-sheet__section
+    h2.request--heading.heading--final-deadline.print-large
+      = t('cases.cover_sheet.final_deadline')
+      span  #{l @case.external_deadline, format: :default}
 
-= link_to "Print cover sheet", "javascript:window.print()", class: "button btn-primary", id: "print-cover-page"
+  = link_to "Print cover sheet", "javascript:window.print()", class: "button btn-primary", id: "print-cover-page"

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -5,12 +5,10 @@
 
 h1.cover-sheet-heading
   ul
-    li.cover-sheet-heading__detail
+    li.cover-sheet-heading__name
       = @case.number
     li.cover-sheet-heading__name
       = @case.subject_full_name&.upcase
-    li.cover-sheet-heading__detail
-      = @case.subject_aliases&.upcase
     li.cover-sheet-heading__detail
       = @case.prison_number&.upcase
 

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -5,7 +5,7 @@
 
 h1.cover-sheet-heading
   ul
-    li.cover-sheet-heading__name
+    li.cover-sheet-heading__case-number
       = @case.number
     li.cover-sheet-heading__name
       = @case.subject_full_name&.upcase

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -10,7 +10,9 @@ h1.cover-sheet-heading
     li.cover-sheet-heading__name
       = @case.subject_full_name&.upcase
     li.cover-sheet-heading__detail
-      = @case.prison_number&.upcase
+      = @case.first_prison_number&.upcase
+    li.cover-sheet-heading__detail
+      = @case.recipient_address
 
 section.case-info
   = render partial: 'cases/cover_pages/data_requests', locals: { case_details: @case }

--- a/app/views/cases/cover_pages/show.html.slim
+++ b/app/views/cases/cover_pages/show.html.slim
@@ -12,7 +12,11 @@ h1.cover-sheet-heading
     li.cover-sheet-heading__detail
       = @case.first_prison_number&.upcase
     li.cover-sheet-heading__detail
+      - if @case.recipient == 'subject_recipient'
+      - else
+        = @case.third_party_relationship + ' - '
       = @case.recipient_address
+
 
 section.case-info
   = render partial: 'cases/cover_pages/data_requests', locals: { case_details: @case }

--- a/spec/site_prism/page_objects/pages/cases/cover_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/cover_page.rb
@@ -14,7 +14,7 @@ module PageObjects
           element :prison_number, 'li:nth-child(3)'
         end
 
-        element :covere_sheet_address, '.cover-sheet__address'
+        element :cover_sheet_address, '.cover-sheet__address'
 
         section :data_requests,
           PageObjects::Sections::Cases::DataRequestsSection, '.data-requests'

--- a/spec/site_prism/page_objects/pages/cases/cover_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/cover_page.rb
@@ -8,12 +8,13 @@ module PageObjects
                 PageObjects::Sections::PrimaryNavigationSection, '.global-nav'
 
         section :page_heading,
-          PageObjects::Sections::PageHeadingSection, '.cover-sheet-heading' do
+          PageObjects::Sections::PageHeadingSection, '.cover-sheet__heading' do
           element :case_number, 'li:first-child'
-          element :subject_full_name, '.cover-sheet-heading__name'
-          element :aliases, 'li:nth-child(3)'
-          element :prison_number, 'li:nth-child(4)'
+          element :subject_full_name, 'li:nth-child(2)'
+          element :prison_number, 'li:nth-child(3)'
         end
+
+        element :covere_sheet_address, '.cover-sheet__address'
 
         section :data_requests,
           PageObjects::Sections::Cases::DataRequestsSection, '.data-requests'

--- a/spec/views/cases/cover_pages/show_html_slim_spec.rb
+++ b/spec/views/cases/cover_pages/show_html_slim_spec.rb
@@ -28,7 +28,7 @@ describe 'cases/cover_pages/show', type: :view do
       expect(@page.page_heading.subject_full_name.text).to eq "#{data_request.kase.subject_full_name&.upcase}"
       expect(@page.page_heading.case_number.text).to eq data_request.kase.number
       expect(@page.page_heading.prison_number.text).to eq data_request.kase.first_prison_number&.upcase
-      expect(@page.covere_sheet_address.text).to eq data_request.kase.recipient_address
+      expect(@page.cover_sheet_address.text).to eq data_request.kase.recipient_address
 
       row = @page.data_requests.rows[0]
       expect(row.location).to have_text 'HMP Leicester'

--- a/spec/views/cases/cover_pages/show_html_slim_spec.rb
+++ b/spec/views/cases/cover_pages/show_html_slim_spec.rb
@@ -27,8 +27,8 @@ describe 'cases/cover_pages/show', type: :view do
     it 'has required content' do
       expect(@page.page_heading.subject_full_name.text).to eq "#{data_request.kase.subject_full_name&.upcase}"
       expect(@page.page_heading.case_number.text).to eq data_request.kase.number
-      expect(@page.page_heading.aliases.text).to eq "#{data_request.kase.subject_aliases&.upcase}"
-      expect(@page.page_heading.prison_number.text).to eq data_request.kase.prison_number
+      expect(@page.page_heading.prison_number.text).to eq data_request.kase.first_prison_number&.upcase
+      expect(@page.covere_sheet_address.text).to eq data_request.kase.recipient_address
 
       row = @page.data_requests.rows[0]
       expect(row.location).to have_text 'HMP Leicester'


### PR DESCRIPTION
## Description
Changes to cover sheet data and style:
- Make case number big
- Show one prison number (using functionality from another branch. (CT-3113)
- show address of recipient, and relationship if 3rd party
- Make it fit on one page when 6 data requests

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
old

![image](https://user-images.githubusercontent.com/22935203/96443430-7d857700-1204-11eb-8ee5-8adc1a38d1b6.png)


new
![image](https://user-images.githubusercontent.com/22935203/96443366-6a72a700-1204-11eb-849b-7d2ab23887d4.png)

one page:

![image](https://user-images.githubusercontent.com/22935203/96443509-a0b02680-1204-11eb-8844-b2d1bb7036fc.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3119

### Deployment
n/a

### Manual testing instructions
Progress Offender SAR case until ready for vetting.
Click on Preview cover page
