### PR TITLE
CT-3338 add "not applicable"

### DIFF
--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -37,6 +37,7 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
     inaccurate_data: 'inaccurate_data',
     redacted_data: 'redacted_data',
     timeliness: 'timeliness',
+    not_applicable: 'not_applicable'
   }
 
   enum priority: {

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
@@ -59,6 +59,8 @@ module PageObjects
               choose('offender_sar_complaint_complaint_subtype_redacted_data', visible: false)
             elsif kase.timeliness?
               choose('offender_sar_complaint_complaint_subtype_timeliness', visible: false)
+            elsif kase.not_applicable?
+              choose('offender_sar_complaint_complaint_subtype_not_applicable', visible: false)
             end
           end
 


### PR DESCRIPTION
## Description
In order to facilitate migration of existing cases from Access, we need a new complaint_subtype of "None" so that migrated cases will validate and be able to be edited/saved once they're imported. 

Turns out we can’t use “none” because this will generate a class method "none", which is already defined by Active Record so using “Not applicable” instead

Can't find any tests to update, apologies for one-liner PR 😹 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
![image](https://user-images.githubusercontent.com/1161161/104300057-e2780280-54bd-11eb-9ffd-16e092a03bd3.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3338

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
