### PR TITLE
CT-3237 Assign case to complaints officer

### DIFF
--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -31,6 +31,7 @@ module Cases
       if !@case.valid_attributes?(create_params)
         render :new
       elsif @case.valid? && @case.save
+        assign_case_to_creator if @case.offender_sar_complaint?
         session[session_state] = nil
         flash[:notice] = "Case created successfully"
         redirect_to case_path(@case)
@@ -98,6 +99,14 @@ module Cases
     end
 
     private
+
+    def assign_case_to_creator
+      assign_service = CaseSelfAssignService
+                              .new kase: @case,
+                                   role: 'responding',
+                                   user: current_user
+      assign_service.call
+    end
 
     def apply_date_workaround
       # an issue with the Gov UK Date Fields causes the fields to show up empty

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -51,6 +51,7 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
               class: 'button',
               method: 'post'
     when :assign_responder
+      return '' if @case.type_of_offender_sar?
       link_to I18n.t('common.case.assign'),
               new_case_assignment_path(@case),
               id: 'action--assign-to-responder',

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -54,12 +54,12 @@ class Assignment < ApplicationRecord
   scope :flagged_for_approval, ->(teams) do
     where(team: teams, role: 'approving')
   end
-  
+
   scope :team_restriction, ->(user_id, role) {
     joins('join teams_users_roles on assignments.team_id=teams_users_roles.team_id')
     .where('teams_users_roles': {user_id: user_id, role: role.to_s})
     .where.not(state: [ :rejected ] )
-    .select(:case_id).distinct     
+    .select(:case_id).distinct
   }
 
   # Putting a 'limit 1' here breaks the caching of Case::Base#responder_assignment

--- a/app/services/case_self_assign_service.rb
+++ b/app/services/case_self_assign_service.rb
@@ -15,7 +15,6 @@ class CaseSelfAssignService
       if @assignment.valid?
         managing_team = @user.responding_teams.first
         @case.state_machine.assign_responder! acting_user: @user, acting_team: managing_team, target_team: target_team
-        @assignment.case.state_machine.accept_approver_assignment!(acting_user: @user, acting_team: target_team)
         @assignment.accepted!
         @assignment.save!
         @result = :ok

--- a/app/services/case_self_assign_service.rb
+++ b/app/services/case_self_assign_service.rb
@@ -1,0 +1,29 @@
+class CaseSelfAssignService
+  attr_reader :result, :assignment
+
+  def initialize(kase:, role:, user:)
+    @case = kase
+    @role = role
+    @user = user
+    @result = :incomplete
+  end
+
+  def call
+    Assignment.connection.transaction do
+      target_team = @user.responding_teams.first
+      @assignment = @case.assignments.new(team: target_team, role: @role, user: @user)
+      if @assignment.valid?
+        managing_team = @user.responding_teams.first
+        @case.state_machine.assign_responder! acting_user: @user, acting_team: managing_team, target_team: target_team
+        @assignment.case.state_machine.accept_approver_assignment!(acting_user: @user, acting_team: target_team)
+        @assignment.accepted!
+        @assignment.save!
+        @result = :ok
+      else
+        @result = :could_not_create_assignment
+      end
+    end
+    @result == :ok
+  end
+
+end

--- a/app/services/current_team_and_user/sar/offender.rb
+++ b/app/services/current_team_and_user/sar/offender.rb
@@ -7,7 +7,7 @@ module CurrentTeamAndUser
         @case = kase
         @dts = DefaultTeamService.new(@case)
         @team = @case.managing_team
-        @user = nil
+        @user = @case&.responder_assignment&.user
       end
 
     end

--- a/app/views/cases/_case_status.html.slim
+++ b/app/views/cases/_case_status.html.slim
@@ -9,7 +9,7 @@
       .case-status__data--large
         = case_details.status
 
