### PR TITLE
CT-3216 Restore previous team members properly if there is a bad user role

### DIFF
--- a/app/services/team_move_service.rb
+++ b/app/services/team_move_service.rb
@@ -103,8 +103,12 @@ class TeamMoveService
   end
 
   def restore_users_for_old_team
-    @keep_user_roles.each do |ur|
-      TeamsUsersRole.create!(team: Team.find(ur[0]), user: User.find(ur[1]), role: ur[2])
+    @keep_user_roles.each do |team_id, user_id, role|
+      team =  Team.find_by_id(team_id)
+      user = User.find_by_id(user_id)
+      if team && user
+        TeamsUsersRole.create!(team: team, user: user, role: role)
+      end
     end
   end
 end

--- a/spec/services/team_move_service_spec.rb
+++ b/spec/services/team_move_service_spec.rb
@@ -239,6 +239,25 @@ describe TeamMoveService do
           expect(assignments.count).to eq existing_approver_assignments_count
         end
       end
+
+      context 'when the team being moved is has invalid team roles' do
+        let(:disclosure_team) { BusinessUnit.dacu_disclosure }
+        let(:new_user) { create(:user) }
+        let(:disclosure_user) { disclosure_team.users.first }
+        let(:business_unit) { disclosure_team }
+
+        it 'it ignores invalid team roles' do
+          # add a defective user role and a valid user role
+          disclosure_team.user_roles << TeamsUsersRole.new(user_id: nil, role: "responder")
+          disclosure_team.user_roles << TeamsUsersRole.new(user_id: new_user.id, role: "responder")
+          user_count = disclosure_team.users.count
+
+          service.call
+
+          expect(disclosure_team.reload.users.count).to eq user_count
+          expect(disclosure_team.reload.users.last).to eq new_user
+        end
+      end
     end
   end
 end

--- a/spec/services/team_move_service_spec.rb
+++ b/spec/services/team_move_service_spec.rb
@@ -240,13 +240,12 @@ describe TeamMoveService do
         end
       end
 
-      context 'when the team being moved is has invalid team roles' do
+      context 'when the team being moved has invalid team roles' do
         let(:disclosure_team) { BusinessUnit.dacu_disclosure }
         let(:new_user) { create(:user) }
-        let(:disclosure_user) { disclosure_team.users.first }
         let(:business_unit) { disclosure_team }
 
-        it 'it ignores invalid team roles' do
+        it 'restores all valid users for old team' do
           # add a defective user role and a valid user role
           disclosure_team.user_roles << TeamsUsersRole.new(user_id: nil, role: "responder")
           disclosure_team.user_roles << TeamsUsersRole.new(user_id: new_user.id, role: "responder")


### PR DESCRIPTION
## Description
Carry on without breaking the transaction if there is a bad user role

When the team being moved has invalid team roles (e.g where user_id is nil in teams_users_roles) the team move service failed to properly restore the existing users to the deactivated team after those users are moved to the new incarnation. This causes authentication errors on cases wired up to the old team for any users whose team memberships weren't properly copied backwards. 

The service now ignores invalid rows in team_user_roles and restores all valid users for old team, where previously it stopped if one was invalid.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3216

### Deployment
We will need to run a rake task to fix affected users on production

### Manual testing instructions
n/a
