### PR TITLE
CT-3565 Fixed mimemagic license issue and the failure of building docker-image as this result

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem 'slim-rails', '~> 3.2'
 gem 'shell-spinner'
 gem 'schema_plus_enums', '~> 0.1'
 gem 'sidekiq', '~> 6.1.3'
+gem 'mimemagic', '~> 0.3.9'
 
 gem 'table_print'
 # gem 'thor-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mimetype-fu (0.1.2)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
@@ -653,6 +655,7 @@ DEPENDENCIES
   logstash-event
   loofah (>= 2.3.1)
   mechanize (>= 2.7.7)
+  mimemagic (~> 0.3.9)
   mimetype-fu (~> 0.1.2)
   paper_trail (~> 11.1)
   parallel_tests (~> 3.4)


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to fix the mimemagic issue due to the license changes ( all those versions below 0.3.9 have been yanked not available from gem installation)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3565
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
