### PR TITLE
CT-3266 FOI appeals scope change and SAR (monthly) exclude TMM

### DIFF
--- a/app/services/stats/case_selector.rb
+++ b/app/services/stats/case_selector.rb
@@ -27,9 +27,7 @@ module Stats
     end
 
     def ids_for_period_appeals(period_start, period_end)
-      closed_case_ids =  @scope.where(date_responded: [period_start..period_end]).pluck(:id)
-      open_case_ids = @scope.opened.pluck(:id)
-      (closed_case_ids + open_case_ids).uniq
+      @scope.where(received_date: [period_start..period_end]).pluck(:id)
     end
 
     def ids_for_appeals_received_in_period(period_start, period_end)

--- a/app/services/stats/r002_appeals_performance_report.rb
+++ b/app/services/stats/r002_appeals_performance_report.rb
@@ -24,7 +24,7 @@ module Stats
 
     def case_ids
       ir_case_ids = CaseSelector.new(Case::FOI::InternalReview.all).ids_for_period_appeals(@period_start, @period_end)
-      ico_case_ids = CaseSelector.new(Case::ICO::Base.all).ids_for_period_appeals(@period_start, @period_end)
+      ico_case_ids = CaseSelector.new(Case::ICO::FOI.all).ids_for_period_appeals(@period_start, @period_end)
       ir_case_ids + ico_case_ids
     end
 

--- a/app/services/stats/r105_sar_monthly_performance_report.rb
+++ b/app/services/stats/r105_sar_monthly_performance_report.rb
@@ -10,7 +10,10 @@ module Stats
     end
 
     def case_scope
-      Case::SAR::Standard.where(received_date: @period_start..@period_end)
+      tmm = CaseClosure::RefusalReason.tmm
+      Case::SAR::Standard
+        .where('refusal_reason_id IS NULL OR refusal_reason_id != ?', tmm.id)
+        .where(received_date: @period_start..@period_end)
     end
 
     def report_type

--- a/spec/services/stats/r002_appeals_performance_report_spec.rb
+++ b/spec/services/stats/r002_appeals_performance_report_spec.rb
@@ -222,8 +222,6 @@ module Stats # rubocop:disable Metrics/ModuleLength
 
       it 'should produce rag ratings' do
         Timecop.freeze Time.new(2017, 6, 30, 12, 0, 0) do
-
-          actual_lines = report_csv.map { |row| row.map(&:value) }
           rag_ratings = report_csv.map do |row|
             row.map.with_index { |item, index| [index, item.rag_rating] if item.rag_rating }.compact
           end

