### PR TITLE
CT-3442 Hide the data_requests button from to_be_assessed state

### DIFF
--- a/app/views/cases/offender_sar/_data_requests.html.slim
+++ b/app/views/cases/offender_sar/_data_requests.html.slim
@@ -39,9 +39,9 @@
           - if case_details.data_requests.many?
             = render partial: 'shared/table_total_row', locals: { total: case_details.data_requests.sum(:cached_num_pages), label_span: '3', value_span: '3' }
 .data-request-buttons
-  - if case_details.current_state != 'closed' && allow_editing
+  - if policy(case_details).can_record_data_request? && allow_editing
     = action_button_for(:record_data_request)
-  - if allow_editing
+  - if case_details.current_state != 'to_be_assessed' && allow_editing
     = link_to I18n.t('button.exempt_pages'), edit_step_case_sar_offender_path(case_details, 'exempt_pages'), class: 'button-tertiary'
     = link_to I18n.t('button.final_page_count'), edit_step_case_sar_offender_path(case_details, 'final_page_count'), class: 'button-tertiary'
 

--- a/config/state_machine/configs/00_moj/50_offender_sar_complaint/20_offender_sar_complaint_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/50_offender_sar_complaint/20_offender_sar_complaint_standard_workflow.yml
@@ -12,7 +12,6 @@
                   transition_to: data_to_be_requested
                 mark_as_require_response:
                   transition_to: response_required
-                add_data_received:
                 add_note_to_case:
                 send_acknowledgement_letter:
                 edit_case:

--- a/spec/features/cases/offender_sar_complaint/add_data_requests_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/add_data_requests_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'Data Requests for an Offender SAR' do
+feature 'Data Requests for an Offender SAR complaint' do
   given(:manager) { find_or_create :branston_user }
   given(:offender_sar_complaint) { create(:offender_sar_complaint).decorate }
 
@@ -10,6 +10,17 @@ feature 'Data Requests for an Offender SAR' do
 
   scenario 'successfully add 2 new requests', js: true do
     cases_show_page.load(id: offender_sar_complaint.id)
+
+    expect(cases_show_page).to_not have_content "Record data request"
+    expect(cases_show_page).to_not have_content "Update exempt pages"
+    expect(cases_show_page).to_not have_content "Update final page count"
+
+    click_on 'Requires data'
+
+    expect(cases_show_page).to have_content "Record data request"
+    expect(cases_show_page).to have_content "Update exempt pages"
+    expect(cases_show_page).to have_content "Update final page count"
+
     click_on 'Record data request'
     expect(data_request_page).to be_displayed
 
@@ -72,6 +83,7 @@ feature 'Data Requests for an Offender SAR' do
 
   scenario 'partial data entry fails' do
     cases_show_page.load(id: offender_sar_complaint.id)
+    click_on 'Requires data'
     click_on 'Record data request'
 
     # Note only filling in Location field, ommitting corresponding Data field
@@ -84,6 +96,7 @@ feature 'Data Requests for an Offender SAR' do
 
   scenario 'no data entry fails' do
     cases_show_page.load(id: offender_sar_complaint.id)
+    click_on 'Requires data'
     click_on 'Record data request'
 
     data_request_page.form.location.fill_in(with: '    ')

--- a/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
@@ -128,251 +128,6 @@ feature 'offender sar complaint case editing by a manager' do
     then_i_expect_the_case_status_to_be_the_same
   end
 
