### PR TITLE
CT-3290 Added extra backlink and fixed the bug

### DIFF
--- a/app/controllers/cases/offender_sar_complaint_controller.rb
+++ b/app/controllers/cases/offender_sar_complaint_controller.rb
@@ -12,11 +12,12 @@ module Cases
 
       @correspondence_type = CorrespondenceType.offender_sar_complaint
       @correspondence_type_key = 'offender_sar_complaint'
+      @creation_optional_flags = {:flag_for_creation_from_sar_page => 0 }
     end
 
 
     def start_complaint
-      params.merge!(:current_step => "link-offender-sar-case")
+      params.merge!(:current_step => "link-offender-sar-case", :flag_for_creation_from_sar_page => true)
       params.merge!(:commit => true)
       params[@correspondence_type_key] = {}
       params[@correspondence_type_key].merge!("original_case_number" => params["number"])
@@ -104,5 +105,12 @@ module Cases
       permitted_params
     end
 
+    def back_link_url
+      if has_optional_flags? && @case.current_step == 'confirm-offender-sar'
+        case_path @case.original_case.id
+      else
+        super
+      end
+    end
   end
 end

--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -193,7 +193,7 @@ module Cases
     end
 
     def load_optional_flags_from_params
-      @creation_optional_flags.each do |key, value|
+      @creation_optional_flags.each do |key, _|
         @creation_optional_flags[key] = params[key]
       end
     end

--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -13,6 +13,7 @@ module Cases
       super
       @correspondence_type = CorrespondenceType.offender_sar
       @correspondence_type_key = 'offender_sar'
+      @creation_optional_flags = {}
     end
 
     def new
@@ -20,6 +21,8 @@ module Cases
       authorize case_type, :can_add_case?
       @case = build_case_from_session(case_type)
       @case.current_step = params[:step]
+      load_optional_flags_from_params
+      @back_link = back_link_url
     end
 
     def create
@@ -27,6 +30,7 @@ module Cases
       @case = build_case_from_session(case_type)
       @case.creator = current_user #to-do Remove when we use the case create service
       @case.current_step = params[:current_step]
+      load_optional_flags_from_params
       if steps_are_completed? 
         if @case.valid_attributes?(create_params) && @case.valid?
           create_case
@@ -107,7 +111,7 @@ module Cases
       copy_params = @case.process_params_after_step(copy_params)
       session_persist_state(copy_params)
       get_next_step(@case)
-      redirect_to "#{@case.case_route_path}/#{@case.current_step}"
+      redirect_to "#{@case.case_route_path}/#{@case.current_step}#{build_url_params_from_flags}"
     end
 
     def create_case
@@ -187,5 +191,28 @@ module Cases
     def session_state
       "#{@correspondence_type_key}_state".to_sym
     end
+
+    def load_optional_flags_from_params
+      @creation_optional_flags.each do |key, value|
+        @creation_optional_flags[key] = params[key]
+      end
+    end
+
+    def build_url_params_from_flags
+      if has_optional_flags?
+        "?#{@creation_optional_flags.to_param}"
+      else
+        ""
+      end
+    end
+
+    def has_optional_flags?
+      @creation_optional_flags.present? && @creation_optional_flags.values.all? {|x| x.present?}
+    end
+  
+    def back_link_url
+      "#{@case.case_route_path}/#{@case.get_previous_step}#{build_url_params_from_flags}"
+    end
+
   end
 end

--- a/app/decorators/case/sar/offender_base_decorator.rb
+++ b/app/decorators/case/sar/offender_base_decorator.rb
@@ -1,16 +1,7 @@
 class Case::SAR::OffenderBaseDecorator < Case::BaseDecorator
 
   include Steppable
- 
-  def back_link(mode, previous_step)
-    url = if mode == :edit
-            h.case_path(id)
-          else
-            "#{case_route_path}/#{previous_step}"
-          end
-    h.link_to "Back", url, class: 'govuk-back-link'
-  end
- 
+  
   def get_step_partial
     step_name = current_step.split("/").first.tr('-', '_')
     "#{step_name}_step"

--- a/app/views/cases/offender_sar/_edit.html.slim
+++ b/app/views/cases/offender_sar/_edit.html.slim
@@ -1,7 +1,7 @@
 - content_for :sub_heading, flush: true
   = t("cases.edit.offender_sar.sub_heading")
 
-= @case.back_link(:edit, nil)
+= link_to "Back", case_path(@case.id), class: 'govuk-back-link'
 
 = render "cases/offender_sar/#{@case.get_step_partial}", url: case_sar_offender_path(@case)
 