--- a/spec/services/stats/r002_appeals_performance_report_spec.rb
+++ b/spec/services/stats/r002_appeals_performance_report_spec.rb
@@ -65,16 +65,6 @@ module Stats # rubocop:disable Metrics/ModuleLength
 
         create_ico(type: :sar, received: '20170601', responded: '20170628', deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - responded late')
         create_ico(type: :sar, received: '20170604', responded: '20170629', deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - responded late')
-        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - open late')
-        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - open late')
-        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170702', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - open in time')
-        # create_ico(type: :sar, received: '20170606', responded: '20170625', deadline: '20170630', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - responded in time')
-        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170625', team: @team_b, responder: @responder_b, ident: 'ico sar for team b - open late')
-        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170702', team: @team_b, responder: @responder_b, ident: 'ico sar for team b - open in time')
-        # create_ico(type: :sar, received: '20170607', responded: '20170620', deadline: '20170625', team: @team_b, responder: @responder_b, ident: 'ico sar for team b - responded in time')
-        # create_ico(type: :sar, received: '20170604', responded: '20170629', deadline: '20170625', team: @team_c, responder: @responder_c, ident: 'ico sar for team c - responded late')
-        # create_ico(type: :sar, received: '20170606', responded: '20170625', deadline: '20170630', team: @team_c, responder: @responder_c, ident: 'ico sar for team c - responded in time')
-        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170702', team: @team_d, responder: @responder_d, ident: 'ico sar for team d - open in time')
       end
 
       ###############

--- a/spec/services/stats/r002_appeals_performance_report_spec.rb
+++ b/spec/services/stats/r002_appeals_performance_report_spec.rb
@@ -65,16 +65,16 @@ module Stats # rubocop:disable Metrics/ModuleLength
 
         create_ico(type: :sar, received: '20170601', responded: '20170628', deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - responded late')
         create_ico(type: :sar, received: '20170604', responded: '20170629', deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - responded late')
-        create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - open late')
-        create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - open late')
-        create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170702', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - open in time')
-        create_ico(type: :sar, received: '20170606', responded: '20170625', deadline: '20170630', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - responded in time')
-        create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170625', team: @team_b, responder: @responder_b, ident: 'ico sar for team b - open late')
-        create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170702', team: @team_b, responder: @responder_b, ident: 'ico sar for team b - open in time')
-        create_ico(type: :sar, received: '20170607', responded: '20170620', deadline: '20170625', team: @team_b, responder: @responder_b, ident: 'ico sar for team b - responded in time')
-        create_ico(type: :sar, received: '20170604', responded: '20170629', deadline: '20170625', team: @team_c, responder: @responder_c, ident: 'ico sar for team c - responded late')
-        create_ico(type: :sar, received: '20170606', responded: '20170625', deadline: '20170630', team: @team_c, responder: @responder_c, ident: 'ico sar for team c - responded in time')
-        create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170702', team: @team_d, responder: @responder_d, ident: 'ico sar for team d - open in time')
+        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - open late')
+        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170625', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - open late')
+        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170702', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - open in time')
+        # create_ico(type: :sar, received: '20170606', responded: '20170625', deadline: '20170630', team: @team_a, responder: @responder_a, ident: 'ico sar for team a - responded in time')
+        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170625', team: @team_b, responder: @responder_b, ident: 'ico sar for team b - open late')
+        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170702', team: @team_b, responder: @responder_b, ident: 'ico sar for team b - open in time')
+        # create_ico(type: :sar, received: '20170607', responded: '20170620', deadline: '20170625', team: @team_b, responder: @responder_b, ident: 'ico sar for team b - responded in time')
+        # create_ico(type: :sar, received: '20170604', responded: '20170629', deadline: '20170625', team: @team_c, responder: @responder_c, ident: 'ico sar for team c - responded late')
+        # create_ico(type: :sar, received: '20170606', responded: '20170625', deadline: '20170630', team: @team_c, responder: @responder_c, ident: 'ico sar for team c - responded in time')
+        # create_ico(type: :sar, received: '20170605', responded: nil,        deadline: '20170702', team: @team_d, responder: @responder_d, ident: 'ico sar for team d - open in time')
       end
 
       ###############
@@ -129,11 +129,11 @@ module Stats # rubocop:disable Metrics/ModuleLength
             ir_appeal_open_in_time:        2,
             ir_appeal_open_late:           3,
             ico_appeal_performance:        28.6,
-            ico_appeal_total:              18,
-            ico_appeal_responded_in_time:  4,
-            ico_appeal_responded_late:     4,
-            ico_appeal_open_in_time:       4,
-            ico_appeal_open_late:          6,
+            ico_appeal_total:              9,
+            ico_appeal_responded_in_time:  2,
+            ico_appeal_responded_late:     2,
+            ico_appeal_open_in_time:       2,
+            ico_appeal_open_late:          3,
           })
       end
 
@@ -153,10 +153,10 @@ module Stats # rubocop:disable Metrics/ModuleLength
             ir_appeal_open_in_time:        1,
             ir_appeal_open_late:           0,
             ico_appeal_performance:        50.0,
-            ico_appeal_total:              6,
-            ico_appeal_responded_in_time:  2,
-            ico_appeal_responded_late:     2,
-            ico_appeal_open_in_time:       2,
+            ico_appeal_total:              3,
+            ico_appeal_responded_in_time:  1,
+            ico_appeal_responded_late:     1,
+            ico_appeal_open_in_time:       1,
             ico_appeal_open_late:          0,
           })
       end
@@ -177,9 +177,9 @@ module Stats # rubocop:disable Metrics/ModuleLength
             ir_appeal_open_in_time:        0,
             ir_appeal_open_late:           0,
             ico_appeal_performance:        50.0,