-  def and_i_expect_the_ico_contact_details_to_be_visible
-    expect(cases_show_page).to have_content 'ICO Person'
-    expect(cases_show_page).to have_content 'test@email.com'
-    expect(cases_show_page).to have_content '123456789'
-    expect(cases_show_page).to have_content 'REF123456'
-  end
-
-  def and_i_expect_the_ico_and_litigation_details_to_be_visible
-    and_i_expect_the_ico_contact_details_to_be_visible
-    expect(cases_edit_offender_sar_complaint_type_page).to have_content 'Litigation Person'
-    expect(cases_edit_offender_sar_complaint_type_page).to have_content 'test2@email.com'
-    expect(cases_edit_offender_sar_complaint_type_page).to have_content '2345670'
-    expect(cases_edit_offender_sar_complaint_type_page).to have_content 'REF123607'
-  end
-
-  def and_i_update_the_litigation_details_but_not_the_type
-    complaint_type_update_options = { 
-      name: 'Another Litigation Person',
-      email: 'test3@email.com', 
-      phone: '098673234',
-      reference: 'REF756790567'
-    }
-
-    within '.section-complaint-type' do
-      click_on 'Change'
-    end
-
-    cases_edit_offender_sar_complaint_type_page.edit_complaint_type(
-      'litigation',
-      complaint_type_update_options
-    )
-
-    click_on "Continue"
-  end
-
-  def when_i_update_the_exempt_pages_count
-    click_on 'Update exempt pages'
-    expect(page).to have_content('Update exempt pages')
-    fill_in 'offender_sar_complaint_number_exempt_pages', with: '1541'
-    click_on 'Continue'
-  end
-
-  def when_i_update_the_number_of_final_pages
-    click_on 'Update final page count'
-    expect(page).to have_content('Update final page count')
-    fill_in 'offender_sar_complaint_number_final_pages', with: '2849'
-    click_on 'Continue'
-  end
-
-
-  def when_i_progress_the_case_status_past_the_initial_state
-    click_on "Requires data"
-    click_on "Mark as waiting for data"
-    click_on "Mark as ready for vetting"
-    click_on "Mark as vetting in progress"
-  end
-
-  def and_i_update_the_complaint_type_to_litigation
-    complaint_type_update_options = { 
-      name: 'Litigation Person',
-      email: 'test2@email.com', 
-      phone: '2345670',
-      reference: 'REF123607'
-    }
-
-    within '.section-complaint-type' do
-      click_on 'Change'
-    end
-
-    cases_edit_offender_sar_complaint_type_page.edit_complaint_type(
-      'litigation',
-      complaint_type_update_options
-    )
-
-    click_on "Continue"
-  end
-
-  def when_i_update_the_complaint_type_to_ico
-    complaint_type_update_options = { 
-      name: 'ICO Person',
-      email: 'test@email.com', 
-      phone: '123456789',
-      reference: 'REF123456'
-    }
-
-    within '.section-complaint-type' do
-      click_on 'Change'
-    end
-
-    cases_edit_offender_sar_complaint_type_page.edit_complaint_type(
-      'ico',
-      complaint_type_update_options
-    )
-
-    click_on "Continue"
-  end
-
-  def then_i_expect_the_case_status_to_be_reset_to_the_inital_case_state
-    expect(cases_show_page).to have_content "To be assessed"
-  end
-
-  def then_i_expect_the_case_status_to_be_the_same 
-    expect(cases_show_page).to have_content "Vetting in progress"
-  end
-
-  def then_i_should_see_the_updated_exempt_page_count_on_the_show_page
-    expect(page).to have_content('1541')
-    expect(page).to have_content('Case updated')
-  end
-
-  def then_i_should_see_the_pages_for_dispatch_reflected_on_the_show_page
-    expect(page).to have_content('2849')
-    expect(page).to have_content('Case updated')
-  end
-
-  def when_i_progress_case_to_a_closed_state
-    click_on "Requires data"
-    click_on "Mark as waiting for data"
-    click_on "Mark as ready for vetting"
-    click_on "Mark as vetting in progress"
-    click_on "Mark as ready to copy"
-    click_on "Requires response"
-    click_on "Close case"
-  end
-
-  def and_i_add_date_that_the_case_was_responded_to
-    cases_close_page.fill_in_date_responded(offender_sar_complaint.received_date + 10)
-    click_on "Continue"
-  end
-
-  def then_the_case_show_page_should_be_displayed
-    expect(cases_closure_outcomes_page).not_to be_displayed
-    expect(cases_show_page).to have_content "You've closed this case"
-  end
-
-  def when_i_click_the_response_sent_change_link
-    cases_show_page.offender_sar_external_deadline.change_link.click
-  end
-
-  def and_i_edit_the_date_response_sent
-    expect(page).to have_content('Edit case closure details')
-    cases_edit_offender_sar_complaint_date_responded_page.edit_responded_date(offender_sar_complaint.received_date + 5)
-    cases_edit_offender_sar_complaint_date_responded_page.continue_button.click
-  end
-
-  def then_i_expect_the_new_date_to_be_reflected_on_the_case_show_page
-    expect(cases_show_page).to have_content(I18n.l(offender_sar_complaint.received_date + 5, format: :default))
-  end
-
-  def when_i_click_external_deadline_change_link
-    cases_show_page.offender_sar_external_deadline.change_link.click
-  end
-
-  def and_i_edit_the_external_deadline(external_deadline)
-    cases_edit_offender_sar_complaint_external_deadline_page.edit_external_deadline(external_deadline)
-    cases_edit_offender_sar_complaint_external_deadline_page.continue_button.click
-  end
-
-  def then_i_expect_the_new_deadline_to_be_reflected_on_the_case_show_page(external_deadline)
-    expect(cases_show_page).to have_content(I18n.l(external_deadline, format: :default))
-  end
-
-  def when_i_update_the_exempt_pages_count
-    click_on 'Update exempt pages'
-    expect(page).to have_content('Update exempt pages')
-    fill_in 'offender_sar_complaint_number_exempt_pages', with: '1541'
-    click_on 'Continue'
-  end
-
-  def when_i_update_the_number_of_final_pages
-    click_on 'Update final page count'
-    expect(page).to have_content('Update final page count')
-    fill_in 'offender_sar_complaint_number_final_pages', with: '2849'
-    click_on 'Continue'
-  end
-
-
-  def when_i_progress_the_case_status_past_the_initial_state
-    click_on "Requires data"
-    click_on "Mark as waiting for data"
-    click_on "Mark as ready for vetting"
-    click_on "Mark as vetting in progress"
-  end
-
-  def then_i_expect_the_case_status_to_be_reset_to_the_inital_case_state
-    expect(cases_show_page).to have_content "To be assessed"
-  end
-
-  def then_i_should_see_the_updated_exempt_page_count_on_the_show_page
-    expect(page).to have_content('1541')
-    expect(page).to have_content('Case updated')
-  end
-
-  def then_i_should_see_the_pages_for_dispatch_reflected_on_the_show_page
-    expect(page).to have_content('2849')
-    expect(page).to have_content('Case updated')
-  end
-
-  def when_i_progress_case_to_a_closed_state
-    click_on "Requires data"
-    click_on "Mark as waiting for data"
-    click_on "Mark as ready for vetting"
-    click_on "Mark as vetting in progress"
-    click_on "Mark as ready to copy"
-    click_on "Requires response"
-    click_on "Close case"
-  end
-
-  def and_i_add_date_that_the_case_was_responded_to
-    cases_close_page.fill_in_date_responded(offender_sar_complaint.received_date + 10)
-    click_on "Continue"
-  end
-
-  def then_the_case_show_page_should_be_displayed
-    expect(cases_closure_outcomes_page).not_to be_displayed
-    expect(cases_show_page).to have_content "You've closed this case"
-  end
-
-  def when_i_click_the_response_sent_change_link
-    cases_show_page.offender_sar_external_deadline.change_link.click
-  end
-
-  def and_i_edit_the_date_response_sent
-    expect(page).to have_content('Edit case closure details')
-    cases_edit_offender_sar_complaint_date_responded_page.edit_responded_date(offender_sar_complaint.received_date + 5)
-    cases_edit_offender_sar_complaint_date_responded_page.continue_button.click
-  end
-
-  def then_i_expect_the_new_date_to_be_reflected_on_the_case_show_page
-    expect(cases_show_page).to have_content(I18n.l(offender_sar_complaint.received_date + 5, format: :default))
-  end
-
-  def when_i_click_external_deadline_change_link
-    cases_show_page.offender_sar_external_deadline.change_link.click
-  end
-
-  def and_i_edit_the_external_deadline(external_deadline)
-    cases_edit_offender_sar_complaint_external_deadline_page.edit_external_deadline(external_deadline)
-    cases_edit_offender_sar_complaint_external_deadline_page.continue_button.click
-  end
-
-  def then_i_expect_the_new_deadline_to_be_reflected_on_the_case_show_page(external_deadline)
-    expect(cases_show_page).to have_content(I18n.l(external_deadline, format: :default))
-  end
-
   scenario 'user can add/edit approvals for ico complaint case', js: true do
     cases_show_page.load(id: offender_sar_ico_complaint.id)
     expect(cases_show_page).to be_displayed(id: offender_sar_ico_complaint.id)
