### PR TITLE
CT-3322 Use only active teams for managing teams

### DIFF
--- a/app/models/teams_users_role.rb
+++ b/app/models/teams_users_role.rb
@@ -22,4 +22,5 @@ class TeamsUsersRole < ApplicationRecord
   scope :responder_roles, -> { where(role: :responder) }
   scope :approver_roles,  -> { where(role: :approver) }
   scope :active_approver_roles,  -> { where(role: :approver).joins(:team).where("teams": {deleted_at: nil}) }
+  scope :active_manager_roles,  -> { where(role: :manager).joins(:team).where("teams": {deleted_at: nil}) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,7 +53,7 @@ class User < ApplicationRecord
   has_many :team_roles, class_name: 'TeamsUsersRole'
   has_many :teams, through: :team_roles
   has_many :managing_team_roles,
-           -> { manager_roles },
+           -> { active_manager_roles },
            class_name: 'TeamsUsersRole'
   has_many :responding_team_roles,
            -> { responder_roles  },

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -121,13 +121,26 @@ RSpec.describe User, type: :model do
   describe 'has_one: approving_team' do
     it "returns the first active approving team" do
       current_approving_team = approver.approving_team
-      new_team = create :business_unit, correspondence_type_ids: [foi.id]   
+      new_team = create :business_unit, correspondence_type_ids: [foi.id]
       approver.team_roles << TeamsUsersRole.new(team: new_team, role: 'approver')
       approver.reload
       current_approving_team.deleted_at = Time.now
       current_approving_team.save!
       approver.reload
       expect(approver.approving_team).to eq new_team
+    end
+  end
+
+  describe 'has_many: managing_teams' do
+    it "returns active managing teams" do
+      current_managing_team = manager.managing_teams.first
+      new_team = create :managing_team, correspondence_type_ids: [foi.id]
+      manager.team_roles << TeamsUsersRole.new(team: new_team, role: 'manager')
+      manager.reload
+      current_managing_team.deleted_at = Time.now
+      current_managing_team.save!
+      manager.reload
+      expect(manager.managing_teams.first).to eq new_team
     end
   end
 
@@ -159,14 +172,14 @@ RSpec.describe User, type: :model do
   end
 
   describe '#case_team' do
-    
+
     context 'user is in one of the teams associated with the case' do
       it 'returns the team link to user and case both' do
         kase = create :pending_dacu_clearance_case
         new_team = create :business_unit, correspondence_type_ids: [foi.id]
         check_user = kase.responder
         check_user.team_roles << TeamsUsersRole.new(team: new_team, role: 'approver')
-        check_user.reload  
+        check_user.reload
         expect(check_user.case_team(kase)).to eq kase.responding_team
       end
     end
@@ -177,7 +190,7 @@ RSpec.describe User, type: :model do
         new_team = create :business_unit, correspondence_type_ids: [foi.id]
         check_user = create(:user)
         check_user.team_roles << TeamsUsersRole.new(team: new_team, role: 'approver')
-        check_user.reload  
+        check_user.reload
         expect(check_user.case_team(kase)).to eq new_team
       end
     end


### PR DESCRIPTION
## Description
After reorganising teams, some users in BMT have been left with inconsistent privileges because the system checks for the manager role against teams that have been deactivated - we need to do the same for managing teams as we did for approving teams and ensure the system always checks for valid team memberships when deciding on manager role permissions


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
Before - a user in BMT whose managing team roles return a deactivated version of BMT cannot create new cases  because all the correspondence types moved to the new incarnation of BMT
![image](https://user-images.githubusercontent.com/1161161/102980046-d9b79080-44fe-11eb-8b6a-ff4cefc9f06d.png)

After - managing_teams only looks at active teams
![image](https://user-images.githubusercontent.com/1161161/102980170-0ec3e300-44ff-11eb-9f26-51c58657c860.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3322

### Deployment
none

### Manual testing instructions
If you have an anonymised copy of the DB, you can reset the password and log in as user id 722, and go to Create Case. On master, you should see no available correspondence types. With this branch, you should see available correspondence types. 