--- a/app/views/cases/offender_sar/_new.html.slim
+++ b/app/views/cases/offender_sar/_new.html.slim
@@ -1,3 +1,3 @@
-= @case.back_link(:create, @case.get_previous_step) if @case.get_previous_step
+= link_to "Back", @back_link, class: 'govuk-back-link'
 
 = render "cases/offender_sar/#{kase.get_step_partial}", url: case_create_action(@case.object)

--- a/app/views/cases/offender_sar_complaint/_appeal_outcome_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_appeal_outcome_step.html.slim
@@ -8,6 +8,4 @@
   = f.radio_button_fieldset :appeal_outcome_id,
     choices: CaseClosure::OffenderComplaintAppealOutcome.active, value_method: :id, text_method: :name
 
-  input name="current_step" type="hidden" value=@case.current_step
-
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_approval_flags_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_approval_flags_step.html.slim
@@ -15,6 +15,4 @@
                                 :id,
                                 :name
                                 
-  input name="current_step" type="hidden" value=@case.current_step
-
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_complaint_type_step.html.slim
@@ -25,5 +25,6 @@
     choices: Case::SAR::OffenderComplaint::priorities.values
 
   input name="current_step" type="hidden" value=@case.current_step
+  input name="flag_for_creation_from_sar_page" type="hidden" value= @creation_optional_flags[:flag_for_creation_from_sar_page]
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_confirm_offender_sar_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_confirm_offender_sar_step.html.slim
@@ -17,6 +17,10 @@ section.case-info
       = f.radio_button_fieldset :original_case_number, choices: [:yes, :no], inline: true
 
   input name="current_step" type="hidden" value=@case.current_step
-  
+  input name="flag_for_creation_from_sar_page" type="hidden" value= @creation_optional_flags[:flag_for_creation_from_sar_page]
+
   = f.submit 'Continue', class: 'button', id: 'btn-offender-sar-complaint-continue', disabled: true
+
+br
+= link_to "Back", @back_link, class: 'govuk-back-link'
 

--- a/app/views/cases/offender_sar_complaint/_costs_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_costs_step.html.slim
@@ -8,6 +8,4 @@
 
   = f.number_field :total_cost, style: 'width: 20%', min: '0.00', step: '0.01', max: '100000000000.00'
 
-  input name="current_step" type="hidden" value=@case.current_step
-
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_date_received_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_date_received_step.html.slim
@@ -13,5 +13,6 @@
       }
 
   input name="current_step" type="hidden" value=@case.current_step
+  input name="flag_for_creation_from_sar_page" type="hidden" value= @creation_optional_flags[:flag_for_creation_from_sar_page]
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_date_responded_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_date_responded_step.html.slim
@@ -18,6 +18,4 @@ div class="case-#{@correspondence_type_key}"
                 form_hint_text: t('cases.shared.date_responded_form.date_example'),
                 today_button: {class: ''} }
 
-    input name="current_step" type="hidden" value=@case.current_step
-
     = f.submit 'Continue', {class: 'button'}

--- a/app/views/cases/offender_sar_complaint/_edit.html.slim
+++ b/app/views/cases/offender_sar_complaint/_edit.html.slim
@@ -1,7 +1,7 @@
 - content_for :sub_heading, flush: true
   = t("cases.edit.offender_sar_complaint.sub_heading")
 
-= @case.back_link(:edit, nil)
+= link_to "Back", case_path(@case.id), class: 'govuk-back-link'
 
 = render "cases/offender_sar_complaint/#{@case.get_step_partial}", url: case_sar_offender_complaint_path(@case)
 

--- a/app/views/cases/offender_sar_complaint/_new.html.slim
+++ b/app/views/cases/offender_sar_complaint/_new.html.slim
@@ -1,3 +1,3 @@
-= @case.back_link(:create, @case.get_previous_step) if @case.get_previous_step
+= link_to "Back", @back_link, class: 'govuk-back-link'
 
 = render "cases/offender_sar_complaint/#{kase.get_step_partial}", url: case_create_action(@case.object)

--- a/app/views/cases/offender_sar_complaint/_outcome_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_outcome_step.html.slim
@@ -8,6 +8,4 @@
   = f.radio_button_fieldset :outcome_id,
     choices: CaseClosure::OffenderComplaintOutcome.active, value_method: :id, text_method: :name
 
-  input name="current_step" type="hidden" value=@case.current_step
-
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_recipient_details_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_recipient_details_step.html.slim
@@ -27,5 +27,6 @@
         - panel.text_area :postal_address, {rows: 4}
 
   input name="current_step" type="hidden" value=@case.current_step
+  input name="flag_for_creation_from_sar_page" type="hidden" value= @creation_optional_flags[:flag_for_creation_from_sar_page]
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_request_details_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_request_details_step.html.slim
@@ -15,10 +15,7 @@
 
     = f.text_field :requester_reference
 