@@ -481,7 +236,43 @@ feature 'offender sar complaint case editing by a manager' do
     then_i_expect_the_result_to_be_reflected_on_the_case_show_page("8901234.55")
   end
 
+  def and_i_expect_the_ico_contact_details_to_be_visible
+    expect(cases_show_page).to have_content 'ICO Person'
+    expect(cases_show_page).to have_content 'test@email.com'
+    expect(cases_show_page).to have_content '123456789'
+    expect(cases_show_page).to have_content 'REF123456'
+  end
+
+  def and_i_expect_the_ico_and_litigation_details_to_be_visible
+    and_i_expect_the_ico_contact_details_to_be_visible
+    expect(cases_edit_offender_sar_complaint_type_page).to have_content 'Litigation Person'
+    expect(cases_edit_offender_sar_complaint_type_page).to have_content 'test2@email.com'
+    expect(cases_edit_offender_sar_complaint_type_page).to have_content '2345670'
+    expect(cases_edit_offender_sar_complaint_type_page).to have_content 'REF123607'
+  end
+
+  def and_i_update_the_litigation_details_but_not_the_type
+    complaint_type_update_options = { 
+      name: 'Another Litigation Person',
+      email: 'test3@email.com', 
+      phone: '098673234',
+      reference: 'REF756790567'
+    }
+
+    within '.section-complaint-type' do
+      click_on 'Change'
+    end
+
+    cases_edit_offender_sar_complaint_type_page.edit_complaint_type(
+      'litigation',
+      complaint_type_update_options
+    )
+
+    click_on "Continue"
+  end
+
   def when_i_update_the_exempt_pages_count
