### PR TITLE
CT-3280 Changed the scope of business unit performance report to received date only

### DIFF
--- a/app/services/stats/base_business_unit_performance_report.rb
+++ b/app/services/stats/base_business_unit_performance_report.rb
@@ -80,7 +80,7 @@ module Stats
 
     def run(*)
       CaseSelector.new(case_scope)
-        .cases_for_period(@period_start, @period_end)
+        .cases_received_in_period(@period_start, @period_end)
         .reject { |kase| kase.unassigned? }.each do |kase|
         analyse_case(kase)
       end

--- a/app/services/stats/r103_sar_business_unit_performance_report.rb
+++ b/app/services/stats/r103_sar_business_unit_performance_report.rb
@@ -11,7 +11,13 @@ module Stats
 
     def case_scope
       sar_tmm = CaseClosure::RefusalReason.sar_tmm
-      Case::SAR::Standard.where('refusal_reason_id IS NULL OR refusal_reason_id != ?', sar_tmm.id)
+      Case::SAR::Standard
+        .includes(:assign_responder_transitions,
+                  :responded_transitions,
+                  :responder_assignment,
+                  :responding_team,
+                  :approver_assignments)
+        .where('refusal_reason_id IS NULL OR refusal_reason_id != ?', sar_tmm.id)
     end
 
     def report_type

--- a/spec/services/stats/r003_business_unit_performance_report_spec.rb
+++ b/spec/services/stats/r003_business_unit_performance_report_spec.rb
@@ -214,7 +214,9 @@ module Stats
           Timecop.freeze Time.new(2017, 6, 30, 12, 0, 0) do
             d1 = Date.new(2017, 6, 4)
             d2 = Date.new(2017, 6, 30)  
-            report = R003BusinessUnitPerformanceReport.new(period_start: d1, period_end: d2); report.run; report.to_csv
+            report = R003BusinessUnitPerformanceReport.new(period_start: d1, period_end: d2)
+            report.run 
+            report.to_csv
           end
         end
 

--- a/spec/services/stats/r003_business_unit_performance_report_spec.rb
+++ b/spec/services/stats/r003_business_unit_performance_report_spec.rb
@@ -240,8 +240,7 @@ module Stats
               [[6, :green], [18, :green]],
               [[6, :red], [12, :red], [18, :red]],
             ])
-
-          end
+        end
 
         it 'outputs results as a csv lines' do
           super_header = %q{"","","","","","",} +

--- a/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
+++ b/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
@@ -310,7 +310,7 @@ module Stats
         factory = :accepted_sar
         kase = create factory, responding_team: team, responder: responder, identifier: ident, received_date: received_date
         kase.external_deadline = Date.parse(deadline)
-        if flagged == true
+        if flagged
           CaseFlagForClearanceService.new(user: kase.managing_team.users.first, kase: kase, team: @team_dacu_disclosure).call
         end
         unless responded_date.nil?
@@ -321,13 +321,11 @@ module Stats
         end
       end
 
-
       if type.present?
         refusal_reason = CaseClosure::RefusalReason.__send__(type)
         kase.refusal_reason = refusal_reason
       end
       kase.save!
-      kase
     end
     #rubocop:enable Metrics/ParameterLists
 

--- a/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
+++ b/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
+# rubocop:disable Metrics/ModuleLength
 module Stats
   describe R103SarBusinessUnitPerformanceReport do
 
-    Team.all.map(&:destroy)
     before(:all) { 
       create_report_type(abbr: :r103)
 
@@ -56,6 +56,7 @@ module Stats
       Team.where('name like ?','%Responder%').destroy_all
 
     }
+
     after(:all) { DbHousekeeping.clean(seed: true) }
 
     context 'date management, titles, description, etc' do
@@ -332,3 +333,4 @@ module Stats
 
   end
 end
+# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to change the scope of the business unit report to be based on the received_date as the basic scope

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3280

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
1 - Login as London user
2- Choose the "reports" link from top menu
3 - Click "Create report"
4 - Choose the FOI / SAR to generate business unit performance report
5 - Check the figure