-    - if case_details.current_state != 'closed' &&  !case_details.type_of_offender_sar?
+    - if case_details.current_state != 'closed' &&  !case_details.offender_sar?
       .case-status__group.who_its_with
         .case-status__heading
           = t('common.case.who_its_with')

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,6 +52,12 @@ Rails.application.configure do
     Bullet.add_whitelist :type => :n_plus_one_query,
                          :class_name => 'BusinessUnit',
                          :association => :moved_to_unit
+    Bullet.add_whitelist :type => :n_plus_one_query,
+                         :class_name => 'Case::SAR::Offender',
+                         :association => :responder_assignment
+    Bullet.add_whitelist :type => :n_plus_one_query,
+                         :class_name => 'Case::SAR::OffenderComplaint',
+                         :association => :responder_assignment
 
     # Enable this to track down most of the N+1 query issues
     Bullet.raise         = true # raise an error if n+1 query occurs

--- a/config/state_machine/configs/00_moj/50_offender_sar_complaint/20_offender_sar_complaint_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/50_offender_sar_complaint/20_offender_sar_complaint_standard_workflow.yml
@@ -16,6 +16,8 @@
                 add_note_to_case:
                 send_acknowledgement_letter:
                 edit_case:
+                assign_responder:
+                accept_approver_assignment:
               data_review_required:
                 mark_as_vetting_in_progress:
                   transition_to: vetting_in_progress

--- a/spec/factories/case/offender_sar_complaints.rb
+++ b/spec/factories/case/offender_sar_complaints.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
       i_am_deleted        { false }
     end
 
-    current_state                   { 'data_to_be_requested' }
+    current_state                   { 'to_be_assessed' }
     association :original_case, factory: [:offender_sar_case, :closed]
     sequence(:name)                 { |n| "#{identifier} name #{n}" }
     email                           { Faker::Internet.email(name: identifier) }
@@ -140,5 +140,32 @@ FactoryBot.define do
         kase.reload
       end
     end
+
+
+    trait :_transition_to_accepted do
+      after(:create) do |kase, evaluator|
+        kase.responder_assignment.update_attribute :user, evaluator.responder
+        kase.responder_assignment.accepted!
+        create :case_transition_accept_responder_assignment,
+               case: kase,
+               acting_team: kase.responding_team,
+               acting_user: kase.responder,
+               created_at: evaluator.creation_time
+      end
+    end
+
   end
+
+  factory :accepted_complaint_case, parent: :offender_sar_complaint do
+    transient do
+      identifier { "accepted case" }
+    end
+
+    after(:create) do |kase, evaluator|
+      kase.assignments.create(team: kase.responding_team, role: 'responding')
+      kase.responder_assignment.update_attribute :user, evaluator.responder
+      kase.responder_assignment.accepted!
+    end
+  end
+
 end

--- a/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
@@ -23,6 +23,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     then_expect_cases_show_page_to_be_correct_for_data_subject_requesting_own_record
     then_expect_linked_original_case_has_stamp_for_linkage
     then_expect_open_cases_page_to_be_correct
+    then_expect_case_in_my_open_cases
   end
 
   scenario '2 Data subject requesting data to be sent to third party' do
@@ -37,9 +38,10 @@ feature 'offender sar complaint case creation by a manager', js: true do
     then_expect_cases_show_page_to_be_correct_for_data_subject_sending_data_to_third_party
     then_expect_linked_original_case_has_stamp_for_linkage
     then_expect_open_cases_page_to_be_correct
+    then_expect_case_in_my_open_cases
   end
 
- scenario '3 Solicitor requesting data subject record' do
+  scenario '3 Solicitor requesting data subject record' do
     when_i_navigate_to_offender_sar_complaint_subject_page
     and_choose_original_offender_sar_case_and_confirm
     and_fill_in_requester_details_page(:third_party)
@@ -51,7 +53,8 @@ feature 'offender sar complaint case creation by a manager', js: true do
     then_expect_cases_show_page_to_be_correct_for_solicitor_requesting_data_subject_record
     then_expect_linked_original_case_has_stamp_for_linkage
     then_expect_open_cases_page_to_be_correct