+    click_on 'Requires data'
     click_on 'Update exempt pages'
     expect(page).to have_content('Update exempt pages')
     fill_in 'offender_sar_complaint_number_exempt_pages', with: '1541'
@@ -495,6 +286,7 @@ feature 'offender sar complaint case editing by a manager' do
     click_on 'Continue'
   end
 
+
   def when_i_progress_the_case_status_past_the_initial_state
     click_on "Requires data"
     click_on "Mark as waiting for data"
@@ -502,8 +294,52 @@ feature 'offender sar complaint case editing by a manager' do
     click_on "Mark as vetting in progress"
   end
 
+  def and_i_update_the_complaint_type_to_litigation
+    complaint_type_update_options = { 
+      name: 'Litigation Person',
+      email: 'test2@email.com', 
+      phone: '2345670',
+      reference: 'REF123607'
+    }
+
+    within '.section-complaint-type' do
+      click_on 'Change'
+    end
+
+    cases_edit_offender_sar_complaint_type_page.edit_complaint_type(
+      'litigation',
+      complaint_type_update_options
+    )
+
+    click_on "Continue"
+  end
+
+  def when_i_update_the_complaint_type_to_ico
+    complaint_type_update_options = { 
+      name: 'ICO Person',
+      email: 'test@email.com', 
+      phone: '123456789',
+      reference: 'REF123456'
+    }
+
+    within '.section-complaint-type' do
+      click_on 'Change'
+    end
+
+    cases_edit_offender_sar_complaint_type_page.edit_complaint_type(
+      'ico',
+      complaint_type_update_options
+    )
+
+    click_on "Continue"
+  end
+
   def then_i_expect_the_case_status_to_be_reset_to_the_inital_case_state
     expect(cases_show_page).to have_content "To be assessed"
