### PR TITLE
Change delete/create to apply for cronjob to avoid breaking prod

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -136,8 +136,7 @@ function _deploy() {
 
   if [ $environment == "production" ]
     then
-      kubectl delete cronjob cronjob-delete-old-ecr-images -n $namespace --ignore-not-found=true
-      kubectl create -f config/kubernetes/${environment}/cronjob-delete-old-ecr-images.yaml -n $namespace
+      kubectl apply -f config/kubernetes/${environment}/cronjob-delete-old-ecr-images.yaml -n $namespace
     fi
 }
 


### PR DESCRIPTION
## Description
Deleting Cronjob was forbidden on Circle CI - this can be investigated, but might not be needed.
Changed to Apply first, so Cronjob changes are applied directly to existing Cronjob. If we find this doesn't update the Cronjob correctly then we can investigate further on deleting.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`



### Related JIRA tickets
(This was going to be part of another ticket, but that ticket got archived)

### Deployment
Requires deployment through to production.


