### PR TITLE
Ct 2921 db anonymizer

### DIFF
--- a/app/helpers/s3_bucket_helper.rb
+++ b/app/helpers/s3_bucket_helper.rb
@@ -18,7 +18,7 @@ module S3BucketHelper
 
     def put_object(key, body, metadata: nil)
       client.put_object({
-        bucket: credentials.bucket,
+        bucket: @credentials.bucket,
         key: key,
         acl: 'private',
         body: body,
@@ -28,7 +28,7 @@ module S3BucketHelper
 
     def get_object(key, **args)
       client.get_object(
-        {bucket: credentials.bucket, key: key},
+        {bucket: @credentials.bucket, key: key},
         **args
       )
     end
@@ -38,13 +38,13 @@ module S3BucketHelper
     end
 
     def bucket
-      @bucket ||= Aws::S3::Bucket.new(credentials.bucket, { client: client })
+      @bucket ||= Aws::S3::Bucket.new(@credentials.bucket, { client: client })
     end
 
     def client
       @client ||= Aws::S3::Client.new(
-        access_key_id: credentials.access_key_id,
-        secret_access_key: credentials.secret_access_key
+        access_key_id: @credentials.access_key_id,
+        secret_access_key: @credentials.secret_access_key
       )
     end
 

--- a/app/helpers/s3_bucket_helper.rb
+++ b/app/helpers/s3_bucket_helper.rb
@@ -1,0 +1,52 @@
+# require 'aws-sdk-s3'
+
+module S3BucketHelper
+
+  Credentials = Struct.new(:access_key_id, :secret_access_key, :bucket)
+
+  class S3Bucket
+
+    def initialize(access_key_id, secret_access_key)
+      @credentials = Credentials.new(
+        access_key_id,
+        secret_access_key,
+        Settings.case_uploads_s3_bucket
+      )
+    end
+
+    attr_reader :host
+
+    def put_object(key, body, metadata: nil)
+      client.put_object({
+        bucket: credentials.bucket,
+        key: key,
+        acl: 'private',
+        body: body,
+        metadata: metadata
+      })
+    end
+
+    def get_object(key, **args)
+      client.get_object(
+        {bucket: credentials.bucket, key: key},
+        **args
+      )
+    end
+
+    def list(folder_prefix = nil)
+      bucket.objects({prefix: folder_prefix})
+    end
+
+    def bucket
+      @bucket ||= Aws::S3::Bucket.new(credentials.bucket, { client: client })
+    end
+
+    def client
+      @client ||= Aws::S3::Client.new(
+        access_key_id: credentials.access_key_id,
+        secret_access_key: credentials.secret_access_key
+      )
+    end
+
+  end
+end

--- a/lib/db/database_anonymizer.rb
+++ b/lib/db/database_anonymizer.rb
@@ -215,7 +215,7 @@ class DatabaseAnonymizer
   end
 
   def anonymize_case_overturnedico_foi(kase)
-    kase.ico_officer_name = Faker::Name.name unless ase.ico_officer_name.blank?
+    kase.ico_officer_name = Faker::Name.name unless kase.ico_officer_name.blank?
   end
 
   def anonymize_case_overturnedico_sar(kase)

--- a/lib/db/database_anonymizer.rb
+++ b/lib/db/database_anonymizer.rb
@@ -116,9 +116,8 @@ class DatabaseAnonymizer
         offset = @max_num_of_records_per_group * counter
         limit = @max_num_of_records_per_group
         klass.offset(offset).limit(limit).order(klass.primary_key.to_sym).each do | record |
-          # insert_statement = raw_sql_from_record(record) + ';'
-          insert_statement = raw_sql_from_record(record)
-          fp.puts insert_statement
+          sql_statement = raw_sql_from_record(record)
+          fp.puts sql_statement
         end
 
         sql_settings_end(fp)

--- a/lib/db/database_anonymizer.rb
+++ b/lib/db/database_anonymizer.rb
@@ -1,68 +1,65 @@
 class DatabaseAnonymizer
 
-  $arel_silence_type_casting_deprecation = true
+  attr_reader :tables_to_anonymised
 
-  CLASSES_TO_ANONYMISE = [ Case, User, CaseTransition ]
+  # $arel_silence_type_casting_deprecation = true
 
-  def initialize(filename)
-    @filename = File.expand_path(filename)
+  CLASSES_TO_ANONYMISE = [ Case::Base, User, CaseTransition ]
+
+  def initialize()
     @batch_size = 1_000
+    @tables_to_anonymised = {}
+    CLASSES_TO_ANONYMISE.each { |klass| @tables_to_anonymised[klass.table_name] = klass }
   end
 
   def run
     CLASSES_TO_ANONYMISE.each { |klass| anonymise_class(klass) }
   end
 
-  private
-
-  def anonymise_class(klass)
-    File.open(@filename, 'a') do |fp|
-      klass.find_each(batch_size: @batch_size) do |object|
-        insert_statement = if object.is_a?(Case)
-                             insert_stmt_for_case(object)
-                           elsif object.is_a?(User)
-                             insert_stmt_for_user(object)
-                           elsif object.is_a?(CaseTransition)
-                             insert_stmt_for_case_transition(object)
-                           else
-                             raise "Unexpected object #{object.class}"
-
-                           end
+  def anonymise_class(klass, filename)
+    full_path_filename = File.expand_path(filename)
+    File.open(full_path_filename, 'a') do |fp|
+      sql_settings(fp)
+      klass.find_each(batch_size: @batch_size) do | record |
+        # Handling the main record 
+        insert_statement = raw_sql_from_record(record) + ';'
         fp.puts insert_statement
       end
     end
   end
 
+  private
 
-  def insert_stmt_for_case(object)
-    kase = anonymize_case(object)
-    kase.class.arel_table.create_insert.tap { |im|
-      im.insert(kase.send(:arel_attributes_with_values_for_create, attrs_without_properties(kase)))
-    }.to_sql + ';'
+  def sql_settings(fp)
+    fp.puts "SELECT pg_catalog.set_config('search_path', 'public', false);"
   end
 
-  def insert_stmt_for_user(object)
-    user = anonymize_user(object)
-    user.class.arel_table.create_insert.tap { |im|
-      im.insert(user.send(:arel_attributes_with_values_for_create, user.attribute_names))
-    }.to_sql + ';'
+  # The key function for producing the insert sqls 
+  def raw_sql_from_record(record, related_model: nil)
+    model = related_model || record.class
+    table = model.arel_table
+
+    record = self.send('anonymize_#{table.table_name}', record)
+    values = record.send(:attributes_with_values_for_create, record.class.column_names)
+    model = record.class
+    substitutes_and_binds = model.send(:_substitute_values, values)
+    type_cast(substitutes_and_binds, record)
+
+    insert_manager = table.create_insert
+    insert_manager.insert substitutes_and_binds
+
+    insert_manager.to_sql
   end
 
-  def insert_stmt_for_case_transition(object)
-    ct = anonymise_case_transition(object)
-    ct.class.arel_table.create_insert.tap { |im|
-      im.insert(ct.send(:arel_attributes_with_values_for_create, attrs_without_metadata(ct)))
-    }.to_sql + ';'
+  def type_cast(data, record)
+    data.each do |attribute, value|
+      data[attribute] = record.class.arel_table.type_cast_for_database(attribute.name, value)
+    end
   end
 
-  def attrs_without_properties(object)
-    object.attribute_names - object.properties.keys
-  end
-
-  def attrs_without_metadata(object)
-    object.attribute_names - object.metadata.keys
-  end
-
+  #
+  # The followings are the functions for anonymising specific table/class
+  #
 
   def anonymize_user(user)
     unless user.email =~ /@digital.justice.gov.uk$/
@@ -72,18 +69,103 @@ class DatabaseAnonymizer
     user
   end
 
+  # Anonymize Cases table including all those case types
   def anonymize_case(kase)
     kase.name = Faker::Name.name
     kase.email = Faker::Internet.email(name:kase.name)
     kase.subject = initial_letters(kase.subject) + Faker::Company.catch_phrase
-    kase.message = Faker::Lorem.paragraph
+    kase.message = Faker::Lorem.paragraph unless kase.message.blank?
     kase.postal_address = fake_address unless kase.postal_address.blank?
+
+    # anonymize some fields only relevent to specific case type
+    begin
+      self.send("anonymize_#{kase.class.name.parameterize.underscore}")
+    rescue => exception      
+    end
+
+    # update the search index in the record
+    kase.update_index
     kase
   end
 
+  def anonymize_case_sar_standard(kase)
+    kase.subject_full_name = Faker::Name.name
+  end
+
+  def anonymize_case_sar_offender(kase)
+    kase.subject_full_name = Faker::Name.name
+    kase.subject_aliases = Faker::Name.name unless kase.subject_aliases.blank?
+    kase.case_reference_number = Faker::Code.asin unless kase.case_reference_number.blank?
+    kase.other_subject_ids = fake_subject_ids(kase.other_subject_ids) unless kase.other_subject_ids.blank?
+    kase.prison_number = Faker::Code.asin unless kase.prison_number.blank?
+    kase.requester_reference = "F" + Faker::Invoice.reference unless kase.requester_reference.blank?
+    kase.third_party_company_name = Faker::Company.name unless kase.third_party_company_name.blank?
+  end
+
+  def anonymize_case_ico_foi(kase)
+    kase.ico_officer_name = Faker::Name.name unless kase.ico_officer_name.blank?
+    kase.ico_reference_number = "F" + Faker::Invoice.reference unless kase.ico_reference_number.blank?
+    kase.ico_decision_comment = Faker::TvShows::DrWho.quote unless kase.ico_decision_comment.blank?
+  end
+
+  def anonymize_case_ico_sar(kase)
+    anonymize_case_ico_foi(kase)
+  end
+
+  def anonymize_case_overturnedico_foi(kase)
+    kase.ico_officer_name = Faker::Name.name unless ase.ico_officer_name.blank?
+  end
+  
+  # Anonymize case_transition table
   def anonymise_case_transition(ct)
     ct.message = initial_letters(ct.message) + "\n\n" + Faker::Lorem.paragraph unless ct.message.nil?
     ct
+  end
+
+  # Anonymize case_transition table
+  def anonymise_case_transition(ct)
+    ct.message = initial_letters(ct.message) + "\n\n" + Faker::Lorem.paragraph unless ct.message.nil?
+    ct
+  end
+
+
+  # Anonymize warehouse_case_reports table
+  # This table is difficult one, as it contains the informaton from multiple tables 
+  # like cases, teams, users which cannot be easily cooperated during this anonymization process
+  # The approach is to anonymize this table anyway, it wil cause the inconsistences between this 
+  # table and other main entries table, which can be fixed later by triggering the syncing process manually
+  # after dumping the anonymized data into target database
+  def anonymise_warehouse_case_reports(kase)
+    kase.name = Faker::Name.name unless kase.name.blank?
+    kase.email = Faker::Internet.email(name:kase.name) unless kase.email.blank?
+    kase.sar_subject_full_name = Faker::Name.name unless kase.sar_subject_full_name.blank?
+    kase.casework_officer = Faker::Name.name unless kase.casework_officer.blank?
+    kase.created_by = Faker::Name.name unless kase.created_by.blank?
+    kase.director_general_name = Faker::Name.name unless kase.director_general_name.blank?
+    kase.director_name = Faker::Name.name unless kase.director_name.blank?
+    kase.deputy_director_name = Faker::Name.name unless kase.deputy_director_name.blank?
+    kase.third_party_company_name = Faker::Company.name unless kase.third_party_company_name.blank?
+    kase.postal_address = fake_address unless kase.postal_address.blank?
+    kase.message = Faker::Lorem.paragraph unless kase.message.blank?
+  end
+
+  def anonymise_teams(team)
+    team.email = Faker::Internet.email(name:kase.name) unless team.email.blank?
+  end
+
+  def anonymise_team_properites(tp)
+    tp.key = Faker::Name.name
+    tp.value = Faker::Lorem.sentence
+  end
+
+  def anonymise_data_requests(tp)
+    tp.key = Faker::Name.name
+    tp.value = Faker::Lorem.sentence
+  end
+
+  def anonymise_case_attachments(ca)
+    ca.key = Faker::File.file_name
+    ca.preview_key = Faker::File.file_name
   end
 
   def initial_letters(phrase)
@@ -99,4 +181,12 @@ class DatabaseAnonymizer
         Faker::Address.zip
     ].join("\n")
   end
+
+  def fake_subject_ids(subject_ids_str)
+    subject_ids1 = subject_ids_str.split(",")
+    subject_ids2 = subject_ids_str.split(" ")
+    subject_ids = (subject_ids1.count > subject_ids2.count ? subject_ids1 : subject_ids2)
+    Array.new(subject_ids.count) { Faker::Code.asin }
+  end
+
 end

--- a/lib/db/database_anonymizer.rb
+++ b/lib/db/database_anonymizer.rb
@@ -16,16 +16,19 @@ class DatabaseAnonymizer
     end
 
     private 
-    
+    # The reason for disabling the checking is that 
+    # 'delete' being suggest doesn't remove double quotes I need 
+    # rubocop:disable Performance/StringReplacement
     def process_value(data)
       if data.nil?
         '\N'
       elsif data.is_a? String
-        data.inspect.delete('"', '')
+        data.inspect.gsub('"', '')
       else
         data
       end
     end
+    # rubocop:enable Performance/StringReplacement
 
     def extract_data
       attrs = {}

--- a/lib/db/database_anonymizer.rb
+++ b/lib/db/database_anonymizer.rb
@@ -2,13 +2,96 @@ class DatabaseAnonymizer
 
   attr_reader :tables_to_anonymised
 
-  # $arel_silence_type_casting_deprecation = true
+  CLASSES_TO_ANONYMISE = [ Team, TeamProperty, ::Warehouse::CaseReport, Case::Base, User, CaseTransition, CaseAttachment]
 
-  CLASSES_TO_ANONYMISE = [ Case::Base, User, CaseTransition ]
+  class RecordToCopySql
+    def initialize(record)
+      @record = record
+      @table = record.class.arel_table
+      @type_caster = @table.send(:type_caster)
+    end
 
-  def initialize()
-    @batch_size = 1_000
+    def to_sql
+      compile_to_copy_sql(extract_data)
+    end
+
+    private 
+    
+    def process_value(data)
+      if data.nil?
+        '\N'
+      elsif data.is_a? String
+        data.inspect.gsub('"', '')
+      else
+        data
+      end
+    end
+
+    def extract_data
+      attrs = {}
+      @record.class.column_names.each do | attribute |
+        value = @record._read_attribute(attribute)
+        if value.is_a? Hash
+          value.each do | sub_attr, sub_value |
+            value[sub_attr] = process_value(sub_value) unless sub_value.blank?
+          end
+          attrs[attribute] = @type_caster.type_cast_for_database(attribute, value) 
+        else
+          real_value = @type_caster.type_cast_for_database(attribute, value)
+          attrs[attribute] = process_value(real_value)
+        end
+      end
+      attrs
+    end
+
+    def compile_to_copy_sql(extract_data)
+      extract_data.values().join("\t").gsub("'", '''')
+    end
+  end
+ 
+  class RecordToInsertSql
+
+    def initialize(record)
+      @record = record
+      @table = record.class.arel_table
+      @type_caster = @table.send(:type_caster)
+    end
+
+    def to_sql
+      @table.compile_insert(extract_data).to_sql
+    end
+
+    private 
+    
+
+    def extract_data
+      # note attributes_for_creater is a private method
+      # therefore not great to depend on.
+      # call to it extracted here for later refactor.
+      attribute_names = @record.send(:attributes_for_create, @record.class.column_names)
+
+      attrs = add_values(attribute_names)
+      type_cast(attrs)
+    end
+
+    def type_cast(data)
+      data.each do |attribute, value|
+        data[attribute] = @type_caster.type_cast_for_database(attribute.name, value)
+      end
+    end
+
+    def add_values(attribute_names)
+      attrs = {}
+      @record.class.column_names.each do |name|
+        attrs[@table[name]] = @record._read_attribute(name)
+      end
+      attrs
+    end
+  end
+
+  def initialize(max_num_of_records_per_group=10000)
     @tables_to_anonymised = {}
+    @max_num_of_records_per_group = max_num_of_records_per_group
     CLASSES_TO_ANONYMISE.each { |klass| @tables_to_anonymised[klass.table_name] = klass }
   end
 
@@ -17,51 +100,68 @@ class DatabaseAnonymizer
   end
 
   def anonymise_class(klass, filename)
-    full_path_filename = File.expand_path(filename)
-    File.open(full_path_filename, 'a') do |fp|
-      sql_settings(fp)
-      klass.find_each(batch_size: @batch_size) do | record |
-        # Handling the main record 
-        insert_statement = raw_sql_from_record(record) + ';'
-        fp.puts insert_statement
+    files = []
+    counter = 0
+    number_of_groups = cal_number_of_groups(klass)
+
+    number_of_groups.times do | number |
+      number_file = "%.#{number_of_groups.to_s.length}i" % ( counter + 1 )
+      full_path_filename = File.expand_path("#{filename}.#{number_file}.sql")
+      File.open(full_path_filename, 'a') do |fp|
+        puts full_path_filename
+        files << full_path_filename
+
+        sql_settings_start(fp, klass)
+
+        offset = @max_num_of_records_per_group * counter
+        limit = @max_num_of_records_per_group
+        klass.offset(offset).limit(limit).order(klass.primary_key.to_sym).each do | record |
+          # insert_statement = raw_sql_from_record(record) + ';'
+          insert_statement = raw_sql_from_record(record)
+          fp.puts insert_statement
+        end
+
+        sql_settings_end(fp)
       end
+      counter += 1      
     end
+    files
   end
 
   private
 
-  def sql_settings(fp)
-    fp.puts "SELECT pg_catalog.set_config('search_path', 'public', false);"
+  def cal_number_of_groups(klass)
+    (Float(klass.all.count)/@max_num_of_records_per_group).ceil()
   end
+
+  def sql_settings_start(fp, class_model)
+    # Search path with public space
+    fp.puts "SELECT pg_catalog.set_config('search_path', 'public', false);"
+
+    fp.puts "\n"
+    fp.puts "\n"
+
+    # Set the fields for copy command
+    fp.puts "COPY #{class_model.table_name} ( #{class_model.column_names.join(", ")} ) FROM stdin;"
+  end
+
+  def sql_settings_end(fp)
+    fp.puts '\.'
+    fp.puts "\n"
+    fp.puts "\n"
+end
 
   # The key function for producing the insert sqls 
-  def raw_sql_from_record(record, related_model: nil)
-    model = related_model || record.class
-    table = model.arel_table
-
-    record = self.send('anonymize_#{table.table_name}', record)
-    values = record.send(:attributes_with_values_for_create, record.class.column_names)
-    model = record.class
-    substitutes_and_binds = model.send(:_substitute_values, values)
-    type_cast(substitutes_and_binds, record)
-
-    insert_manager = table.create_insert
-    insert_manager.insert substitutes_and_binds
-
-    insert_manager.to_sql
-  end
-
-  def type_cast(data, record)
-    data.each do |attribute, value|
-      data[attribute] = record.class.arel_table.type_cast_for_database(attribute.name, value)
-    end
+  def raw_sql_from_record(record)
+    record = self.send("anonymize_#{record.class.table_name}", record)
+    RecordToCopySql.new(record).to_sql
   end
 
   #
   # The followings are the functions for anonymising specific table/class
   #
 
-  def anonymize_user(user)
+  def anonymize_users(user)
     unless user.email =~ /@digital.justice.gov.uk$/
       user.full_name = Faker::Name.unique.name
       user.email = Faker::Internet.email(name: user.full_name)
@@ -70,17 +170,17 @@ class DatabaseAnonymizer
   end
 
   # Anonymize Cases table including all those case types
-  def anonymize_case(kase)
-    kase.name = Faker::Name.name
+  def anonymize_cases(kase)
+    kase.name = Faker::Name.name unless kase.class unless kase.class.name.start_with?("Case::ICO")
+    kase.subject = initial_letters(kase.subject) + Faker::Company.catch_phrase unless kase.class.name.start_with?("Case::ICO")
     kase.email = Faker::Internet.email(name:kase.name)
-    kase.subject = initial_letters(kase.subject) + Faker::Company.catch_phrase
     kase.message = Faker::Lorem.paragraph unless kase.message.blank?
     kase.postal_address = fake_address unless kase.postal_address.blank?
 
     # anonymize some fields only relevent to specific case type
     begin
-      self.send("anonymize_#{kase.class.name.parameterize.underscore}")
-    rescue => exception      
+      self.send("anonymize_#{kase.class.name.parameterize.underscore}", kase)
+    rescue => exception
     end
 
     # update the search index in the record
@@ -93,12 +193,14 @@ class DatabaseAnonymizer
   end
 
   def anonymize_case_sar_offender(kase)
+    kase.subject_address = fake_address unless kase.subject_address.blank?
     kase.subject_full_name = Faker::Name.name
     kase.subject_aliases = Faker::Name.name unless kase.subject_aliases.blank?
     kase.case_reference_number = Faker::Code.asin unless kase.case_reference_number.blank?
     kase.other_subject_ids = fake_subject_ids(kase.other_subject_ids) unless kase.other_subject_ids.blank?
     kase.prison_number = Faker::Code.asin unless kase.prison_number.blank?
     kase.requester_reference = "F" + Faker::Invoice.reference unless kase.requester_reference.blank?
+    kase.third_party_name = Faker::Name.name unless kase.third_party_name.blank?
     kase.third_party_company_name = Faker::Company.name unless kase.third_party_company_name.blank?
   end
 
@@ -115,15 +217,13 @@ class DatabaseAnonymizer
   def anonymize_case_overturnedico_foi(kase)
     kase.ico_officer_name = Faker::Name.name unless ase.ico_officer_name.blank?
   end
+
+  def anonymize_case_overturnedico_sar(kase)
+    anonymize_case_overturnedico_foi(kase)
+  end
   
   # Anonymize case_transition table
-  def anonymise_case_transition(ct)
-    ct.message = initial_letters(ct.message) + "\n\n" + Faker::Lorem.paragraph unless ct.message.nil?
-    ct
-  end
-
-  # Anonymize case_transition table
-  def anonymise_case_transition(ct)
+  def anonymize_case_transitions(ct)
     ct.message = initial_letters(ct.message) + "\n\n" + Faker::Lorem.paragraph unless ct.message.nil?
     ct
   end
@@ -135,7 +235,7 @@ class DatabaseAnonymizer
   # The approach is to anonymize this table anyway, it wil cause the inconsistences between this 
   # table and other main entries table, which can be fixed later by triggering the syncing process manually
   # after dumping the anonymized data into target database
-  def anonymise_warehouse_case_reports(kase)
+  def anonymize_warehouse_case_reports(kase)
     kase.name = Faker::Name.name unless kase.name.blank?
     kase.email = Faker::Internet.email(name:kase.name) unless kase.email.blank?
     kase.sar_subject_full_name = Faker::Name.name unless kase.sar_subject_full_name.blank?
@@ -147,30 +247,35 @@ class DatabaseAnonymizer
     kase.third_party_company_name = Faker::Company.name unless kase.third_party_company_name.blank?
     kase.postal_address = fake_address unless kase.postal_address.blank?
     kase.message = Faker::Lorem.paragraph unless kase.message.blank?
+    kase
   end
 
-  def anonymise_teams(team)
-    team.email = Faker::Internet.email(name:kase.name) unless team.email.blank?
+  def anonymize_teams(team)
+    team.email = Faker::Internet.email(name:team.name) unless team.email.blank?
+    team
   end
-
-  def anonymise_team_properites(tp)
+  
+  def anonymize_team_properties(tp)
     tp.key = Faker::Name.name
     tp.value = Faker::Lorem.sentence
+    tp
   end
 
-  def anonymise_data_requests(tp)
-    tp.key = Faker::Name.name
-    tp.value = Faker::Lorem.sentence
+  def anonymize_data_requests(data_request)
+    data_request.request_type_note = Faker::Lorem.sentence
+    data_request
   end
 
-  def anonymise_case_attachments(ca)
-    ca.key = Faker::File.file_name
+  def anonymize_case_attachments(ca)
+    ca.key = Faker::File.file_name + SecureRandom.uuid 
     ca.preview_key = Faker::File.file_name
+    ca
   end
 
   def initial_letters(phrase)
-    words = phrase.split(' ')
-    "[#{words[0..9].map{ |w| w.first.upcase }.join('')}]"
+    # words = phrase.split(' ')
+    # "[#{words[0..9].map{ |w| w.first.upcase }.join('')}]"
+    "[#{Faker::Name.name}]"
   end
 
   def fake_address
@@ -186,7 +291,7 @@ class DatabaseAnonymizer
     subject_ids1 = subject_ids_str.split(",")
     subject_ids2 = subject_ids_str.split(" ")
     subject_ids = (subject_ids1.count > subject_ids2.count ? subject_ids1 : subject_ids2)
-    Array.new(subject_ids.count) { Faker::Code.asin }
+    Array.new(subject_ids.count) { Faker::Code.asin }.join(', ')
   end
 
 end

--- a/lib/db/database_dumper.rb
+++ b/lib/db/database_dumper.rb
@@ -19,7 +19,6 @@ class DatabaseDumper
   end
 
   def run
-    created_at = Time.now.strftime('%Y%m%d-%H%M%S')
     dirname = "./dumps_#{@tag}"
     FileUtils.mkpath(dirname)
 
@@ -49,7 +48,8 @@ class DatabaseDumper
           "table_name" => activerecord_model.table_name, 
           "attributes" => activerecord_model.new.attributes.keys
         }  
-      rescue NotImplementedError  => err
+      rescue NotImplementedError
+        false
       end
     end
     File.open("#{dirname}/#{@tag}_activerecord_models_snapshot.json", "w") do |f|
@@ -127,7 +127,7 @@ class DatabaseDumper
     "#{filename}.sql"
   end
 
-  def upload_to_s3(upload_files, table_name, created_at)
+  def upload_to_s3(compressed_files, table_name, created_at)
     if @s3_bucket
       compressed_files.each do | upload_file |
         @s3_bucket.put_object(

--- a/lib/db/database_dumper.rb
+++ b/lib/db/database_dumper.rb
@@ -1,25 +1,25 @@
 #  This class is to provide easy functin to get the data out of environent and anonymize them
 #  initial plan is to not provide clear option
 #
-#
-# require 'colorize'
-# require 'shell-spinner'
-
 
 class DatabaseDumper
 
   attr_reader :outcome_files
 
-  TABLES_TO_BE_EXCLUDED = ["reports", "search_queries", "sessions"]
+  TABLES_TO_BE_EXCLUDED = ["reports", "search_queries", "sessions", "versions"]
 
-  def initialize(anonymize)
+  def initialize(anonymize, tag, where_to_stored)
     @anonymize = anonymize
+    @anonymizer = nil
     @db_connection_url = ENV['DATABASE_URL'] || 'postgres://localhost/correspondence_platform_development'
     @s3_bucket = S3BucketHelper::S3Bucket.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"])
     @outcome_files = []
+    @tag = tag
+    @where_to_stored = where_to_stored
   end
 
   def run
+    # dump_schema_screenshot
     dump_local_database
     @outcome_files
   end
@@ -28,38 +28,52 @@ class DatabaseDumper
 
   def dump_local_database
     require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_anonymizer')
+    require File.join(Rails.root, 'lib', 'tasks', 'rake_task_helpers', 'dumper_utils')
 
-    @anonymizer = DatabaseAnonymizer.new()
     created_at = Time.now.strftime('%Y%m%d-%H%M%S')
-    base_file_name = "#{Rails.env}_#{created_at}"
-
-    dump_pre_data_tables(base_file_name)
-    # dump_sequences_tables(base_file_name)
-    counter = 2
+    dirname = "./dumps_#{@tag}"
+    FileUtils.mkpath(dirname)
+    base_file_name = "#{dirname}/#{@tag}_#{created_at}"
+    @anonymizer = DatabaseAnonymizer.new()
+    
+    @outcome_files << dump_pre_data_tables(base_file_name)
+    counter = 1
     ActiveRecord::Base.connection.tables.each do | table_name |
       if TABLES_TO_BE_EXCLUDED.include? table_name
         next
       end
 
-      table_base_file_name = "#{base_file_name}_#{counter > 10 ? counter.to_s : '0'+counter.to_s}"
-      byebug
-      if @anonymize && @anonymizer.tables_to_anonymised.keys().include?(table_name)
-
-        table_final_name = @anonymizer.anonymise_class(
-          @anonymizer.tables_to_anonymise[table_name], 
-          table_base_file_name)
-        compressed_file = compress_file(table_final_name)
-        upload_to_s3(compressed_file, table_name, created_at)
-      else
-        table_final_name = dump_single_table(table_name, table_base_file_name)
-        compressed_file = compress_file(table_final_name)
-      end
-
-      @outcome_files << table_final_name
+      puts "exporting data #{table_name}"
+      dump_single_table(table_name, base_file_name, counter, created_at)
       counter += 1
     end 
-    dump_post_data_tables("#{base_file_name}_#{counter}")
+    @outcome_files << dump_post_data_tables("#{base_file_name}_#{counter}")
   end  
+
+  def dump_single_table(table_name, base_file_name, counter, time_stamp)
+    outcome_from_single_tables = []
+    table_base_name = "#{base_file_name}_#{counter >= 10 ? counter.to_s : '0'+counter.to_s}_#{table_name}"
+    if require_to_be_anonymised?(table_name)
+      outcome_from_single_tables = @anonymizer.anonymise_class(
+        @anonymizer.tables_to_anonymised[table_name], table_base_name)
+    else
+      outcome_from_single_tables << dump_single_clear_table(table_name, table_base_name)      
+    end
+    compressed_files = compresssed_files(outcome_from_single_tables)
+    if @where_to_stored == 'bucket'
+      upload_to_s3(compressed_files, table_name, time_stamp)
+    end
+  end
+
+  def compresssed_files(files)
+    results = []
+    files.each { | filename | results << DumperUtils.compress_file(filename) }
+    results
+  end
+
+  def require_to_be_anonymised?(table_name)
+    @anonymize && @anonymizer.tables_to_anonymised.keys().include?(table_name)
+  end
 
   def dump_pre_data_tables(base_file_name)
     filename = "#{base_file_name}_00_pre_data.sql"
@@ -77,21 +91,23 @@ class DatabaseDumper
     filename 
   end
 
-  def dump_single_table(table_name, table_base_file_name)
-    filename = "#{table_base_file_name}_#{table_name}.sql"
-    command_line = "pg_dump #{@db_connection_url} -v --no-owner --no-privileges --no-password --column-inserts --data-only --table=#{table_name} -f #{filename}"
+  def dump_single_clear_table(table_name, filename)
+    # --column-inserts 
+    command_line = "pg_dump #{@db_connection_url} -v --no-owner --no-privileges --no-password --data-only --table=#{table_name} -f #{filename}.sql"
     result = system command_line
     raise 'Unable to execute pg_dump command' unless result == true
-    filename 
+    "#{filename}.sql"
   end
 
-  def upload_to_s3(upload_file, table_name, created_at)
+  def upload_to_s3(upload_files, table_name, created_at)
     if @s3_bucket
-      @s3_bucket.put_object(
-        compressed_file, 
-        File.read(compressed_file), 
-        { "table" => table_name, "created_at" => created_at.to_s}
-      )
+      compressed_files.each do | upload_file |
+        @s3_bucket.put_object(
+          "dumps/#{@tag}/#{upload_file}", 
+          File.read(upload_file), 
+          metadata: { "table" => table_name, "created_at" => created_at.to_s}
+        )
+      end
     end
   end 
 

--- a/lib/db/database_dumper.rb
+++ b/lib/db/database_dumper.rb
@@ -1,127 +1,98 @@
-require 'colorize'
-require 'shell-spinner'
+#  This class is to provide easy functin to get the data out of environent and anonymize them
+#  initial plan is to not provide clear option
+#
+#
+# require 'colorize'
+# require 'shell-spinner'
+
 
 class DatabaseDumper
 
-  HOST_NAMES = {
-    'prod' => 'prod.cts',
-    'demo' => 'demo.cts'
-  }.freeze
+  attr_reader :outcome_files
 
-  ANONYMISED_TABLES = %w( users cases case_transitions versions)
+  TABLES_TO_BE_EXCLUDED = ["reports", "search_queries", "sessions"]
 
-  def initialize(env, host, anonymize)
-    puts "Create SQL dump of #{env} environemnt on host #{host} - run rake db:dump:help for assistance".yellow
-    @ssh_user = ENV['CTS_SSH_USER']
-    exit_with_error('No CTS_SSH_USER environment variable found') if @ssh_user.blank?
-    @env = env
-    @host = host.blank? ? HOST_NAMES[@env] : host
+  def initialize(anonymize)
     @anonymize = anonymize
+    @db_connection_url = ENV['DATABASE_URL'] || 'postgres://localhost/correspondence_platform_development'
+    @s3_bucket = S3BucketHelper::S3Bucket.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"])
+    @outcome_files = []
   end
 
   def run
-    safeguard
-    begin
-      client_filename = dump_local_database
-      compressed_file = compress_file(client_filename)
-      copy_to_container_host(compressed_file)
-      download_compressed_file(compressed_file)
-      remove_files_on_host_and_container(compressed_file)
-      puts "Dumpfile #{ENV['HOME']}/#{compressed_file} created".yellow
-    rescue => err
-      puts err.message
-      puts err.backtrace
-      exit_with_error(err.message)
-    end
-  end
-
-  def self.excluded_anonymised_tables
-    ANONYMISED_TABLES.map{ |x| "--exclude-table-data #{x}"}.join( ' ')
+    dump_local_database
+    @outcome_files
   end
 
   private
 
-  def safeguard
-    puts 'Are you sure you need to do this data dump?'
-    puts ''
-    question_user('is the issue covered with existing feature tests? ')
-    question_user('can you track problem through Kibana? ')
-    question_user('can you recreate the problem locally? ')
-    question_user('can you recreate the problem on staging with an anonymised dump? ')
-    confirm_data_dump
-    verify_password
-  end
-
-  def question_user(query)
-    print query
-    input = STDIN.gets.chomp
-    unless(input.downcase.start_with?('n')) || input.nil?
-      puts 'exiting'
-      exit
-    end
-  end
-
-  def confirm_data_dump
-    print "If you are still certain that you need to make a dump of the database please confirm y/n "
-    input = STDIN.gets.chomp
-    exit unless(input.downcase.start_with?('y')) || input.nil?
-  end
-
-  def verify_password
-    sudo_command = "sudo -v"
-    result = system sudo_command
-    exit unless result == true
-  end
-
   def dump_local_database
-    filename = "#{Time.now.strftime('%Y%m%d-%H%M%S')}_#{@env}_dump.sql"
-    ssh_command = "ssh #{@ssh_user}@#{@host} sudo docker exec correspondence-staff rake db:dump:local[#{filename},#{@anonymize}]"
-    puts "Executing: #{ssh_command}"
-    result = system ssh_command
-    raise 'Unable to execute SSH command' unless result == true
-    filename
+    require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_anonymizer')
+
+    @anonymizer = DatabaseAnonymizer.new()
+    created_at = Time.now.strftime('%Y%m%d-%H%M%S')
+    base_file_name = "#{Rails.env}_#{created_at}"
+
+    dump_pre_data_tables(base_file_name)
+    # dump_sequences_tables(base_file_name)
+    counter = 2
+    ActiveRecord::Base.connection.tables.each do | table_name |
+      if TABLES_TO_BE_EXCLUDED.include? table_name
+        next
+      end
+
+      table_base_file_name = "#{base_file_name}_#{counter > 10 ? counter.to_s : '0'+counter.to_s}"
+      byebug
+      if @anonymize && @anonymizer.tables_to_anonymised.keys().include?(table_name)
+
+        table_final_name = @anonymizer.anonymise_class(
+          @anonymizer.tables_to_anonymise[table_name], 
+          table_base_file_name)
+        compressed_file = compress_file(table_final_name)
+        upload_to_s3(compressed_file, table_name, created_at)
+      else
+        table_final_name = dump_single_table(table_name, table_base_file_name)
+        compressed_file = compress_file(table_final_name)
+      end
+
+      @outcome_files << table_final_name
+      counter += 1
+    end 
+    dump_post_data_tables("#{base_file_name}_#{counter}")
+  end  
+
+  def dump_pre_data_tables(base_file_name)
+    filename = "#{base_file_name}_00_pre_data.sql"
+    command_line = "pg_dump #{@db_connection_url} -v --no-owner --no-privileges --no-password -O --section=pre-data -f #{filename}"
+    result = system command_line
+    raise 'Unable to execute pg_dump command' unless result == true
+    filename 
   end
 
-  def compress_file(filename)
-    ssh_command = "ssh #{@ssh_user}@#{@host} sudo docker exec correspondence-staff gzip  -3 -f #{filename}"
-    puts "Executing: #{ssh_command}"
-    result = system ssh_command
-    raise 'Unable to execute SSH command' unless result == true
-    filename + '.gz'
+  def dump_post_data_tables(base_file_name)
+    filename = "#{base_file_name}_post_data.sql"
+    command_line = "pg_dump #{@db_connection_url} -v --no-owner --no-privileges --no-password -O --section=post-data -f #{filename}"
+    result = system command_line
+    raise 'Unable to execute pg_dump command' unless result == true
+    filename 
   end
 
-  def copy_to_container_host(filename)
-    ssh_command = "ssh #{@ssh_user}@#{@host} sudo docker cp correspondence-staff:/usr/src/app/#{filename} ."
-    puts "Executing: #{ssh_command}"
-    result = system ssh_command
-    raise 'Unable to execute SSH command' unless result == true
+  def dump_single_table(table_name, table_base_file_name)
+    filename = "#{table_base_file_name}_#{table_name}.sql"
+    command_line = "pg_dump #{@db_connection_url} -v --no-owner --no-privileges --no-password --column-inserts --data-only --table=#{table_name} -f #{filename}"
+    result = system command_line
+    raise 'Unable to execute pg_dump command' unless result == true
+    filename 
   end
 
-  def download_compressed_file(compressed_file)
-    puts 'Downloading dump file %s from host %s' % [compressed_file, @host]
-    scp_command = "scp #{@ssh_user}@#{@host}:#{compressed_file} #{ENV['HOME']}/"
-    puts "Executing: #{scp_command}"
-    result = system scp_command
-    raise 'Unable to execute SSH command' unless result == true
-  end
-
-  def remove_files_on_host_and_container(compressed_file)
-    ssh_command = "ssh #{@ssh_user}@#{@host} sudo docker exec correspondence-staff rm /usr/src/app/#{compressed_file}"
-    puts "Executing: #{ssh_command}"
-    system ssh_command
-
-    ssh_command = "ssh #{@ssh_user}@#{@host} rm #{compressed_file}"
-    puts "Executing: #{ssh_command}"
-    result = system ssh_command
-    raise 'Unable to execute SSH command' unless result == true
-  end
-
-  def exit_with_error(message)
-    puts message.red
-    Rake::Task['db:dump:help'].invoke
-    exit 2
-  end
-
-
+  def upload_to_s3(upload_file, table_name, created_at)
+    if @s3_bucket
+      @s3_bucket.put_object(
+        compressed_file, 
+        File.read(compressed_file), 
+        { "table" => table_name, "created_at" => created_at.to_s}
+      )
+    end
+  end 
 
 end

--- a/lib/db/database_dumper.rb
+++ b/lib/db/database_dumper.rb
@@ -19,20 +19,34 @@ class DatabaseDumper
   end
 
   def run
-    # dump_schema_screenshot
-    dump_local_database
+    created_at = Time.now.strftime('%Y%m%d-%H%M%S')
+    dirname = "./dumps_#{@tag}"
+    FileUtils.mkpath(dirname)
+
+    dump_schema_snapshot(dirname)
+    dump_data_models_snapshot(dirname)
+    dump_local_database(dirname)
     @outcome_files
   end
 
   private
 
-  def dump_local_database
+  def dump_schema_snapshot(dirname)
+    filename = "#{dirname}/#{@tag}_database_schema_snapshot.sql"
+    command_line = "pg_dump #{@db_connection_url} -v --no-owner --no-privileges --no-password -s -f #{filename}"
+    result = system command_line
+    raise 'Unable to execute pg_dump command' unless result == true
+    filename
+  end
+
+  def dump_data_models_snapshot(dirname)
+    
+  end
+
+  def dump_local_database(dirname)
     require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_anonymizer')
     require File.join(Rails.root, 'lib', 'tasks', 'rake_task_helpers', 'dumper_utils')
 
-    created_at = Time.now.strftime('%Y%m%d-%H%M%S')
-    dirname = "./dumps_#{@tag}"
-    FileUtils.mkpath(dirname)
     base_file_name = "#{dirname}/#{@tag}_#{created_at}"
     @anonymizer = DatabaseAnonymizer.new()
     

--- a/lib/db/database_dumper.rb
+++ b/lib/db/database_dumper.rb
@@ -31,7 +31,7 @@ class DatabaseDumper
   private
 
   def dump_schema_snapshot(dirname)
-    filename = "#{dirname}/#{@tag}_database_schema_snapshot.sql"
+    filename = "#{dirname}/#{@tag}_database_schema_snapshot.snap"
     command_line = "pg_dump #{@db_connection_url} -v --no-owner --no-privileges --no-password -s -f #{filename}"
     result = system command_line
     raise 'Unable to execute pg_dump command' unless result == true

--- a/lib/tasks/db_dump.rake
+++ b/lib/tasks/db_dump.rake
@@ -54,7 +54,7 @@ namespace :db do
 
 
     desc 'makes a sql dump of the production database and copies to the local machine'
-    task :prod, [:host] do |_task, args|
+    task :prod do |_task|
       require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
       safeguard
       chosen_first_pod = get_first_pod("production")
@@ -174,7 +174,7 @@ namespace :db do
       require 'open3'
 
       pod_name = nil
-      output = Open3.popen3("kubectl get pods -n track-a-query-development") { |stdin, stdout, stderr, wait_thr| stdout.read }
+      output = Open3.popen3("kubectl get pods -n track-a-query-#{working_env}") { |_, stdout, _, _| stdout.read }
       if output.present?
         output_lines = output.split('\n')
         if output_lines.count >= 2

--- a/lib/tasks/db_dump.rake
+++ b/lib/tasks/db_dump.rake
@@ -1,71 +1,152 @@
 
+# This taks is to provide the following 3 functions
+# - dumper dump clear DB as compressed-sql files from remote env to local  
+#   the assumption for use this command to do this is to run it on your local env and you need to have the 
+#   the permission to access those environment and it is via kubectl exec command
+#   This part is based on the existing codes with  changes from ssh to kubectl exec command
+# - anonymizer: dump anonymised db as compressed-sql files against local db from remote env or local db with options to upload 
+#   to s3 buckets 
+#   This part is not take environment as the input, if you want to run it on remote pod but from local env please use other 
+#   facilities to run it e.g. kubectl exec
+# 
+#   The process of db anoymizer is below
+#     - dump the basic data out of target database 
+#     - dump the data out of db per table base
+#       - check whether this table is within the tables which require anonymised
+#       - if does, then call anon
+#       - compress the outcome 
+#       - if the env is remote, then upload into s3 bucket.
+# - bucket_downloader
+#   Download the  
+# - restorer 
+#    restore the sql files into target db (non-prod env) 
+#    -- drop the schema at target table
+#    -- import the data per table bases into the target the db
+#    -- run migratoins
+#    -- run udpate for search index
+#    -- restart the instances
+#    -- not sure whether we need to reindex at database level
+
+#   Safegurd checking 
+#   - manul checking list
+#   - auto-checking approach 
+#     e.g. - any database schema changes and the data model's attributes changes
+#      keep the latest coppy of schema and the data model structure 
+#      scan current db schema and data models structure
+#      calculate the hash value/ md5_sum values based on the content of current and latest copy
+#      if different, then die out 
+#      The only way which can fix this problem is to run separated task to update the copy in the cloud
+require 'open3'
+# require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
+
+
 namespace :db do
   namespace :dump  do
 
     desc 'Help text for rake db:dump:* tasks'
     task :help do
       puts 'rake db:dump:<environment> will produce an SQL dump of the database from the '.yellow
-      puts ' specified environment (prod, demo, staging).'.yellow
-      puts ' '
-      puts 'SSH username:'.yellow
-      puts 'The ssh username used to connect to the remote server must be specified in the'.yellow
-      puts 'CTS_SSH_USER environment variable.'.yellow
-      puts ' '
-      puts 'Hostname:'.yellow
-      puts 'The hostname or IP address can be specified as a parameter, for example'.yellow
-      puts ' '
-      puts '   rake db:dump:demo[123.202.5.66]'.yellow
-      puts ' '
-      puts 'or the following hostnames will be assumed if none specified:'.yellow
-      puts '  prod      prod.cts'.yellow
-      puts '  demo      demo.cts'.yellow
-      puts '  staging   stage.cts'.yellow
+      puts 'rake db:dump:anonymized will process anonymisation again the database the current env/pod connects with '.yellow
+      puts 'rake db:dump:download will download'.yellow
+      puts 'rake db:dump:restore will process restore '.yellow
+      # puts 'rake db:dump:<environment> will produce an SQL dump of the database from the '.yellow
+      # puts ' specified environment (prod, demo, staging).'.yellow
+      # puts ' '
+      # puts 'SSH username:'.yellow
+      # puts 'The ssh username used to connect to the remote server must be specified in the'.yellow
+      # puts 'CTS_SSH_USER environment variable.'.yellow
+      # puts ' '
+      # puts 'Hostname:'.yellow
+      # puts 'The hostname or IP address can be specified as a parameter, for example'.yellow
+      # puts ' '
+      # puts '   rake db:dump:demo[123.202.5.66]'.yellow
+      # puts ' '
+      # puts 'or the following hostnames will be assumed if none specified:'.yellow
+      # puts '  prod      prod.cts'.yellow
+      # puts '  demo      demo.cts'.yellow
+      # puts '  staging   stage.cts'.yellow
     end
 
 
     desc 'makes a sql dump of the production database and copies to the local machine'
     task :prod, [:host] do |_task, args|
-      require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
-      DatabaseDumper.new('prod', args[:host], 'anon').run
+      # require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
+      safeguard
+      chosen_first_pod = get_first_pod("production")
+      raise "Cannot find the available pod from this env" unless chosen_first_pod.present?
+
+      prefix_command = "kubectl exec -it #{chosen_first_pod} -n track-a-query-production -c webapp "
+      dump_files = DatabaseDumper.new(true).run
+      dump_files.each do | compressed_file |
+        download_compressed_file(compressed_file, "track-a-query-production", chosen_first_pod)
+        remove_files_on_container(compressed_file, prefix_command: prefix_command)
+      end
     end
 
-    desc 'makes an sql dump of the database on the demo environement to the local machine'
-    task :demo, [:host] do |_task, args|
-      require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
-      DatabaseDumper.new('demo', args[:host], 'clear').run
-    end
+    # desc 'makes an sql dump of the database on the demo environement to the local machine'
+    # task :demo, [:host] do |_task, args|
+    #   # require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
+    #   DatabaseDumper.new('demo', args[:host], 'clear').run
+    # end
 
-
-    desc 'makes an sql dump of the database on the staging environment to the local machine'
-    task :staging, [:host] do |_task, args|
-      require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
-      DatabaseDumper.new('demo', args[:host], 'clear').run
-    end
+    # desc 'makes an sql dump of the database on the staging environment to the local machine'
+    # task :staging, [:host] do |_task, args|
+    #   # require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
+    #   DatabaseDumper.new('demo', args[:host], 'clear').run
+    # end
 
     desc 'makes an anonymised dump of the local database'
-    task :local, [:filename, :anonymized] => :environment do |_task, args|require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
-      require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_anonymizer')
-      filename = args[:filename]
-      raise "Must specify a filename" if filename.blank?
+    task :local, [:anonymized] => :environment do |_task, args|
+      require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_dumper')
       raise "Second argument must be 'anon' or 'clear', is: #{args[:anonymized]}" unless args[:anonymized].in?(%w( anon clear ))
-      db_connection_url = ENV['DATABASE_URL'] || 'postgres://localhost/correspondence_platform_development'
-      if args[:anonymized] == 'anon'
-        ShellSpinner 'exporting unanonymised database data' do
-          system "pg_dump #{db_connection_url} #{DatabaseDumper.excluded_anonymised_tables} --insert -f #{filename}"
-        end
-        ShellSpinner 'adding anonymised tables' do
-          DatabaseAnonymizer.new(filename).run
-        end
-      else
-        ShellSpinner 'exporting unanonymised database data' do
-          system "pg_dump #{db_connection_url} --insert -f #{filename}"
-        end
+      ShellSpinner 'exporting unanonymised database data' do
+        DatabaseDumper.new(args[:anonymized] == 'anon').run
       end
-
     end
+
+    private
+
+    def safeguard
+      puts 'Are you sure you need to do this data dump?'
+      puts ''
+      question_user('is the issue covered with existing feature tests? ')
+      question_user('can you track problem through Kibana? ')
+      question_user('can you recreate the problem locally? ')
+      question_user('can you recreate the problem on staging with an anonymised dump? ')
+      confirm_data_dump
+      verify_password
+    end
+
+    def question_user(query)
+      print query
+      input = STDIN.gets.chomp
+      unless(input.downcase.start_with?('n')) || input.nil?
+        puts 'exiting'
+        exit
+      end
+    end
+
+    def confirm_data_dump
+      print "If you are still certain that you need to make a dump of the database please confirm y/n "
+      input = STDIN.gets.chomp
+      exit unless(input.downcase.start_with?('y')) || input.nil?
+    end
+
+    def get_first_pod(working_env)
+      pod_name = nil
+      output = Open3.popen3("kubectl get pods -n track-a-query-development") { |stdin, stdout, stderr, wait_thr| stdout.read }
+      if output.present?
+        output_lines = output.split('\n')
+        if output_lines.count >= 2
+          pod_name = output_lines[1].split(' ')[0].delete(' ')
+        end 
+      end
+      pod_name
+    end
+
   end
 
-  namespace :load do
+  namespace :restore do
     desc 'Loads an SQL dump of the database created by db:dump:<env> rake task to the local database'
     task :local, [:file] => :environment do |_task, args|
       require File.expand_path(File.dirname(__FILE__) + '/../../lib/db/database_loader')

--- a/lib/tasks/rake_task_helpers/dumper_utils.rb
+++ b/lib/tasks/rake_task_helpers/dumper_utils.rb
@@ -1,37 +1,46 @@
 module DumperUtils
 
-  def shell_working message = 'working', &block
+  def self.shell_working message = 'working', &block
     ShellSpinner message do
       yield
     end
   end
 
-  def download_compressed_file(compressed_file, name_space, chosen_pod)
+  def self.download_compressed_file(compressed_file, name_space, chosen_pod)
     shell_working 'Downloading dump file %s from host %s' % [compressed_file, @host] do
       result  = system "kubectl cp #{name_space}/#{chosen_pod}:/usr/src/app/#{compressed_file}, ./#{compressed_file}"
+      raise 'Unable to execute cp command' unless result == true
     end
-    raise 'Unable to execute cp command' unless result == true
   end
 
-  def remove_files_on_container(compressed_file, prefix_command: nil)
+  def self.remove_files_on_container(compressed_file, prefix_command: nil)
     shell_working "removing file #{compressed_file}" do
-      result  = system "#{prefix_command.present? prefix_command + " " : ""}rm /usr/src/app/#{compressed_file}"
+      result  = system "#{prefix_command.present? ? prefix_command + ' ' : ''}rm /usr/src/app/#{compressed_file}"
+      raise 'Unable to execute rm command' unless result == true
     end
-    raise 'Unable to execute rm command' unless result == true
   end
 
-  def exit_with_error(message)
-    puts message.red
-    Rake::Task['db:dump:help'].invoke
-    exit 2
-  end
-
-  def compress_file(filename, prefix_command: nil)
-    shell_working "compressing file #{filename}" do
-      result  = system "#{prefix_command.present? prefix_command + " " : ""}gzip -3 -f #{filename}"
+  def self.compress_file(filename, prefix_command: nil)
+    result = false
+    ShellSpinner "compressing file #{filename}" do
+      result  = system "#{prefix_command.present? ? prefix_command + '' : ''}gzip -3 -f #{filename}"
     end
     raise 'Unable to execute gzip command' unless result == true
     "#{filename}.gz"
   end
 
+  def self.decompress_file(filename)
+    shell_working "decompressing file #{filename}" do
+      system "gunzip -3 -f #{filename}"
+    end
+  end
+
+  def self.question_user(query)
+    print query
+    input = STDIN.gets.chomp
+    if (input.downcase.start_with?('n')) || input.nil?
+      puts 'exiting'
+      exit
+    end
+  end
 end

--- a/lib/tasks/rake_task_helpers/dumper_utils.rb
+++ b/lib/tasks/rake_task_helpers/dumper_utils.rb
@@ -1,0 +1,37 @@
+module DumperUtils
+
+  def shell_working message = 'working', &block
+    ShellSpinner message do
+      yield
+    end
+  end
+
+  def download_compressed_file(compressed_file, name_space, chosen_pod)
+    shell_working 'Downloading dump file %s from host %s' % [compressed_file, @host] do
+      result  = system "kubectl cp #{name_space}/#{chosen_pod}:/usr/src/app/#{compressed_file}, ./#{compressed_file}"
+    end
+    raise 'Unable to execute cp command' unless result == true
+  end
+
+  def remove_files_on_container(compressed_file, prefix_command: nil)
+    shell_working "removing file #{compressed_file}" do
+      result  = system "#{prefix_command.present? prefix_command + " " : ""}rm /usr/src/app/#{compressed_file}"
+    end
+    raise 'Unable to execute rm command' unless result == true
+  end
+
+  def exit_with_error(message)
+    puts message.red
+    Rake::Task['db:dump:help'].invoke
+    exit 2
+  end
+
+  def compress_file(filename, prefix_command: nil)
+    shell_working "compressing file #{filename}" do
+      result  = system "#{prefix_command.present? prefix_command + " " : ""}gzip -3 -f #{filename}"
+    end
+    raise 'Unable to execute gzip command' unless result == true
+    "#{filename}.gz"
+  end
+
+end

--- a/lib/tasks/rake_task_helpers/dumper_utils.rb
+++ b/lib/tasks/rake_task_helpers/dumper_utils.rb
@@ -1,6 +1,6 @@
 module DumperUtils
 
-  def self.shell_working message = 'working', &block
+  def self.shell_working message = 'working'
     ShellSpinner message do
       yield
     end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to provide the foundation for db anonymizer, this codes are based on existing script and the db anonymizer from CCCD projects.  

The tasks being implementation is below 
      rake db:dump:prod will produce an SQL dump of the database from the production env
         ---> haven't be tested yet
      rake db:dump:local will dump and anonymize again the database the current env/pod connects with
        ---> tested locally
      rake db:dump:list_s3_dumps will list all the files under dumps folder
        ---> tested partially on cloud env
      rake db:dump:delete_s3_dumps will delete all the files under dumps folder
        ---> tested partially on cloud env
      rake db:dump:copy_s3_dump will download all the files under dumps folder
        ---> tested partially on cloud env
      rake db:dump:decompress will decompress alt the gz files under dumps folder
        ---> tested locally
      rake db:dump:restore will process restore '.yellow
        ---> tested locally

The scope of tables and fields which will be anonymsed or be skipped can be found in the Jira ticket

Some concepts in this implementation 
1 - tagging:  in most of the tasks,  "tag" argument will be asked, the default is "latest", this concept is common in github branch management
    it allows us to produce dump-files for different purpose. The restoring process is based on "latest" tag by default 
2 - snapshots for current database and data-model structure.  2 snapshots will be produced. Those will be the approach I want to validate whether any changes happens compared with last time dumping.

The artefacts being produced from the anoymiszation is 
1 - Folder structure
   - `dumps_<tag>`
     -- `<tag>_database_schema_snapshot.sql`
     -- `<tag>_activerecord_models_snapshot.json`
     -- `<tag>_<time_stamp>_<order>_pre_data.sql`
     -- `<tag>_<time_stamp>_<order>_<table_name>.<sub_group>.sql` (will be compressed, then extention will be .gz)
     -- `<tag>_<time_stamp>_<order>_post_data.sql`
2 - the snapshots about the current structure of our database and data models
3 - The bunch of sql files 
   - pre-data section
   - data copy sql per table ( if the number of records is beyond 10000, a sequence of files will be produced)
   - post-data section

The key pattern when uploading into s2 buckets is 
/dumps/<tag>/<filename, the same as the one mentioned above> with the following metadata 
metadata: { "table" => <table_name>, "created_at" => <time_stamp>}


Improvements in the future
1 - Implement the validation process based on the snapshots 
2 - Implement the deploy process by using kubernetes commands for cloud env

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
Test it locally
1 - rake db:dump:local[anon,,local]
2 - rake db:dump:decompress[latest]
3 - rake db:restore:local[latest]