- end
+    then_expect_case_in_my_open_cases
+  end
 
   scenario '4 Solicitor requesting record to be sent to data subject' do
     when_i_navigate_to_offender_sar_complaint_subject_page
@@ -65,6 +68,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     then_expect_cases_show_page_to_be_correct_for_solicitor_requesting_data_for_data_subject
     then_expect_linked_original_case_has_stamp_for_linkage
     then_expect_open_cases_page_to_be_correct
+    then_expect_case_in_my_open_cases
   end
 
   scenario '5 Copy the third part details from linked offender sar case' do
@@ -79,6 +83,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     then_expect_cases_show_page_to_have_same_third_party_detail
     then_expect_linked_original_case_has_stamp_for_linkage
     then_expect_open_cases_page_to_be_correct
+    then_expect_case_in_my_open_cases
   end
 
   scenario '6 Create the complaint case from closed offender sar case' do
@@ -92,6 +97,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     then_basic_details_of_show_page_are_correct
     then_expect_cases_show_page_to_have_same_third_party_detail
     then_expect_open_cases_page_to_be_correct
+    then_expect_case_in_my_open_cases
   end
 
   scenario '7 Create the complaint case from open late offender sar case' do
@@ -107,6 +113,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     then_expect_cases_show_page_to_be_correct_for_solicitor_requesting_data_for_data_subject
     then_expect_linked_original_case_has_stamp_for_linkage(offender_sar_case: offender_sar_open_late)
     then_expect_open_cases_page_to_be_correct(offender_sar_case: offender_sar_open_late)
+    then_expect_case_in_my_open_cases
   end
 
   scenario '8 Create the complaint case from open late offender sar case' do
@@ -235,6 +242,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
   def then_basic_details_of_show_page_are_correct(offender_sar_case: nil)
     linked_case = (offender_sar_case ||  offender_sar)
     expect(cases_show_page).to be_displayed
+    expect_the_case_to_be_assigned_to_me
     expect(cases_show_page).to have_content "OFFENDER-SAR-COMPLAINT"
     expect(cases_show_page).to have_content "Case created successfully"
     expect(cases_show_page.page_heading).to have_content linked_case.subject
@@ -248,7 +256,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
   def then_expect_open_cases_page_to_be_correct(offender_sar_case: nil)
     click_on "Cases"
     expect(open_cases_page).to be_displayed
-    expect(cases_page).to have_content "branston registry responding user"
+    expect(open_cases_page).to have_content "branston registry responding user"
     expect(open_cases_page).to have_content (offender_sar_case || offender_sar).subject
   end
 
@@ -257,6 +265,21 @@ feature 'offender sar complaint case creation by a manager', js: true do
     expect(cases_show_page).to have_content "Company name Foogle and Sons Solicitors at Law"
     expect(cases_show_page).to have_content "Relationship Solicitor"
     expect(cases_show_page).to have_content "Address\n22 High Street"
+  end
+
+  def expect_the_case_to_be_assigned_to_me
+    expect(cases_show_page.case_history).to have_content "Assign responder"
+    expect(cases_show_page.case_history).to have_content "Assigned to Branston Registr"
+    expect(cases_show_page).to have_content "With\nbranston registry responding user"
+  end
+
+  def then_expect_case_in_my_open_cases
+    complaint_case = Case::Base.offender_sar_complaint.last
+    click_on "My open cases"
+    expect(my_open_cases_page).to be_displayed
+    row = my_open_cases_page.row_for_case_number(complaint_case.number)
+    expect(row).to have_content complaint_case.number
+    expect(row).to have_content 'branston registry responding user'
   end
 end
 

--- a/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
@@ -158,7 +158,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     expect(cases_show_page).to be_displayed(id: (offender_sar_case || offender_sar).id)
     expect(cases_show_page.case_history.entries.first)
       .to have_content I18n.t(
-        'common.case/offender_sar.complaint_case_link_message', 
+        'common.case/offender_sar.complaint_case_link_message',
         creation_date: Date.today)
   end
 