+  end
+
+  def then_i_expect_the_case_status_to_be_the_same 
+    expect(cases_show_page).to have_content "Vetting in progress"
   end
 
   def then_i_should_see_the_updated_exempt_page_count_on_the_show_page

--- a/spec/features/cases/offender_sar_complaint/log_data_received_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/log_data_received_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-feature 'Log data received for an Offender SAR Data Request' do
+feature 'Log data received for an Offender SAR complaint Data Request' do
   given!(:manager) { find_or_create :branston_user }
-  given!(:offender_sar_complaint) { create(:offender_sar_complaint) }
+  given!(:offender_sar_complaint) { create(:offender_sar_complaint, :data_to_be_requested) }
   given!(:data_request) { create(:data_request, offender_sar_case: offender_sar_complaint) }
 
   background do

--- a/spec/policies/cases/sar/offender_complaint_policy_spec.rb
+++ b/spec/policies/cases/sar/offender_complaint_policy_spec.rb
@@ -5,7 +5,7 @@ describe Case::SAR::OffenderComplaintPolicy do
   let(:user) { create :branston_user }
 
   permissions :can_record_data_request? do
-    it { should permit(user, create(:offender_sar_complaint)) }
+    it { should permit(user, create(:offender_sar_complaint, :data_to_be_requested)) }
     it { should_not permit(user, create(:sar_case)) }
   end
 end

--- a/spec/state_machines/workflows/offender_sar_complaint_permitted_events/ico_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_complaint_permitted_events/ico_spec.rb
@@ -20,7 +20,8 @@ describe ConfigurableStateMachine::Machine do
           :mark_as_vetting_in_progress, 
           :mark_as_require_response,
           :send_acknowledgement_letter,
-          :reset_to_initial_state
+          :reset_to_initial_state,
+          :add_data_received
         ]
       },
       {
@@ -28,6 +29,7 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :mark_as_waiting_for_data, 
           :send_acknowledgement_letter,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -38,6 +40,7 @@ describe ConfigurableStateMachine::Machine do
           :mark_as_require_response, 
           :send_acknowledgement_letter, 
           :preview_cover_page,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -46,6 +49,7 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :mark_as_vetting_in_progress, 
           :preview_cover_page,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -54,6 +58,7 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :mark_as_ready_to_copy, 
           :preview_cover_page,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -61,6 +66,7 @@ describe ConfigurableStateMachine::Machine do
         state: :ready_to_copy,
         specific_events: [
           :mark_as_require_response,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -70,6 +76,7 @@ describe ConfigurableStateMachine::Machine do
           :close, 
           :send_dispatch_letter, 
           :add_complaint_appeal_outcome, 
+          :add_data_received,
           :add_approval_flags_for_ico,
           :reset_to_initial_state
         ]
@@ -89,7 +96,6 @@ describe ConfigurableStateMachine::Machine do
 
     UNIVERSAL_EVENTS_ICO = %i[
       add_note_to_case
-      add_data_received
       edit_case
       reassign_user
     ].freeze

--- a/spec/state_machines/workflows/offender_sar_complaint_permitted_events/litigation_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_complaint_permitted_events/litigation_spec.rb
@@ -19,6 +19,7 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :mark_as_vetting_in_progress, 
           :mark_as_require_response,
+          :add_data_received,
           :send_acknowledgement_letter,
           :reset_to_initial_state
         ]
