### PR TITLE
CT-3384 Changed rule of complaint case number

### DIFF
--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -194,9 +194,29 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
 
   def set_number
     if self.original_case.present?
-      self.number = "Q#{self.original_case.number}"
+      self.number = next_number_from_original_case
     else
       next_number
     end
   end
+
+  private 
+  
+  def next_number_from_original_case
+    # It should be rarely multiple persons are tryniig to create a new complaint 
+    # against the same original case and submit nearly at the same time. So IMO (yikang)
+    # it is not worthying to track the counter per cases level, simple appoach here is to 
+    # try 2 times only if the case number somehow is duplicate
+    begin
+      retries ||= 0
+      counter = self.original_case.case_links.count
+      counter_str = counter > 0 ? "-#{counter.to_s.rjust(3, "0")}" : ""
+      new_case_number = "Q#{self.original_case.number}#{counter_str}"
+      raise "Duplicate case number, please try again " unless Case::Base.find_by_number(new_case_number).blank?
+      new_case_number
+    rescue
+      retry if (retries += 1) < 3
+    end
+  end
+
 end

--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -203,8 +203,8 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
   def next_number_from_original_case
     # It should be rarely multiple persons are tryniig to create a new complaint 
     # against the same original case and submit nearly at the same time. So IMO (yikang)
-    # it is not worthying to track the counter per cases level, simple appoach here is to 
-    # try 2 times only if the case number somehow is duplicate
+    # it is not worthying to track the counter per cases level at DB like case number for other types, 
+    # simple appoach here is to try 2 times only if the case number somehow is duplicate by any chance
     begin
       retries ||= 0
       counter = self.original_case.case_links.count

--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -201,10 +201,10 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
   end
   
   def next_number_from_original_case
-    # It should be rarely multiple persons are tryniig to create a new complaint 
+    # It should be rare that multiple persons are trying to create a new complaint 
     # against the same original case and submit nearly at the same time. So IMO (yikang)
-    # it is not worthying to track the counter per cases level at DB like case number for other types, 
-    # simple appoach here is to try 2 times only if the case number somehow is duplicate by any chance
+    # it is not worth trying to track the counter per cases level at DB like case number for other types, 
+    # simple appoach here is to try 2 times only if the case number somehow is duplicated by any chance
     begin
       retries ||= 0
       counter = self.original_case.case_links.count

--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -199,8 +199,6 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
       next_number
     end
   end
-
-  private 
   
   def next_number_from_original_case
     # It should be rarely multiple persons are tryniig to create a new complaint 

--- a/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
@@ -35,7 +35,7 @@ feature 'Generate an acknowledgement letter by a responder' do
 
       click_on "Save as Word"
       expect(cases_show_letter_page).to be_displayed
-      sleep 1
+      sleep 2
       output_files = Dir["#{Rails.root}/acknowledgement.docx"]
       expect(output_files.length).to eq 1
       File.delete(output_files.first)

--- a/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
@@ -10,7 +10,7 @@ feature 'Generate an acknowledgement letter by a responder' do
     login_as responder
   end
 
-  context 'responder can choose a template and view the rendered letter', js: true do
+  context 'responder can choose a template and view the rendered letter' do
     scenario 'when the case has just been created' do
       cases_show_page.load(id: offender_sar_complaint.id)
       expect(cases_show_page).to be_displayed

--- a/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
@@ -33,16 +33,9 @@ feature 'Generate an acknowledgement letter by a responder' do
       expect(cases_show_letter_page).to be_displayed
       expect(cases_show_letter_page).to have_content "Thank you for your offender subject access request, Bob"
 
-      Dir.glob("#{Rails.root}/*.docx").sort.map do | local_filename |
-        puts "#{local_filename}"
-      end
-
       click_on "Save as Word"
       expect(cases_show_letter_page).to be_displayed
-      sleep 2
-      Dir.glob("#{Rails.root}/*.docx").sort.map do | local_filename |
-        puts "#{local_filename}"
-      end
+      sleep 1
       output_files = Dir["#{Rails.root}/acknowledgement.docx"]
       expect(output_files.length).to eq 1
       File.delete(output_files.first)

--- a/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/generate_acknowledgement_letter_spec.rb
@@ -10,7 +10,7 @@ feature 'Generate an acknowledgement letter by a responder' do
     login_as responder
   end
 
-  context 'responder can choose a template and view the rendered letter' do
+  context 'responder can choose a template and view the rendered letter', js: true do
     scenario 'when the case has just been created' do
       cases_show_page.load(id: offender_sar_complaint.id)
       expect(cases_show_page).to be_displayed
@@ -33,9 +33,16 @@ feature 'Generate an acknowledgement letter by a responder' do
       expect(cases_show_letter_page).to be_displayed
       expect(cases_show_letter_page).to have_content "Thank you for your offender subject access request, Bob"
 
+      Dir.glob("#{Rails.root}/*.docx").sort.map do | local_filename |
+        puts "#{local_filename}"
+      end
+
       click_on "Save as Word"
       expect(cases_show_letter_page).to be_displayed
       sleep 2
+      Dir.glob("#{Rails.root}/*.docx").sort.map do | local_filename |
+        puts "#{local_filename}"
+      end
       output_files = Dir["#{Rails.root}/acknowledgement.docx"]
       expect(output_files.length).to eq 1
       File.delete(output_files.first)

--- a/spec/models/case/sar/offender_complaint_spec.rb
+++ b/spec/models/case/sar/offender_complaint_spec.rb
@@ -819,10 +819,16 @@ describe Case::SAR::OffenderComplaint do
     end
   end
 
-  describe '#case number' do
-    it "Take the original case's number with 'Q' as the prefix" do 
+  describe '#case number' do    
+    it "'Q' + original_case.number if one complaint" do 
       complaint = create(:offender_sar_complaint)
       expect(complaint.number).to eq "Q#{complaint.original_case.number}"
+    end
+
+    it "'Q' + original_case.number + '-' + sequence number if multi-complaints" do 
+      complaint = create(:offender_sar_complaint)
+      complaint1 = create(:offender_sar_complaint, original_case: complaint.original_case)
+      expect(complaint1.number).to eq "Q#{complaint.original_case.number}-001"
     end
   end
 end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to fix the issue of duplicate case number if multi-complaints are raised against the same offender sar case.  The rule is below 
Original Offender SAR case number: 210108002
New Complaint case number:  Q210108002
2nd Complaint case number:   Q210108002 - 001 
3rd Complaint case number:    Q210108002 - 002 and so on.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/browse/CT-3384

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