@@ -170,7 +170,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
       click_on "Closed cases"
     end
     click_link link_case.number
-    expect(cases_show_page).to be_displayed 
+    expect(cases_show_page).to be_displayed
     click_on "Start complaint"
   end
 
@@ -197,7 +197,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     expect(cases_new_offender_sar_complaint_confirm_case_page).to be_displayed
     cases_new_offender_sar_complaint_confirm_case_page.confirm_yes
     click_on "Continue"
-  end 
+  end
 
   def and_fill_in_requester_details_page(params = nil)
     cases_new_offender_sar_complaint_requester_details_page.fill_in_case_details(params)
@@ -248,7 +248,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
   def then_expect_open_cases_page_to_be_correct(offender_sar_case: nil)
     click_on "Cases"
     expect(open_cases_page).to be_displayed
-    expect(cases_page).to have_content "Branston Registry"
+    expect(cases_page).to have_content "branston registry responding user"
     expect(open_cases_page).to have_content (offender_sar_case || offender_sar).subject
   end
 

--- a/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
@@ -96,6 +96,7 @@ feature 'offender sar complaint case editing by a manager' do
   end
 
   def when_i_progress_case_to_a_closed_state
+    click_on "Requires data"
     click_on "Mark as waiting for data"
     click_on "Mark as ready for vetting"
     click_on "Mark as vetting in progress"

--- a/spec/features/cases/offender_sar_complaint/case_progressing_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_progressing_spec.rb
@@ -19,6 +19,9 @@ feature 'offender sar complaint case creation by a manager' do
   scenario 'progressing an offender sar complaint case', js: true do
     cases_show_page.load(id: offender_sar_complaint.id)
 
+    expect(cases_show_page).to have_content "Requires data"
+    click_on "Requires data"
+
     expect(cases_show_page).to have_content "Mark as waiting for data"
     expect(cases_show_page).to have_content "Data to be requested"
     expect(cases_show_page).to have_content "Send acknowledgement letter"

--- a/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
@@ -14,7 +14,7 @@ feature 'Generate an acknowledgement letter by a responder' do
     scenario 'when the case has just been created' do
       cases_show_page.load(id: offender_sar_complaint.id)
       expect(cases_show_page).to be_displayed
-      expect(cases_show_page).to have_content "Data to be requested"
+      expect(cases_show_page).to have_content "To be assessed"
       expect(cases_show_page).to have_content "Send acknowledgement letter"
     end
 

--- a/spec/models/case/sar/offender_complaint_spec.rb
+++ b/spec/models/case/sar/offender_complaint_spec.rb
@@ -480,7 +480,11 @@ describe Case::SAR::OffenderComplaint do
   describe '#allow_waiting_for_data_state?' do
     it 'is true when the current state is data_to_be_requested only' do
       kase = build :offender_sar_complaint
-      expect(kase.current_state).to eq 'data_to_be_requested'
+
+      expect(kase.current_state).to eq 'to_be_assessed'
+      expect(kase.allow_waiting_for_data_state?).to be false
+
+      kase.current_state = 'data_to_be_requested'
       expect(kase.allow_waiting_for_data_state?).to be true
 
       kase.current_state = 'waiting_for_data'

--- a/spec/services/case_self_assign_service_spec.rb
+++ b/spec/services/case_self_assign_service_spec.rb
@@ -54,15 +54,6 @@ describe CaseSelfAssignService, type: :service do
         service.call
       end
 
-      it 'triggers an accept_approver_assignment! event' do
-        expect(unassigned_case.state_machine)
-            .to receive(:accept_approver_assignment!)
-                    .with(
-                        acting_user: responder,
-                        acting_team: team)
-        service.call
-      end
-
       it 'saves the assignment' do
         service.call
         expect(service.assignment).to eq new_assignment