-  / start remove this ! Temp hidden subject_full name field because params[:offender_sar] needs to be populated
-  = f.hidden_field :subject_full_name
-  / end remove this
-
   input name="current_step" type="hidden" value=@case.current_step
+  input name="flag_for_creation_from_sar_page" type="hidden" value= @creation_optional_flags[:flag_for_creation_from_sar_page]
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_requested_info_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_requested_info_step.html.slim
@@ -9,5 +9,6 @@
   = f.text_area :message, { rows: 12, label_options: { class: 'visually-hidden' } }
 
   input name="current_step" type="hidden" value=@case.current_step
+  input name="flag_for_creation_from_sar_page" type="hidden" value= @creation_optional_flags[:flag_for_creation_from_sar_page]
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_requester_details_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_requester_details_step.html.slim
@@ -16,5 +16,6 @@
       - fieldset.radio_input(false, text_method: :humanize)
 
   input name="current_step" type="hidden" value=@case.current_step
+  input name="flag_for_creation_from_sar_page" type="hidden" value= @creation_optional_flags[:flag_for_creation_from_sar_page]
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_set_deadline_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_set_deadline_step.html.slim
@@ -13,5 +13,6 @@
       }
 
   input name="current_step" type="hidden" value=@case.current_step
+  input name="flag_for_creation_from_sar_page" type="hidden" value= @creation_optional_flags[:flag_for_creation_from_sar_page]
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_complaint/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_subject_details_step.html.slim
@@ -29,5 +29,6 @@
     - fieldset.radio_input(false, text_method: :humanize)
 
   input name="current_step" type="hidden" value=@case.current_step
+  input name="flag_for_creation_from_sar_page" type="hidden" value= @creation_optional_flags[:flag_for_creation_from_sar_page]
 
   = f.submit 'Continue', class: 'button'

--- a/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_creating_spec.rb
@@ -142,11 +142,16 @@ feature 'offender sar complaint case creation by a manager', js: true do
     then_expect_case_in_my_open_cases
   end
 
-  scenario '8 Create the complaint case from open late offender sar case' do
+  scenario '8 Create the complaint case from open in time offender sar case' do
     offender_sar_open_in_time = create(:offender_sar_case, :third_party)
     then_expect_no_button_for_creating_complaint_case(offender_sar_open_in_time)
   end
 
+  scenario '9 back to offender sar case page when creating complaint from its page ' do
+    when_i_navigate_to_offender_sar_subject_page_and_start_complaint
+    and_click_back_link
+    then_expect_back_to_offender_sar_page_again
+  end
 
   context 'when complaint is an ICO complaint' do
     let(:complaint_type) { 'ico_complaint' }
@@ -337,6 +342,7 @@ feature 'offender sar complaint case creation by a manager', js: true do
     click_on "Continue"
     expect(cases_new_offender_sar_complaint_confirm_case_page).to have_content "Create Offender SAR Complaint case"
     expect(cases_new_offender_sar_complaint_confirm_case_page).to be_displayed
+    expect(cases_new_offender_sar_complaint_confirm_case_page.back_links.size).to eq 2
     cases_new_offender_sar_complaint_confirm_case_page.confirm_yes
     click_on "Continue"
   end
@@ -468,6 +474,16 @@ feature 'offender sar complaint case creation by a manager', js: true do
     row = my_open_cases_page.row_for_case_number(complaint_case.number)
     expect(row).to have_content complaint_case.number
     expect(row).to have_content 'branston registry responding user'
+  end
+
+  def and_click_back_link
+    cases_new_offender_sar_complaint_confirm_case_page.find_first_back_link.click
+  end
+
+  def then_expect_back_to_offender_sar_page_again
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content offender_sar.number
+    expect(cases_show_page).to have_content "Start complaint"
   end
 end
 

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_confirm_case.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_confirm_case.rb
@@ -16,8 +16,15 @@ module PageObjects
 
           element :submit_button, '.button'
 
+          sections :back_links, '.govuk-back-link' do
+          end
+  
           def confirm_yes
             choose('offender_sar_complaint_original_case_number_yes', visible: false)
+          end
+
+          def find_first_back_link
+            find(".govuk-back-link", match: :first)
           end
         end
       end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to 
- Add an extra back-link for the step of confirming offender SAR detail during the complaint-creation journey
- If the complaint is created via "Start complaint",  when a user clicks back-link, it should return back the SAR detail.

Sounds simple change but I found I cannot simply use 'back' behaviour as it is a wizard for the creation journey, so I need to add an extra flag if the starting point is from the related Offender SAR page, and also found some of unnecessary 'current-step' flag in a few pages, plus moved back_link() from decorator to controller level which I think is more appropriate. 

All in all,  somehow I ended up modifying a few more files, but they are still simple changes

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3290
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
