### PR TITLE
CT-2087 remove duplicate IDs and update JavaScript

### DIFF
--- a/app/assets/javascripts/modules/QuickLinks.js
+++ b/app/assets/javascripts/modules/QuickLinks.js
@@ -1,6 +1,6 @@
 moj.Modules.QuickLinks = {
   init: function (){
-    var $quickLinks = $('.quick-link-option--first, .quick-link-option');
+    var $quickLinks = $('.js-quick-links .quick-link-option');
      this.bindFinalDeadlineEvents($quickLinks);
   },
 
@@ -9,7 +9,7 @@ moj.Modules.QuickLinks = {
       var $elem = $(this);
       var objFromData = $elem.data('date-from');
       var objToData = $elem.data('date-to');
-      var fieldsIDprefix = 'search_query_' + this.id;
+      var fieldsIDprefix = 'search_query_' + $elem.data('target-id');
       var $parentForm = $elem.closest('form');
 
       $('#' + fieldsIDprefix + '_from_dd').val(objFromData.day);

--- a/app/views/cases/search_filters/_date_range.html.slim
+++ b/app/views/cases/search_filters/_date_range.html.slim
@@ -8,7 +8,7 @@ fieldset
           - filter.available_choices.each do | _, date_info |
             li.quick-link-option
               a { href="#"
-                  id="#{filter.class.date_field_name}"
+                  data-target-id="#{filter.class.date_field_name}"
                   aria-describeby="quick-link-label"
                   data-date-from=date_info[:from]
                   data-date-to=date_info[:to]


### PR DESCRIPTION
## Description
Remove duplicate IDs from quick links filter - updated JavaScript to maintain functionality

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/22935203/103795220-9e0fe100-503d-11eb-9a10-109150a4714d.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2087

### Deployment
n/a

### Manual testing instructions
Click on the quick links filters like Today, next 3 days etc, should work as expected, then check for duplicate IDs using this extension Dup-ID for Chrome, and check if any there on All open cases page.