--- a/spec/services/case_self_assign_service_spec.rb
+++ b/spec/services/case_self_assign_service_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe CaseSelfAssignService, type: :service do
+  let(:team) { find_or_create :team_branston }
+  let(:unassigned_case) { find_or_create :offender_sar_complaint }
+  let(:responder) { find_or_create :branston_user }
+  let(:service)           { CaseSelfAssignService
+                              .new kase: unassigned_case,
+                                   role: 'responding',
+                                   user: responder }
+  let(:new_assignment) { instance_double Assignment }
+
+describe '#initialize' do
+    it 'defaults result to incomplete' do
+      expect(service.result).to eq :incomplete
+    end
+end
+
+  describe '#call' do
+    before do
+      allow(unassigned_case).to receive_message_chain(:assignments,
+                                                      new: new_assignment)
+      allow(unassigned_case.state_machine).to receive(:assign_responder!)
+      allow(unassigned_case.state_machine).to receive(:accept_approver_assignment!)
+    end
+
+    context 'assignment is valid' do
+      before do
+        allow(new_assignment).to receive_messages valid?: true,
+                                                  save!: true,
+                                                  case: unassigned_case,
+                                                  user: responder,
+                                                  team: team,
+                                                  accepted!: true,
+                                                  state: 'accepted'
+      end
+
+      it 'returns true on success' do
+        expect(service.call).to eq true
+      end
+
+      it 'sets the result to :ok' do
+        service.call
+        expect(service.result).to eq :ok
+      end
+
+      it 'triggers an assign_responder! event' do
+        expect(unassigned_case.state_machine)
+            .to receive(:assign_responder!)
+                    .with(
+                        acting_user: responder,
+                        acting_team: responder.responding_teams.first,
+                        target_team: team)
+        service.call
+      end
+
+      it 'triggers an accept_approver_assignment! event' do
+        expect(unassigned_case.state_machine)
+            .to receive(:accept_approver_assignment!)
+                    .with(
+                        acting_user: responder,
+                        acting_team: team)
+        service.call
+      end
+
+      it 'saves the assignment' do
+        service.call
+        expect(service.assignment).to eq new_assignment
+      end
+
+      it 'assignment is accepted' do
+        service.call
+        expect(service.assignment.state).to eq 'accepted'
+      end
+
+    end
+  end
+
+end

--- a/spec/services/case_self_assign_service_spec.rb
+++ b/spec/services/case_self_assign_service_spec.rb
@@ -10,11 +10,11 @@ describe CaseSelfAssignService, type: :service do
                                    user: responder }
   let(:new_assignment) { instance_double Assignment }
 
-describe '#initialize' do
+  describe '#initialize' do
     it 'defaults result to incomplete' do
       expect(service.result).to eq :incomplete
     end
-end
+  end
 
   describe '#call' do
     before do

--- a/spec/services/current_team_and_user/sar/offender_spec.rb
+++ b/spec/services/current_team_and_user/sar/offender_spec.rb
@@ -35,4 +35,22 @@ describe 'CurrentTeamAndUserSAROffenderService' do
            )
     end
   end
+
+  context 'offender sar complaint unassigned' do
+    let(:kase)  { create :offender_sar_complaint }
+    it 'returns the correct team and user' do
+      expect(kase.current_state).to eq 'to_be_assessed'
+      expect(service.team).to eq team_branston
+      expect(service.user).to be_nil
+    end
+  end
+
+  context 'offender sar complaint assigned' do
+    let(:kase)  { create :accepted_complaint_case }
+    it 'returns the correct team and user' do
+      expect(kase.current_state).to eq 'to_be_assessed'
+      expect(service.team).to eq team_branston
+      expect(service.user).to eq team_branston.users.first
+    end
+  end
 end

--- a/spec/views/cases/_case_status_html_slim_spec.rb
+++ b/spec/views/cases/_case_status_html_slim_spec.rb
@@ -11,7 +11,8 @@ describe 'cases/case_status.html.slim', type: :view do
       current_state: 'drafting',
       type_abbreviation: 'FOI',
       who_its_with: 'DACU',
