### PR TITLE
CT-3362 Fix label matching on team add/edit forms

### DIFF
--- a/app/views/teams/_form.html.slim
+++ b/app/views/teams/_form.html.slim
@@ -1,9 +1,9 @@
 
-= form.text_field :name, label_options: { value: @team.pretty_type}
+= form.text_field :name, label_options: { value: @team.pretty_type, for: "team_name"}
 
-= form.text_field :email, label_options: { value: "#{@team.pretty_type} email" }
+= form.text_field :email, label_options: { value: "#{@team.pretty_type} email", for: 'team_email' }
 
-= form.text_field :team_lead, label_options: { value: @team.pretty_team_lead_title }
+= form.text_field :team_lead, label_options: { value: @team.pretty_team_lead_title, for: 'team_team_lead' }
 
 - if @team.is_a?(BusinessUnit)
 

--- a/spec/site_prism/page_objects/pages/teams/new_page.rb
+++ b/spec/site_prism/page_objects/pages/teams/new_page.rb
@@ -13,19 +13,19 @@ module PageObjects
         element :lead, '#team_team_lead'
 
         #Business Group
-        element :business_group_label, 'label[for="team_name_business_group"]'
-        element :business_group_email_label, 'label[for="team_email_business_group_email"]'
-        element :director_general_label, 'label[for="team_team_lead_director_general"]'
+        element :business_group_label, 'label[for="team_name"]'
+        element :business_group_email_label, 'label[for="team_email"]'
+        element :director_general_label, 'label[for="team_team_lead"]'
 
         #Directorate
-        element :directorate_label, 'label[for="team_name_directorate"]'
-        element :directorate_email_label, 'label[for="team_email_directorate_email"]'
-        element :director_label, 'label[for="team_team_lead_director"]'
+        element :directorate_label, 'label[for="team_name"]'
+        element :directorate_email_label, 'label[for="team_email"]'
+        element :director_label, 'label[for="team_team_lead"]'
 
         #Business Unit
-        element :business_unit_label, 'label[for="team_name_business_unit"]'
-        element :business_unit_email_label, 'label[for="team_email_business_unit_email"]'
-        element :deputy_director_label, 'label[for="team_team_lead_deputy_director"]'
+        element :business_unit_label, 'label[for="team_name"]'
+        element :business_unit_email_label, 'label[for="team_email"]'
+        element :deputy_director_label, 'label[for="team_team_lead"]'
 
         element :responding_role_option, :xpath, '//input[@value="responder"]//..'
         element :approving_role_option, :xpath, '//input[@value="approver"]//..'


### PR DESCRIPTION
## Description
Match form labels for pages: Add / Edit Directorate, Business Group, Business Unit

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3362

### Deployment
n/a

### Manual testing instructions
Add or edit a Directorate, Business Group or Business Unit. Click on form headings (top 3 textboxes) - should highlight / land in the textbox.