-            ico_appeal_total:              4,
-            ico_appeal_responded_in_time:  2,
-            ico_appeal_responded_late:     2,
+            ico_appeal_total:              2,
+            ico_appeal_responded_in_time:  1,
+            ico_appeal_responded_late:     1,
             ico_appeal_open_in_time:       0,
             ico_appeal_open_late:          0,
           })
@@ -201,16 +201,16 @@ module Stats # rubocop:disable Metrics/ModuleLength
             Appeals report (FOI) - 1 Jan 2017 to 30 Jun 2017
             #{super_header}
             #{header}
-            BGAB,"","",#{@bizgrp_ab.team_lead},28.6,9,2,2,2,3,28.6,18,4,4,4,6
-            BGAB,DRA,"",#{@dir_a.team_lead},20.0,6,1,2,1,2,20.0,12,2,4,2,4
-            BGAB,DRA,RTA,#{@team_a.team_lead},20.0,6,1,2,1,2,20.0,12,2,4,2,4
-            BGAB,DRB,"",#{@dir_b.team_lead},50.0,3,1,0,1,1,50.0,6,2,0,2,2
-            BGAB,DRB,RTB,#{@team_b.team_lead},50.0,3,1,0,1,1,50.0,6,2,0,2,2
-            BGCD,"","",#{@bizgrp_cd.team_lead},50.0,3,1,1,1,0,50.0,6,2,2,2,0
-            BGCD,DRCD,"",#{@dir_cd.team_lead},50.0,3,1,1,1,0,50.0,6,2,2,2,0
-            BGCD,DRCD,RTC,#{@team_c.team_lead},50.0,2,1,1,0,0,50.0,4,2,2,0,0
-            BGCD,DRCD,RTD,#{@team_d.team_lead},0.0,1,0,0,1,0,0.0,2,0,0,2,0
-            Total,"","","",33.3,12,3,3,3,3,33.3,24,6,6,6,6
+            BGAB,"","",#{@bizgrp_ab.team_lead},28.6,9,2,2,2,3,28.6,9,2,2,2,3
+            BGAB,DRA,"",#{@dir_a.team_lead},20.0,6,1,2,1,2,20.0,6,1,2,1,2
+            BGAB,DRA,RTA,#{@team_a.team_lead},20.0,6,1,2,1,2,20.0,6,1,2,1,2
+            BGAB,DRB,"",#{@dir_b.team_lead},50.0,3,1,0,1,1,50.0,3,1,0,1,1
+            BGAB,DRB,RTB,#{@team_b.team_lead},50.0,3,1,0,1,1,50.0,3,1,0,1,1
+            BGCD,"","",#{@bizgrp_cd.team_lead},50.0,3,1,1,1,0,50.0,3,1,1,1,0
+            BGCD,DRCD,"",#{@dir_cd.team_lead},50.0,3,1,1,1,0,50.0,3,1,1,1,0
+            BGCD,DRCD,RTC,#{@team_c.team_lead},50.0,2,1,1,0,0,50.0,2,1,1,0,0
+            BGCD,DRCD,RTD,#{@team_d.team_lead},0.0,1,0,0,1,0,0.0,1,0,0,1,0
+            Total,"","","",33.3,12,3,3,3,3,33.3,12,3,3,3,3
           EOCSV
           actual_lines = report_csv.map { |row| row.map(&:value) }
           expected_lines = expected_text.split("\n")
@@ -221,25 +221,28 @@ module Stats # rubocop:disable Metrics/ModuleLength
       end
 
       it 'should produce rag ratings' do
-        rag_ratings = report_csv.map do |row|
-          row.map.with_index { |item, index| [index, item.rag_rating] if item.rag_rating }.compact
-        end
+        Timecop.freeze Time.new(2017, 6, 30, 12, 0, 0) do
 
