### PR TITLE
CT-3505 Fixed the wrong msg when no change made from user

### DIFF
--- a/app/services/case_updater_service.rb
+++ b/app/services/case_updater_service.rb
@@ -13,7 +13,13 @@ class CaseUpdaterService
     ActiveRecord::Base.transaction do
       begin
         @kase.assign_attributes(@params)
-        if @kase.changed?
+        # properties is JSON object, if one of keys was not included 
+        # but later this key with value of nil is added, 
+        # it will be treated as changed which will give a misleading message 
+        # as from user's point of view, he/she doesn't change anything
+        # Each key within this JSON object will be tracked individually, 
+        # no need for tracking properties as the whole.
+        if (@kase.changed_attributes.keys - ["properties"]).present?
           @kase.save!
           @kase.state_machine.edit_case!(acting_user: @user, acting_team: @team)
           @result = :ok

--- a/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
@@ -425,6 +425,7 @@ feature 'offender sar complaint case editing by a manager' do
     when_i_click_add_appeal_outcome
     and_i_not_tick_appeal_outcome
     expect(cases_show_page).to have_content('Add outcome')
+    expect(cases_show_page).to have_content 'No changes were made'
 
     when_i_click_add_appeal_outcome
     and_i_tick_appeal_outcome(CaseClosure::OffenderComplaintAppealOutcome.upheld)
@@ -449,6 +450,7 @@ feature 'offender sar complaint case editing by a manager' do
     when_i_click_add_outcome
     and_i_not_tick_outcome
     expect(cases_show_page).to have_content('Add outcome')
+    expect(cases_show_page).to have_content 'No changes were made'
 
     when_i_click_add_outcome
     and_i_tick_outcome(CaseClosure::OffenderComplaintOutcome.not_succeeded)
@@ -469,6 +471,10 @@ feature 'offender sar complaint case editing by a manager' do
     expect(cases_show_page).to have_content('Add approval')
     expect(cases_show_page).to have_content('Add outcome')
     expect(cases_show_page).to have_content('Add costs')
+
+    when_i_click_add_costs
+    click_on 'Continue'
+    expect(cases_show_page).to have_content 'No changes were made'
 
     when_i_click_add_costs
     and_i_fill_in_costs(11111.11, 22222.22)


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to fix the wrong case update message even there is no change made from user 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3505
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
