### PR TITLE
CT-2548 adjust layout of searchbox area on mobile

### DIFF
--- a/app/assets/stylesheets/moj/_govuk_overrides.scss
+++ b/app/assets/stylesheets/moj/_govuk_overrides.scss
@@ -48,3 +48,10 @@ legend .heading-small{
 .form-control-1-1 {
   width: 100%;
 }
+
+@include media(mobile) {
+  #search_query_search_text { 
+    width: calc(100% - 12px)
+  }
+  #search-button { margin: 10px 0 0 0; width: 100%;} 
+}


### PR DESCRIPTION
## Description
Tidy up layout on mobile for protruding search box. Headings being inconsistent, and large gap under heading will be dealt with here: https://dsdmoj.atlassian.net/browse/CT-3471 - but search box protrusion was causing accessibility issues as layout was breaking only for mobile.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/22935203/108360284-ebf53880-71e8-11eb-965a-a709d1cccffc.png)


After: 
![image](https://user-images.githubusercontent.com/22935203/108360147-bd775d80-71e8-11eb-81b5-c4b5d33a6b47.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2548

### Deployment
n/a

### Manual testing instructions
Search box should look tidy on mobile view and same as before on other views.
