### PR TITLE
CT-3165 specify complaint type

### DIFF
--- a/app/assets/stylesheets/moj/_layout.scss
+++ b/app/assets/stylesheets/moj/_layout.scss
@@ -63,7 +63,8 @@
   margin: 0;
 }
 
-#case-offender_sar {
+#case-offender_sar,
+#case-offender_sar_complaint {
   .request .grid-row {
     .request--heading {
       display: inline-block;

--- a/app/controllers/concerns/offender_form_validators.rb
+++ b/app/controllers/concerns/offender_form_validators.rb
@@ -1,7 +1,7 @@
 module OffenderFormValidators
   extend ActiveSupport::Concern
 
-  private 
+  private
 
   def validate_subject_details(params)
     set_empty_value_if_unset(params, "subject_type")
@@ -9,6 +9,13 @@ module OffenderFormValidators
     set_empty_value_if_unset(params, "flag_as_high_profile")
     object.assign_attributes(params)
     object.validate_date_of_birth
+  end
+
+  def validate_complaint_type(params)
+    set_empty_value_if_unset(params, "complaint_type")
+    set_empty_value_if_unset(params, "complaint_subtype")
+    set_empty_value_if_unset(params, "priority")
+    object.assign_attributes(params)
   end
 
   def validate_requester_details(params)

--- a/app/controllers/concerns/offender_sar_complaint_cases_params.rb
+++ b/app/controllers/concerns/offender_sar_complaint_cases_params.rb
@@ -5,6 +5,8 @@ module OffenderSARComplaintCasesParams
   def create_offender_sar_complaint_params
     params.require(:offender_sar_complaint).permit(
       :case_reference_number,
+      :complaint_type,
+      :complaint_subtype,
       :delivery_method,
       :date_of_birth_dd, :date_of_birth_mm, :date_of_birth_yyyy,
       :requester_reference,
@@ -15,6 +17,7 @@ module OffenderSARComplaintCasesParams
       :number_exempt_pages,
       :other_subject_ids,
       :postal_address,
+      :priority,
       :prison_number,
       :previous_case_numbers,
       :received_date_dd, :received_date_mm, :received_date_yyyy,

--- a/app/form_models/offender_sar_complaint_case_form.rb
+++ b/app/form_models/offender_sar_complaint_case_form.rb
@@ -1,10 +1,11 @@
 module OffenderSARComplaintCaseForm
   extend ActiveSupport::Concern
-  
+
   include OffenderFormValidators
 
   STEPS = %w[link-offender-sar-case
              confirm-offender-sar
+             complaint-type
              requester-details
              recipient-details
              requested-info
@@ -53,24 +54,24 @@ module OffenderSARComplaintCaseForm
     params.merge!(original_case_id: object.original_case_id)
     params.delete(:original_case_number)
     fields_subject_details = [
-      "subject_full_name", 
-      "subject_type", 
-      "subject_aliases", 
-      "subject_address", 
-      "prison_number", 
-      "other_subject_ids", 
-      "recipient", 
-      "third_party_relationship", 
-      "third_party", 
-      "third_party_company_name", 
-      "third_party_name", 
-      "postal_address", 
+      "subject_full_name",
+      "subject_type",
+      "subject_aliases",
+      "subject_address",
+      "prison_number",
+      "other_subject_ids",
+      "recipient",
+      "third_party_relationship",
+      "third_party",
+      "third_party_company_name",
+      "third_party_name",
+      "postal_address",
       "flag_as_high_profile",
       "date_of_birth"
     ]
     fields_subject_details.each do | single_field |
       params[single_field] = object.original_case.send(single_field)
-    end 
+    end
     params
   end
 

--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -32,16 +32,6 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
     high: 'high',
   }
 
-  # CT-3165 WIP REQUIRED FOR VALIDATIONS
-  #         REMOVE ONCE UX IS COMPLETED
-  before_validation :set_types
-  def set_types
-    self.complaint_type = 'standard'
-    self.complaint_subtype = 'missing_data'
-    self.priority = 'normal'
-  end
-  # CT-3165 END REMOVE ONCE UX IS COMPLETED
-
   class << self
     def type_abbreviation
       'OFFENDER_SAR_COMPLAINT'
@@ -67,7 +57,7 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
       acting_user: self.creator,
       acting_team: self.creator.case_team(self.original_case),
       message: I18n.t(
-        'common.case/offender_sar.complaint_case_link_message', 
+        'common.case/offender_sar.complaint_case_link_message',
         received_date: self.received_date.to_date))
   end
 

--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -15,13 +15,13 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
   validates :priority, presence: true
 
   enum complaint_type: {
-    standard:  'standard',
+    standard: 'standard',
     ico: 'ico',
     litigation: 'litigation',
   }
 
   enum complaint_subtype: {
-    missing_data:  'missing_data',
+    missing_data: 'missing_data',
     inaccurate_data: 'inaccurate_data',
     redacted_data: 'redacted_data',
     timeliness: 'timeliness',

--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -50,6 +50,14 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
     false
   end
 
+  def normal_priority?
+    normal?
+  end
+
+  def high_priority?
+    high?
+  end
+
   private
 
   def stamp_on_original_case

--- a/app/views/cases/offender_sar_complaint/_case_details.html.slim
+++ b/app/views/cases/offender_sar_complaint/_case_details.html.slim
@@ -12,6 +12,8 @@
 
         = render partial: 'cases/offender_sar_complaint/subject_details', locals: { case_details: case_details }
 
+        = render partial: 'cases/offender_sar_complaint/complaint_type', locals: { case_details: case_details }
+
         = render partial: 'cases/offender_sar_complaint/requested_on_behalf', locals: { case_details: case_details }
 
         - if case_details.third_party?

--- a/app/views/cases/offender_sar_complaint/_complaint_type.html.slim
+++ b/app/views/cases/offender_sar_complaint/_complaint_type.html.slim
@@ -1,0 +1,17 @@
+tr.complaint-type.section
+  th
+    = t('common.case.complaint_type')
+  td
+    = case_details.complaint_type.humanize
+  td
+    = link_to t('common.links.change'), edit_step_case_sar_offender_complaint_path(case_details, "complaint_type")
+tr.complaint-type.section
+  th
+    = t('common.case.complaint_subtype')
+  td
+    = case_details.complaint_subtype.humanize
+tr.complaint-type.section
+  th
+    = t('common.case.priority')
+  td
+    = case_details.priority.humanize

--- a/app/views/cases/offender_sar_complaint/_complaint_type.html.slim
+++ b/app/views/cases/offender_sar_complaint/_complaint_type.html.slim
@@ -5,12 +5,12 @@ tr.complaint-type.section
     = case_details.complaint_type.humanize
   td
     = link_to t('common.links.change'), edit_step_case_sar_offender_complaint_path(case_details, "complaint_type")
-tr.complaint-type.section
+tr.complaint-type
   th
     = t('common.case.complaint_subtype')
   td
     = case_details.complaint_subtype.humanize
-tr.complaint-type.section
+tr.complaint-type
   th
     = t('common.case.priority')
   td

--- a/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
@@ -8,6 +8,9 @@
   = f.radio_button_fieldset :complaint_type,
     choices: Case::SAR::OffenderComplaint::complaint_types.keys
 
+  = f.radio_button_fieldset :complaint_subtype,
+    choices: Case::SAR::OffenderComplaint::complaint_subtypes.keys
+
   input name="current_step" type="hidden" value=@case.current_step
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
@@ -11,6 +11,9 @@
   = f.radio_button_fieldset :complaint_subtype,
     choices: Case::SAR::OffenderComplaint::complaint_subtypes.keys
 
+  = f.radio_button_fieldset :priority,
+    choices: Case::SAR::OffenderComplaint::priorities.keys
+
   input name="current_step" type="hidden" value=@case.current_step
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
@@ -1,0 +1,13 @@
+- content_for :heading, flush: true
+  = t('cases.offender_sar.subject_heading')
+
+= render partial: 'layouts/header'
+
+= form_for @case.object, url: url, as: :offender_sar_complaint do |f|
+
+  = f.radio_button_fieldset :complaint_type,
+    choices: Case::SAR::OffenderComplaint::complaint_types.keys
+
+  input name="current_step" type="hidden" value=@case.current_step
+
+  = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
@@ -14,6 +14,10 @@
   = f.radio_button_fieldset :priority,
     choices: Case::SAR::OffenderComplaint::priorities.keys
 
+  / TODO required to enable create_params - remove as part of
+  / https://dsdmoj.atlassian.net/browse/CT-3166
+  = f.hidden_field :third_party_relationship
+
   input name="current_step" type="hidden" value=@case.current_step
 
   = f.submit 'Continue', class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -650,6 +650,7 @@ en:
       clearance_copy: 'You are clearing the response to: '
       complaint_type: What sort of complaint is this?
       complaint_subtype: What is the nature of the complaint?
+      priority: Priority
       compliant_in_time: Uploaded in time
       compliant_late: Uploaded late
       compliant_unknown: Unknown draft compliancy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -648,6 +648,8 @@ en:
         date_responded: Date response sent to ICO
       clear_response: Clear response
       clearance_copy: 'You are clearing the response to: '
+      complaint_type: What sort of complaint is this?
+      complaint_subtype: What is the nature of the complaint?
       compliant_in_time: Uploaded in time
       compliant_late: Uploaded late
       compliant_unknown: Unknown draft compliancy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,9 +170,9 @@ en:
               blank: can't be blank
         case/sar/offender_complaint:
           attributes:
-            linked_cases: 
+            linked_cases:
               original_case_already_related: already linked as the original case
-          original_case_number: 
+          original_case_number:
             blank: "Enter original case number"
             not_authorised: can't be authorised to link this case
             wrong_type: Original case must be Offender SAR
@@ -361,6 +361,9 @@ en:
         third_party: Please choose yes or no
       offender_sar_complaint:
         original_case_number: Is this the correct case?
+        complaint_type: What sort of complaint is this?
+        complaint_subtype: What is the nature of the complaint?
+        priority: Choose a priority level
       report:
         correspondence_type: Which type of cases do you want to report on?
         report_type_id: What should this report cover?

--- a/spec/decorators/case/offender_sar_complaint_decorator_spec.rb
+++ b/spec/decorators/case/offender_sar_complaint_decorator_spec.rb
@@ -31,6 +31,8 @@ describe Case::SAR::OffenderComplaintDecorator do
       offender_sar_complaint.next_step
       expect(offender_sar_complaint.get_step_partial).to eq "confirm_offender_sar_step"
       offender_sar_complaint.next_step
+      expect(offender_sar_complaint.get_step_partial).to eq "complaint_type_step"
+      offender_sar_complaint.next_step
       expect(offender_sar_complaint.get_step_partial).to eq "requester_details_step"
       offender_sar_complaint.next_step
       expect(offender_sar_complaint.get_step_partial).to eq "recipient_details_step"

--- a/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
@@ -265,6 +265,9 @@ feature 'offender sar complaint case creation by a manager', js: true do
     expect(cases_show_page).to have_content linked_case.prison_number
     expect(cases_show_page).to have_content linked_case.subject_type.humanize
     expect(cases_show_page).to have_content linked_case.subject_address
+    expect(cases_show_page).to have_content "Standard"
+    expect(cases_show_page).to have_content "Missing data"
+    expect(cases_show_page).to have_content "Normal priority"
   end
 
   def then_expect_open_cases_page_to_be_correct(offender_sar_case: nil)

--- a/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
@@ -267,7 +267,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     expect(cases_show_page).to have_content linked_case.subject_address
     expect(cases_show_page).to have_content "Standard"
     expect(cases_show_page).to have_content "Missing data"
-    expect(cases_show_page).to have_content "Normal priority"
+    expect(cases_show_page).to have_content "Normal"
   end
 
   def then_expect_open_cases_page_to_be_correct(offender_sar_case: nil)

--- a/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
@@ -14,6 +14,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
   scenario '1 find the original offender sar case' do
     when_i_navigate_to_offender_sar_complaint_subject_page
     and_choose_original_offender_sar_case_and_confirm
+    and_fill_in_complaint_type_page
     and_fill_in_requester_details_page
     and_fill_in_recipient_details_page
     and_fill_in_requested_info_page
@@ -29,6 +30,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
   scenario '2 Data subject requesting data to be sent to third party' do
     when_i_navigate_to_offender_sar_complaint_subject_page
     and_choose_original_offender_sar_case_and_confirm
+    and_fill_in_complaint_type_page
     and_fill_in_requester_details_page
     and_fill_in_recipient_details_page(:third_party)
     and_fill_in_requested_info_page
@@ -44,6 +46,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
   scenario '3 Solicitor requesting data subject record' do
     when_i_navigate_to_offender_sar_complaint_subject_page
     and_choose_original_offender_sar_case_and_confirm
+    and_fill_in_complaint_type_page
     and_fill_in_requester_details_page(:third_party)
     and_fill_in_recipient_details_page(recipient: 'requester_recipient')
     and_fill_in_requested_info_page
@@ -59,6 +62,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
   scenario '4 Solicitor requesting record to be sent to data subject' do
     when_i_navigate_to_offender_sar_complaint_subject_page
     and_choose_original_offender_sar_case_and_confirm
+    and_fill_in_complaint_type_page
     and_fill_in_requester_details_page(:third_party)
     and_fill_in_recipient_details_page(recipient: 'subject_recipient')
     and_fill_in_requested_info_page
@@ -74,6 +78,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
   scenario '5 Copy the third part details from linked offender sar case' do
     when_i_navigate_to_offender_sar_complaint_subject_page
     and_choose_original_offender_sar_case_and_confirm
+    and_fill_in_complaint_type_page
     click_on "Continue"
     click_on "Continue"
     and_fill_in_requested_info_page
@@ -89,6 +94,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
   scenario '6 Create the complaint case from closed offender sar case' do
     when_i_navigate_to_offender_sar_subject_page_and_start_complaint
     and_confirm_offender_sar_case
+    and_fill_in_complaint_type_page
     click_on "Continue"
     click_on "Continue"
     and_fill_in_requested_info_page
@@ -104,6 +110,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     offender_sar_open_late = create(:offender_sar_case, :third_party, received_date: Date.new(2017, 1, 4))
     when_i_navigate_to_offender_sar_subject_page_and_start_complaint(offender_sar_case: offender_sar_open_late)
     and_confirm_offender_sar_case
+    and_fill_in_complaint_type_page
     and_fill_in_requester_details_page(:third_party)
     and_fill_in_recipient_details_page(recipient: 'subject_recipient')
     and_fill_in_requested_info_page
@@ -206,7 +213,14 @@ feature 'offender sar complaint case creation by a manager', js: true do
     click_on "Continue"
   end
 
+  def and_fill_in_complaint_type_page(params = nil)
+    expect(cases_new_offender_sar_complaint_complaint_type_page).to be_displayed
+    cases_new_offender_sar_complaint_complaint_type_page.fill_in_case_details(params)
+    click_on "Continue"
+  end
+
   def and_fill_in_requester_details_page(params = nil)
+    expect(cases_new_offender_sar_complaint_requester_details_page).to be_displayed
     cases_new_offender_sar_complaint_requester_details_page.fill_in_case_details(params)
     click_on "Continue"
     expect(cases_new_offender_sar_complaint_recipient_details_page).to have_content "Create OFFENDER-SAR-COMPLAINT case"

--- a/spec/form_models/offender_sar_complaint_case_form_spec.rb
+++ b/spec/form_models/offender_sar_complaint_case_form_spec.rb
@@ -10,12 +10,13 @@ RSpec.describe OffenderSARComplaintCaseForm do
   describe "#steps" do
     it "returns the list of steps" do
       expect(case_form.steps).to eq [
-        "link-offender-sar-case", 
-        "confirm-offender-sar", 
-        "requester-details", 
-        "recipient-details", 
-        "requested-info", 
-        "request-details", 
+        "link-offender-sar-case",
+        "confirm-offender-sar",
+        "complaint-type",
+        "requester-details",
+        "recipient-details",
+        "requested-info",
+        "request-details",
         "date-received"]
     end
   end

--- a/spec/models/case/sar/offender_complaint_spec.rb
+++ b/spec/models/case/sar/offender_complaint_spec.rb
@@ -47,7 +47,6 @@ describe Case::SAR::OffenderComplaint do
   describe '#complaint_type' do
     context 'validates that complaint type is not blank' do
       it 'errors' do
-        pending 'removal of the "set_type" validation hack'
         kase = build(:offender_sar_complaint, complaint_type: nil)
         expect(kase).not_to be_valid
         expect(kase.errors[:complaint_type]).to eq ["can't be blank"]
@@ -74,7 +73,6 @@ describe Case::SAR::OffenderComplaint do
   describe '#priority' do
     context 'validates that priority is not blank' do
       it 'errors' do
-        pending 'removal of the "set_type" validation hack'
         kase = build(:offender_sar_complaint, priority: nil)
         expect(kase).not_to be_valid
         expect(kase.errors[:priority]).to eq ["can't be blank"]
@@ -100,7 +98,6 @@ describe Case::SAR::OffenderComplaint do
   describe '#complaint_subtype' do
     context 'validates that complaint_subtype is not blank' do
       it 'errors' do
-        pending 'removal of the "set_type" validation hack'
         kase = build(:offender_sar_complaint, complaint_subtype: nil)
         expect(kase).not_to be_valid
         expect(kase.errors[:complaint_subtype]).to eq ["can't be blank"]

--- a/spec/models/case/sar/offender_complaint_spec.rb
+++ b/spec/models/case/sar/offender_complaint_spec.rb
@@ -95,6 +95,24 @@ describe Case::SAR::OffenderComplaint do
     end
   end
 
+  describe '#normal_priority?' do
+    it 'delegates to normal?' do
+      kase = build(:offender_sar_complaint, priority: 'normal')
+      expect(kase.normal_priority?).to be true
+      kase.high!
+      expect(kase.normal_priority?).to be false
+    end
+  end
+
+  describe '#high_priority?' do
+    it 'delegates to high?' do
+      kase = build(:offender_sar_complaint, priority: 'high')
+      expect(kase.high_priority?).to be true
+      kase.normal!
+      expect(kase.high_priority?).to be false
+    end
+  end
+
   describe '#complaint_subtype' do
     context 'validates that complaint_subtype is not blank' do
       it 'errors' do

--- a/spec/services/stats/r901_offender_sar_cases_report_spec.rb
+++ b/spec/services/stats/r901_offender_sar_cases_report_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module Stats
   describe R901OffenderSarCasesReport do
-    # before(:all) { DbHousekeeping.clean(seed: true) }
+    before(:all) { DbHousekeeping.clean(seed: true) }
     after(:all) { DbHousekeeping.clean(seed: true) }
 
     describe '.title' do

--- a/spec/site_prism/page_objects/pages/application.rb
+++ b/spec/site_prism/page_objects/pages/application.rb
@@ -46,7 +46,8 @@ module PageObjects
         cases_edit_offender_sar_date_received:        'Cases::Edit::OffenderSARPageDateReceived',
 
         cases_new_offender_sar_complaint_confirm_case:       'Cases::New::OffenderSARComplaintPageConfirmCase',
-        cases_new_offender_sar_complaint_link_offender_sar:  'Cases::New::OffenderSARComplaintPageLinkSarCase', 
+        cases_new_offender_sar_complaint_link_offender_sar:  'Cases::New::OffenderSARComplaintPageLinkSarCase',
+        cases_new_offender_sar_complaint_complaint_type:     'Cases::New::OffenderSARComplaintPageComplaintType',
         cases_new_offender_sar_complaint_requester_details:  'Cases::New::OffenderSARComplaintPageRequesterDetails',
         cases_new_offender_sar_complaint_recipient_details:  'Cases::New::OffenderSARComplaintPageRecipientDetails',
         cases_new_offender_sar_complaint_requested_info:     'Cases::New::OffenderSARComplaintPageRequestedInfo',

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
@@ -17,6 +17,12 @@ module PageObjects
           def fill_in_case_details(params={})
             kase = FactoryBot.build :offender_sar_complaint, params
 
+            fill_in_complaint_type(kase)
+            fill_in_complaint_subtype(kase)
+            fill_in_priority(kase)
+          end
+
+          def fill_in_complaint_type(kase)
             if kase.standard?
               choose('offender_sar_complaint_complaint_type_standard', visible: false)
             elsif kase.ico?
@@ -24,7 +30,9 @@ module PageObjects
             elsif kase.litigation?
               choose('offender_sar_complaint_complaint_type_litigation', visible: false)
             end
+          end
 
+          def fill_in_complaint_subtype(kase)
             if kase.missing_data?
               choose('offender_sar_complaint_complaint_subtype_missing_data', visible: false)
             elsif kase.inaccurate_data?
@@ -34,13 +42,14 @@ module PageObjects
             elsif kase.timeliness?
               choose('offender_sar_complaint_complaint_subtype_timeliness', visible: false)
             end
+          end
 
+          def fill_in_priority(kase)
             if kase.normal_priority?
               choose('offender_sar_complaint_priority_normal_priority', visible: false)
             elsif kase.high_priority?
               choose('offender_sar_complaint_priority_standard_priority', visible: false)
             end
-
           end
 
         end

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
@@ -46,9 +46,9 @@ module PageObjects
 
           def fill_in_priority(kase)
             if kase.normal_priority?
-              choose('offender_sar_complaint_priority_normal_priority', visible: false)
+              choose('offender_sar_complaint_priority_normal', visible: false)
             elsif kase.high_priority?
-              choose('offender_sar_complaint_priority_standard_priority', visible: false)
+              choose('offender_sar_complaint_priority_standard', visible: false)
             end
           end
 

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
@@ -1,0 +1,33 @@
+module PageObjects
+  module Pages
+    module Cases
+      module New
+        class OffenderSARComplaintPageComplaintType < PageObjects::Pages::Base
+
+          set_url '/cases/offender_sar_complaints/complaint-type'
+
+          section :primary_navigation,
+                  PageObjects::Sections::PrimaryNavigationSection, '.global-nav'
+
+          section :page_heading,
+                  PageObjects::Sections::PageHeadingSection, '.page-heading'
+
+          element :submit_button, '.button'
+
+          def fill_in_case_details(params={})
+            kase = FactoryBot.build :offender_sar_complaint, params
+
+            if kase.standard?
+              choose('offender_sar_complaint_complaint_type_standard', visible: false)
+            elsif kase.ico?
+              choose('offender_sar_complaint_complaint_type_ico', visible: false)
+            elsif kase.litigation?
+              choose('offender_sar_complaint_complaint_type_litigation', visible: false)
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
@@ -24,6 +24,17 @@ module PageObjects
             elsif kase.litigation?
               choose('offender_sar_complaint_complaint_type_litigation', visible: false)
             end
+
+            if kase.missing_data?
+              choose('offender_sar_complaint_complaint_subtype_missing_data', visible: false)
+            elsif kase.inaccurate_data?
+              choose('offender_sar_complaint_complaint_subtype_inaccurate_data', visible: false)
+            elsif kase.redacted_data?
+              choose('offender_sar_complaint_complaint_subtype_redacted_data', visible: false)
+            elsif kase.timeliness?
+              choose('offender_sar_complaint_complaint_subtype_timeliness', visible: false)
+            end
+
           end
 
         end

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
@@ -35,6 +35,12 @@ module PageObjects
               choose('offender_sar_complaint_complaint_subtype_timeliness', visible: false)
             end
 
+            if kase.normal_priority?
+              choose('offender_sar_complaint_priority_normal_priority', visible: false)
+            elsif kase.high_priority?
+              choose('offender_sar_complaint_priority_standard_priority', visible: false)
+            end
+
           end
 
         end


### PR DESCRIPTION
## Description
Add the complaint type step, allowing the user to create and view the details for complaint_type, complaint_subtype, and priority on the case show page

Removes the workaround that allowed cases to be created

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/101335302-ebe3ce80-3870-11eb-8a57-573cdf6647c6.png)

![image](https://user-images.githubusercontent.com/1161161/101335383-09189d00-3871-11eb-86c2-4c0f13d86c9e.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3165

### Deployment
Updates the values for complaint type, subtype, priority on existing cases so they don't break

### Manual testing instructions
Create a complaint case - you should be asked for the new fields and the values should show up correctly on the show page
