### PR TITLE
CT-3262 added extra case_id into existing csv file

### DIFF
--- a/lib/tasks/complaint_cases_links.rake
+++ b/lib/tasks/complaint_cases_links.rake
@@ -7,17 +7,20 @@ namespace :complaints do
     task :check, [:file] => :environment do |_task, args|
       raise "Must specify the csv file containing the list of complaint cases" if args[:file].blank?    
       raise "The file doesn't exist" if !File.file?(args[:file])
-      result_file = "#{args[:file].delete("csv")}_checking_result.csv"
+      result_file = "#{args[:file].delete(".csv")}_checking_result.csv"
       counter = 1
       CSV.open(result_file, "wb") do |csv|
-        csv << ["ReqNo", "DPARefNo", "Exist?", ]
+        csv << ["ReqNo", "DPARefNo", "Exist?", "case_id"]
         CSV.foreach(args[:file], headers: true) do |row|
           puts "Checking #{row['DPARefNo']}"
           offender = Case::SAR::Offender.find_by_number("MIG#{row['DPARefNo']}")
           if offender.nil?
             offender = Case::SAR::Offender.find_by_number("#{row['DPARefNo']}")
           end
-          csv << [row["ReqNo"], row["DPARefNo"], (offender.present? ? "Y" : "N")]
+          csv << [row["ReqNo"], 
+                  row["DPARefNo"], 
+                  (offender.present? ? "Y" : "N"), 
+                  (offender.present? ? offender.id : "")]
           counter += 1 unless offender.present?
         end  
       end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is simple a minor change on a existing task by adding another case_id column for linked offender sar when checking the link between offender sar and complaint

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3262
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
rake complaints:links:check[<csv file]