-      type_of_offender_sar?: false
+      type_of_offender_sar?: false,
+      offender_sar?: false
 
 
     render partial: 'cases/case_status.html.slim',
@@ -43,7 +44,8 @@ describe 'cases/case_status.html.slim', type: :view do
       current_state: 'closed',
       type_abbreviation: 'FOI',
       who_its_with: '',
-      type_of_offender_sar?: false
+      type_of_offender_sar?: false,
+      offender_sar?: false
 
     render partial: 'cases/case_status.html.slim',
            locals:{ case_details: closed_case}
@@ -68,7 +70,8 @@ describe 'cases/case_status.html.slim', type: :view do
       current_state: 'drafting',
       type_abbreviation: 'FOI',
       who_its_with: 'DACU',
-      type_of_offender_sar?: false
+      type_of_offender_sar?: false,
+      offender_sar?: false
 
     render partial: 'cases/case_status.html.slim',
            locals:{ case_details: non_trigger_case}
@@ -94,7 +97,8 @@ describe 'cases/case_status.html.slim', type: :view do
         current_state: 'drafting',
         type_abbreviation: 'FOI',
         who_its_with: 'DACU',
-        type_of_offender_sar?: false
+        type_of_offender_sar?: false,
+        offender_sar?: false
 
       render partial: 'cases/case_status.html.slim',
              locals:{ case_details: non_trigger_case}
@@ -123,7 +127,8 @@ describe 'cases/case_status.html.slim', type: :view do
         current_state: 'drafting',
         type_abbreviation: 'ICO',
         who_its_with: 'DACU',
-        type_of_offender_sar?: false
+        type_of_offender_sar?: false,
+        offender_sar?: false
 
 
       render partial: 'cases/case_status.html.slim',
@@ -155,6 +160,7 @@ describe 'cases/case_status.html.slim', type: :view do
         who_its_with: 'Branston Registry',
         type_of_offender_sar?: false,
         offender_sar_complaint?: false,
+        offender_sar?: false,
         page_count: '500',
         number_exempt_pages: '200',
         number_final_pages: '250'
@@ -188,7 +194,8 @@ describe 'cases/case_status.html.slim', type: :view do
         current_state: 'drafting',
         type_abbreviation: 'ICO',
         who_its_with: 'DACU',
-        type_of_offender_sar?: false
+        type_of_offender_sar?: false,
+        offender_sar?: false
 
 
       render partial: 'cases/case_status.html.slim',
@@ -209,7 +216,8 @@ describe 'cases/case_status.html.slim', type: :view do
         current_state: 'drafting',
         type_abbreviation: 'OVERTURNED_SAR',
         who_its_with: 'DACU',
-        type_of_offender_sar?: false
+        type_of_offender_sar?: false,
+        offender_sar?: false
     }
 
     it 'displays ICO case reference number for ICO overturned SAR cases' do


### PR DESCRIPTION
## Description
This PR adds an assignment to the user who created the case. We also update the Offender SAR Complaint factory to default to a state of "To be assessed" now that this is the new initial state; this resulted in a few updates to specs which needed it.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Case assigned to creator - reflected on the Case Show page: 
![image](https://user-images.githubusercontent.com/1161161/100159640-077ccb80-2ea6-11eb-8c38-1d5f4e709ed5.png)

"My cases" show up based on the self-assignment by user who created them:
![image](https://user-images.githubusercontent.com/1161161/100159708-2713f400-2ea6-11eb-9113-6fd2150f2b3c.png)

Case history no longer shows approver assignment
![image](https://user-images.githubusercontent.com/1161161/100744074-24992900-33d5-11eb-83bb-0eb150512f1f.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3237

### Deployment
n/a

### Manual testing instructions
Sign in a a branston user and create a new Offender SAR Complaint - should be assigned to the user when you view the case show page and show up in "My open cases" list. There should be no change to the display of Offender SAR cases. 
