### PR TITLE
CT-3251  Added extra column for complaint type in open cases report

### DIFF
--- a/app/services/stats/r901_offender_sar_cases_report.rb
+++ b/app/services/stats/r901_offender_sar_cases_report.rb
@@ -5,6 +5,8 @@ module Stats
 
     CSV_COLUMN_HEADINGS = [
         'Case number',
+        'Case type',
+        'Nature of the complaint', 
         'Date received at MOJ',
         'Final deadline',
         'Who is making the request?',
@@ -19,16 +21,16 @@ module Stats
     ]
 
     def self.title
-      'Cases report for Offender SAR'
+      'Cases report for Offender SAR and Complaint'
     end
 
     def self.description
-      'The list of Offender SAR cases within allowed and filtered scope'
+      'The list of Offender SAR and Complaint cases within allowed and filtered scope'
     end
 
     def initialize(**options)
       super(**options)
-      @case_scope = options[:case_scope] || Case::Base.offender_sar.all
+      @case_scope = options[:case_scope] || basic_scope
     end
 
     def case_scope
@@ -41,6 +43,8 @@ module Stats
     def analyse_case(kase)
       [
         kase.number,
+        case_type(kase), 
+        complaint_subtype_for_report(kase),
         kase.received_date,
         kase.external_deadline,
         kase.third_party? ? kase.third_party_relationship : 'Data subject',
@@ -62,5 +66,21 @@ module Stats
     def report_type
       ReportType.r901
     end
+
+    private 
+
+    def basic_scope
+      # As the Complaint class is inheried from Offender, so the following will return both type cases
+      # which may cause issue in the future if we change the hierarchy of offender related classes
+      Case::SAR::Offender.all
+    end
+
+    def complaint_subtype_for_report(kase)
+      kase.offender_sar_complaint? ? kase.complaint_subtype.humanize : ""
+    end
+
+    def case_type(kase)
+      kase.offender_sar_complaint? ? "Offender SAR Complaint" : kase.decorate.pretty_type
+    end 
   end
 end

--- a/spec/services/stats/r901_offender_sar_cases_report_spec.rb
+++ b/spec/services/stats/r901_offender_sar_cases_report_spec.rb
@@ -7,14 +7,14 @@ module Stats
 
     describe '.title' do
       it 'returns correct title' do
-        expect(described_class.title).to eq 'Cases report for Offender SAR'
+        expect(described_class.title).to eq 'Cases report for Offender SAR and Complaint'
       end
     end
 
     describe '.description' do
       it 'returns correct description' do
         expect(described_class.description)
-          .to eq 'The list of Offender SAR cases within allowed and filtered scope'
+          .to eq 'The list of Offender SAR and Complaint cases within allowed and filtered scope'
       end
     end
 
@@ -23,7 +23,7 @@ module Stats
         create_report_type(abbr: :r901)
       end
 
-      it 'returns correct columns' do
+      it 'returns correct columns for offender sar' do
         report = described_class.new()
         offender_sar_case = create :offender_sar_case, :waiting_for_data,
                                     subject_type: 'ex_probation_service_user',
@@ -31,11 +31,37 @@ module Stats
         result = report.analyse_case(offender_sar_case)
         expect(result).to include(
           offender_sar_case.number,
+          offender_sar_case.decorate.pretty_type, 
+          "",
           offender_sar_case.received_date,
           offender_sar_case.external_deadline,
           "Data subject",
           nil,
           "testing analyse_case",
+          "Ex-probation service user",
+          0,
+          "in time",
+          "Waiting for data",
+          1,
+          "No"
+        )
+      end
+
+      it 'returns correct columns for offender sar complaint' do
+        report = described_class.new()
+        offender_sar_complaint = create :offender_sar_complaint, :waiting_for_data, 
+                                    subject_type: 'ex_probation_service_user',
+                                    subject_full_name: 'testing analyse_complaint_case'
+        result = report.analyse_case(offender_sar_complaint)
+        expect(result).to include(
+          offender_sar_complaint.number,
+          "Offender SAR Complaint", 
+          offender_sar_complaint.complaint_subtype.humanize,
+          offender_sar_complaint.received_date,
+          offender_sar_complaint.external_deadline,
+          "Data subject",
+          nil,
+          "testing analyse_complaint_case",
           "Ex-probation service user",
           0,
           "in time",
@@ -63,16 +89,24 @@ module Stats
 
         @sar_4 = create :accepted_sar, identifier: 'sar-4'
         @offender_sar_4 = create :offender_sar_case, :ready_to_copy, identifier: 'osar-4'
+
+        @offender_sar_complaint_1 = create :offender_sar_complaint, :ready_to_copy, identifier: 'osar-complaint-4'
       end
 
-      it 'returns only Offender SAR cases with initial scope of nil' do
+      it 'returns only Offender SAR related cases with initial scope of nil' do
         report = described_class.new()
-        expect(report.case_scope).to match_array( [@offender_sar_1, @offender_sar_2, @offender_sar_3, @offender_sar_4])
+        expect(report.case_scope).to match_array( [
+          @offender_sar_1, 
+          @offender_sar_2, 
+          @offender_sar_3, 
+          @offender_sar_4, 
+          @offender_sar_complaint_1.original_case, 
+          @offender_sar_complaint_1])
       end
 
-      it 'returns only Offender SAR cases with initial scope of ready-to-copy cases being asked' do
+      it 'returns only Offender SAR related cases with initial scope of ready-to-copy cases being asked' do
         report = described_class.new(case_scope: Case::SAR::Offender.all.where(current_state: 'ready_to_copy'))
-        expect(report.case_scope).to match_array( [@offender_sar_4])
+        expect(report.case_scope).to match_array( [@offender_sar_4, @offender_sar_complaint_1])
       end
     end
   end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to add 2 columns into open cases report for offender sar and complaint 
- Case type
- Nature of complaint

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3251

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
1 - Login as Branston user
2 - Click 'Open cases' tab
3 - Click 'Download cases'
4 - Check the data