### PR TITLE
CT-3220 excluded deactivated team from approving team

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ control aspects of the build. The available build arguments are:
   to generate a PDF preview (libreoffice).
 
 #### Generating Documentation
-
+ 
 You can generate documentation for the project with:
 
 ```

--- a/app/models/teams_users_role.rb
+++ b/app/models/teams_users_role.rb
@@ -21,4 +21,5 @@ class TeamsUsersRole < ApplicationRecord
   scope :manager_roles,   -> { where(role: :manager)  }
   scope :responder_roles, -> { where(role: :responder) }
   scope :approver_roles,  -> { where(role: :approver) }
+  scope :active_approver_roles,  -> { where(role: :approver).joins(:team).where("teams": {deleted_at: nil}) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
            -> { responder_roles  },
            class_name: 'TeamsUsersRole'
   has_one :approving_team_roles,
-           -> { approver_roles  },
+           -> { active_approver_roles  },
            class_name: 'TeamsUsersRole'
   has_many :managing_teams, through: :managing_team_roles, source: :team
   has_many :responding_teams, through: :responding_team_roles, source: :team

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -118,6 +118,19 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'has_one: approving_team' do
+    it "returns the first active approving team" do
+      current_approving_team = approver.approving_team
+      new_team = create :business_unit, correspondence_type_ids: [foi.id]   
+      approver.team_roles << TeamsUsersRole.new(team: new_team, role: 'approver')
+      approver.reload
+      current_approving_team.deleted_at = Time.now
+      current_approving_team.save!
+      approver.reload
+      expect(approver.approving_team).to eq new_team
+    end
+  end
+
   describe '#roles' do
     it 'returns the roles given users' do
       expect(manager.roles).to eq ['manager']

--- a/spec/services/team_move_service_spec.rb
+++ b/spec/services/team_move_service_spec.rb
@@ -231,12 +231,16 @@ describe TeamMoveService do
           existing_approver_assignments_count = assignments.count
           expect(assignments.first.user).to eq disclosure_user
           expect(assignments.count).to eq existing_approver_assignments_count
+          expect(disclosure_user.approving_team).to eq business_unit
 
           service.call
 
+          disclosure_user.reload
           assignments = kase.approver_assignments.for_team(BusinessUnit.dacu_disclosure)
           expect(assignments.first.user).to eq disclosure_user
           expect(assignments.count).to eq existing_approver_assignments_count
+          expect(disclosure_user.teams).to eq [business_unit, service.new_team]
+          expect(disclosure_user.approving_team).to eq service.new_team
         end
       end
 


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to fix the permission issue of Will and Kashan on triggered FOI cases as approver in Disclosure team due to the partial of failure of team movement. 
The issue we found was that the approving_team derived from those users returned the old team, the deactivated Disclosure team, not the new one, although they both are perfectly in the new disclosure team too.  we discovered the assumption for returning this approving team from user before this fix was 
1 - The approving team for a user should only have one 
2 - If the approving team gets moved (which will cause the users will be in 2 teams, one is the deactivated one, one is the new one, the new one is the copy of old new),  then top one should be the new team
Because of the partial failure and re-correction action happened afterwards,  the assumption is broken.  This fix is to exclude those deactivate ones which we believe is the correct logic it should be 

I added a new spec in user model to covering this change,   also added some extra checking in team_moving_service_spec to make sure the logic being fulfilled.  Those extra checking in the old logic will failure ( it seems to me we never really test this logic properly before)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3220
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
Happy path ( not sure how to create a situation we had in live)
1 - Create a new Directorates
2 - move the disclosure team into new directorates
3 - login as approver in the disclosure team 
4 - check whether you can still see the cases under "New cases", you can take on case and assign another  team member