-        expect(rag_ratings).to eq([
-          [],
-          (0..15).map { |x| [x, :blue] },
-          (0..15).map { |x| [x, :grey] },
-          [[4, :red], [10, :red]],
-          [[4, :red], [10, :red]],
-          [[4, :red], [10, :red]],
-          [[4, :red], [10, :red]],
-          [[4, :red], [10, :red]],
-          [[4, :red], [10, :red]],
-          [[4, :red], [10, :red]],
-          [[10, :red]],
-          [[4, :red], [10, :red]],
-          [[4, :red], [10, :red]],
-        ])
+          actual_lines = report_csv.map { |row| row.map(&:value) }
+          rag_ratings = report_csv.map do |row|
+            row.map.with_index { |item, index| [index, item.rag_rating] if item.rag_rating }.compact
+          end
+          expect(rag_ratings).to eq([
+            [],
+            (0..15).map { |x| [x, :blue] },
+            (0..15).map { |x| [x, :grey] },
+            [[4, :red], [10, :red]],
+            [[4, :red], [10, :red]],
+            [[4, :red], [10, :red]],
+            [[4, :red], [10, :red]],
+            [[4, :red], [10, :red]],
+            [[4, :red], [10, :red]],
+            [[4, :red], [10, :red]],
+            [[4, :red], [10, :red]],
+            [[4, :red], [10, :red]],
+            [[4, :red], [10, :red]],
+          ])
+        end
       end
     end
 

--- a/spec/services/stats/r105_sar_monthly_performance_report_spec.rb
+++ b/spec/services/stats/r105_sar_monthly_performance_report_spec.rb
@@ -29,6 +29,9 @@ module Stats
       end
 
       before(:all) do
+        require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
+        CaseClosure::MetadataSeeder.seed!
+  
         Timecop.freeze Time.new(2019, 6, 30, 12, 0, 0) do
           @period_start = 0.business_days.after(Date.new(2018, 12, 20))
           @period_end = 0.business_days.after(Date.new(2018, 12, 31))
@@ -42,8 +45,12 @@ module Stats
           @sar_3 = create :accepted_sar, identifier: 'sar-3', creation_time: @period_start + 5.days
           @foi_3 = create :accepted_case, identifier: 'foi-3', creation_time: @period_start + 5.days
 
-          @sar_4 = create :accepted_sar, identifier: 'sar-4', creation_time: @period_end  + 61.minutes
-          @foi_4 = create :accepted_case, identifier: 'foi-4', creation_time: @period_end  + 61.minutes
+          @sar_4 = create :closed_sar, identifier: 'sar-4', creation_time: @period_start, 
+                          received_date: @period_start + 1.days, date_responded: @period_end
+          @foi_4 = create :closed_case, identifier: 'foi-4', creation_time: @period_start
+
+          @sar_5 = create :closed_sar, :clarification_required, identifier: 'sar-tmm', creation_time: @period_start, 
+                          received_date: @period_start + 1.days, date_responded: @period_end
         end
       end
 
@@ -85,12 +92,12 @@ module Stats
             expect(in_time_unassigned_trigger_sar_case.already_late?).to be false
             expect(report.case_scope).to include(late_unassigned_trigger_sar_case)
             expect(report.case_scope).to include(in_time_unassigned_trigger_sar_case)
-            expect(results[12][:non_trigger_open_late]).to eq(3)
-            expect(results[12][:non_trigger_performance]).to eq(0)
+            expect(results[12][:non_trigger_open_late]).to eq(2)
+            expect(results[12][:non_trigger_performance]).to eq(33.3)
             expect(results[12][:trigger_open_late]).to eq(1)
             expect(results[12][:trigger_open_in_time]).to eq(1)
             expect(results[12][:trigger_performance]).to eq(50)
-            expect(results[12][:overall_performance]).to eq(20)
+            expect(results[12][:overall_performance]).to eq(40)
           end
         end
       end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to fix the following parts
- Change the scope for FOI Appeals report to ICO appeal for FOI only and the date range for received_date, no open cases will be carried over
- Change the scope for SAR appeals report to the date range for received_date, no open cases will be carried over
- Exclude the TMM cases from SAR's monthly performance report 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3266
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
1 - Login as London user
2 - Click "Reports" from top menu
3 - Click "Create report"
4 - Download FOI -appeals report and SAR monthly performance report
5 - Check the figure