### PR TITLE
Add feature flag for case creation for Offender SAR complaint

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -206,7 +206,7 @@ class CasesController < ApplicationController
       @permitted_correspondence_types += types
     elsif policy(Case::Base).can_manage_offender_sar?
       @permitted_correspondence_types << CorrespondenceType.offender_sar
-      @permitted_correspondence_types << CorrespondenceType.offender_sar_complaint
+      @permitted_correspondence_types << CorrespondenceType.offender_sar_complaint if FeatureSet.offender_sar_complaints.enabled?
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -244,6 +244,13 @@ enabled_features:
     Host-staging: true
     Host-qa: true
     Host-prod: true
+  offender_sar_complaints:
+    Local: true
+    Host-dev: true
+    Host-demo: true
+    Host-staging: false
+    Host-qa: true
+    Host-prod: false
   ico:
     Local: true
     Host-dev: true


### PR DESCRIPTION
## Description
We have quite a clunky mechanism for deciding which correspondence types to display on the case creation menu. Need to make this more rational but just for now, add a feature flag and hide the new correspondence type on Staging and Production. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
BEFORE
![image](https://user-images.githubusercontent.com/1161161/96190299-e8e7f400-0f39-11eb-9a42-9ddb688957b5.png)

AFTER
![image](https://user-images.githubusercontent.com/1161161/96190215-c48c1780-0f39-11eb-9fed-f1fa7fb2908e.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3201

### Deployment
nope

### Manual testing instructions
Don't forget to restart your local server, as the feature flags get loaded at boot time
