### PR TITLE
CT-3215 Ensure assignments are present before trying to build reassign link

### DIFF
--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -73,6 +73,7 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
               class: 'button'
     when :reassign_user
       path = nil
+      return '' unless @assignments.present?
       if @assignments.size > 1
         path = select_team_case_assignments_path(@case, assignment_ids: @assignments.map(&:id).join('+'))
       else

--- a/spec/helpers/cases_helper_spec.rb
+++ b/spec/helpers/cases_helper_spec.rb
@@ -193,6 +193,14 @@ href="/cases/#{@case.id}/assignments/select_team?assignment_ids=#{@assignments.f
                )
         end
       end
+
+      context 'when there are no assignments for this users teams' do
+        it 'returns an empty string' do
+          @case = create(:accepted_case)
+          @assignments = []
+          expect(action_button_for(:reassign_user)).to eq('')
+        end
+      end
     end
 
     context 'when event == :upload_response_and_approve' do


### PR DESCRIPTION
## Description
After moving people/business units around in the CMS and deactivating the "Private Office" team this resulted in some users being unable to view a large number of cases.

On investigation, one problem seemed to be the deactivation of the private office team, which has a specific value for "Code" that had been amended as part of the deactivation. 

We restored the missing team, making no other changes to the database. This restored the ability to access some of the cases but other cases failed with a different problem now. 

[09120983cf00da9c7d7e94c6c5c62bff] ActionView::Template::Error (No route matches {:action=>"reassign_user", :case_id=>"20390", :controller=>"assignments", :id=>nil}, missing required keys: [:id]):

This happens in the cases helper for reassign user when the user has no assignments. The helper assumes there will always be at least one assignment or more, but in this case on production it seems there are none and the helper requires one. This PR adds a guard clause to ensure there is always at least one and return an empty string if not.

This doesn't address the root cause, and there may be further errors. Requires further investigation. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3215

### Deployment
n/a

### Manual testing instructions
n/a