@@ -28,6 +29,7 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :mark_as_waiting_for_data, 
           :send_acknowledgement_letter,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -37,6 +39,7 @@ describe ConfigurableStateMachine::Machine do
           :mark_as_ready_for_vetting,
           :send_acknowledgement_letter, 
           :preview_cover_page,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -45,6 +48,7 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :mark_as_vetting_in_progress, 
           :preview_cover_page,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -53,6 +57,7 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :mark_as_ready_to_copy, 
           :preview_cover_page,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -60,6 +65,7 @@ describe ConfigurableStateMachine::Machine do
         state: :ready_to_copy,
         specific_events: [
           :mark_as_ready_to_dispatch,
+          :add_data_received,
           :reset_to_initial_state
         ]
       },
@@ -68,6 +74,7 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :send_dispatch_letter,
           :reset_to_initial_state,
+          :add_data_received,
           :mark_as_legal_proceedings_ongoing
         ]
       },
@@ -76,6 +83,7 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :send_dispatch_letter,
           :reset_to_initial_state,
+          :add_data_received,
           :mark_as_legal_proceedings_ongoing,
         ]
       },
@@ -86,6 +94,7 @@ describe ConfigurableStateMachine::Machine do
           :send_dispatch_letter,
           :reset_to_initial_state,
           :add_complaint_costs, 
+          :add_data_received,
           :add_complaint_outcome, 
           :add_approval_flags_for_litigation
         ]
@@ -105,7 +114,6 @@ describe ConfigurableStateMachine::Machine do
 
     UNIVERSAL_EVENTS_LITIGATION = %i[
       add_note_to_case
-      add_data_received
       edit_case
       reassign_user
     ].freeze

--- a/spec/state_machines/workflows/offender_sar_complaint_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_complaint_permitted_events/standard_spec.rb
@@ -17,13 +17,17 @@ describe ConfigurableStateMachine::Machine do
         specific_events: [
           :mark_as_vetting_in_progress, 
           :mark_as_require_response,
-          :send_acknowledgement_letter, :reset_to_initial_state]
+          :send_acknowledgement_letter, 
+          :add_data_received,
+          :reset_to_initial_state]
       },
       {
         state: :data_to_be_requested,
         specific_events: [
           :mark_as_waiting_for_data, 
-          :send_acknowledgement_letter, :reset_to_initial_state]
+          :send_acknowledgement_letter, 
+          :add_data_received,
+          :reset_to_initial_state]
       },
       {
         state: :waiting_for_data,
@@ -31,29 +35,34 @@ describe ConfigurableStateMachine::Machine do
           :mark_as_ready_for_vetting,
           :mark_as_require_response, 
           :send_acknowledgement_letter, 
-          :preview_cover_page, :reset_to_initial_state]
+          :preview_cover_page, 
+          :reset_to_initial_state, 
+          :add_data_received]
       },
       {
         state: :ready_for_vetting,
         specific_events: [
           :mark_as_vetting_in_progress, 
           :preview_cover_page, 
-          :reset_to_initial_state]
+          :reset_to_initial_state, 
+          :add_data_received]
       },
       {
         state: :vetting_in_progress,
         specific_events: [
           :mark_as_ready_to_copy, 
-          :preview_cover_page, :reset_to_initial_state]
+          :preview_cover_page, 
+          :reset_to_initial_state, 
+          :add_data_received]
       },
       {
         state: :ready_to_copy,
         specific_events: [
-          :mark_as_require_response, :reset_to_initial_state]
+          :mark_as_require_response, :reset_to_initial_state, :add_data_received]
       },
       {
         state: :response_required,
-        specific_events: [:close, :send_dispatch_letter, :reset_to_initial_state]
+        specific_events: [:close, :send_dispatch_letter, :reset_to_initial_state, :add_data_received]
       },
       {
         state: :closed,
@@ -63,7 +72,6 @@ describe ConfigurableStateMachine::Machine do
 
     UNIVERSAL_EVENTS_STANDARD = %i[
       add_note_to_case
-      add_data_received
       edit_case
       reassign_user
     ].freeze


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to remove the 3 buttons related to data_requests from the state of 'to_be_assessed' for the complaint case, 
Also remove lots of duplicated codes in one test spec ( very strange, this duplication must be introduced from merging process somehow)
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3442
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
