### PR TITLE
CT-3361 Fix page titles for some team pages

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -40,6 +40,7 @@ class TeamsController < ApplicationController
   def edit
     authorize @team
     @action_copy = get_action_text(for_creation: false)
+    @team_type = params[:team_type]
   end
 
   def update

--- a/app/views/teams/_business_unit_detail.html.slim
+++ b/app/views/teams/_business_unit_detail.html.slim
@@ -9,7 +9,7 @@
     h2.heading-medium style='display:inline'
       | Team details
   .column-one-third
-    = link_to 'Edit', edit_team_path(@team)
+    = link_to 'Edit', edit_team_path(@team, { team_type: 'bu' })
 
   .column-full
     hr

--- a/app/views/teams/_existing_business_areas_covered.html.slim
+++ b/app/views/teams/_existing_business_areas_covered.html.slim
@@ -1,3 +1,6 @@
+- content_for :page_title do
+  - t("page_title.edit_#{@team_type}_areas", team_name: @team.name)
+
 - areas.each do | area |
   .grid-row id="area-#{area.id}"
     .column-two-thirds.business-areas--details

--- a/app/views/teams/_existing_business_areas_covered.html.slim
+++ b/app/views/teams/_existing_business_areas_covered.html.slim
@@ -1,6 +1,3 @@
-- content_for :page_title do
-  - t("page_title.edit_#{@team_type}_areas", team_name: @team.name)
-
 - areas.each do | area |
   .grid-row id="area-#{area.id}"
     .column-two-thirds.business-areas--details

--- a/app/views/teams/business_areas_covered.html.slim
+++ b/app/views/teams/business_areas_covered.html.slim
@@ -1,3 +1,6 @@
+- content_for :page_title do
+  = t("page_title.new_bu_areas", team_name: @team.name)
+
 = GovukElementsErrorsHelper.error_summary @team,
         "#{pluralize(@team.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""
 

--- a/app/views/teams/business_areas_covered.html.slim
+++ b/app/views/teams/business_areas_covered.html.slim
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  = t("page_title.new_bu_areas", team_name: @team.name)
+  = t("page_title.bu_areas", team_name: @team.name)
 
 = GovukElementsErrorsHelper.error_summary @team,
         "#{pluralize(@team.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""

--- a/app/views/teams/edit.html.slim
+++ b/app/views/teams/edit.html.slim
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  - t("page_title.edit_#{@team_type}", team_name: @team.name)
+  - t("page_title.edit_org_entity", team_type: @team.pretty_type, team_name: @team.name)
 
 - content_for :heading
   = t('.edit', team_type: @team.pretty_type)

--- a/app/views/teams/edit.html.slim
+++ b/app/views/teams/edit.html.slim
@@ -1,3 +1,6 @@
+- content_for :page_title do
+  - t("page_title.edit_#{@team_type}", team_name: @team.name)
+
 - content_for :heading
   = t('.edit', team_type: @team.pretty_type)
 
@@ -9,4 +12,3 @@
 
 = form_for @team, as: :team, url: team_path(@team) do |f|
   = render partial: 'form.html.slim', locals: {form: f}
-

--- a/app/views/teams/new.html.slim
+++ b/app/views/teams/new.html.slim
@@ -1,5 +1,5 @@
 - content_for :page_title do
-  = t("page_title.new_#{@team_type}")
+  = t('page_title.new_org_entity', team_type: @team.pretty_type) 
 
 = GovukElementsErrorsHelper.error_summary @team,
         "#{pluralize(@team.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""

--- a/app/views/teams/new.html.slim
+++ b/app/views/teams/new.html.slim
@@ -1,3 +1,6 @@
+- content_for :page_title do
+  = t("page_title.new_#{@team_type}")
+
 = GovukElementsErrorsHelper.error_summary @team,
         "#{pluralize(@team.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""
 

--- a/app/views/teams/teams_for_user.html.slim
+++ b/app/views/teams/teams_for_user.html.slim
@@ -1,5 +1,7 @@
-= render partial: 'layouts/header'
+- content_for :page_title do
+  - t('page_title.settings_directorate_branston')
 
+= render partial: 'layouts/header'
 
 h1.heading-large
   = t('team_types.business_unit').pluralize

--- a/config/locales/page_titles.en.yml
+++ b/config/locales/page_titles.en.yml
@@ -41,6 +41,7 @@ en:
     settings_business_group: Business group - %{business_group} - Track-a-query
     settings_business_unit: Business unit - %{business_group} - %{directorate} - %{business_unit} - Track-a-query
     settings_directorate: Directorate - %{business_group} - %{directorate} - Track-a-query
+    settings_directorate_branston: Directorate - Branston - Track-a-query
     show_case_page: Viewing case details - %{case_number} - Track-a-query
     show_letter_page: Viewing generated letter - %{case_number} - Track-a-query
     stats: Performance Reports - Track-a-query

--- a/config/locales/page_titles.en.yml
+++ b/config/locales/page_titles.en.yml
@@ -19,7 +19,11 @@ en:
     data_request_edit_page: Update page count
     destroy_case_page: Deleting a case - %{case_number} - Track-a-query
     edit_assignment_page: Accepting or rejecting a case - %{case_number} - Track-a-query
+    edit_bg: Edit Business group - %{team_name} - Track-a-query
+    edit_bu: Edit Business unit - %{team_name} - Track-a-query
+    edit_bu_areas: Edit Business unit - %{team_name} - Areas covered - Track-a-query
     edit_case_page: Editing a case - %{case_number} - Track-a-query
+    edit_dir: Edit Directorate - %{team_name} - Track-a-query
     extend_sar_deadline: Extend deadline for SAR - %{case_number}
     forgot_password: Forgot your password - Track-a-query
     linking_case_page: Linking to an existing case - %{case_number} - Track-a-query
@@ -27,6 +31,10 @@ en:
     mark_as_sent_page: Marking response as sent - %{case_number} - Track-a-query
     marking_response_as_sent: Mark response as sent
     my_cases: My open cases - Track-a-query
+    new_bg: New Business group - Track-a-query
+    new_dir: New Directorate - Track-a-query
+    new_bu: New Business unit - Track-a-query
+    new_bu_areas: New Business unit - %{team_name} - Areas covered - Track-a-query
     new_letter_page: Generate a letter - Track-a-query
     pit_extension_page: Extend for Public Interest Test (PIT) - %{case_number} - Track-a-query
     preview_cover_page: Preview cover page - %{case_number} - Track-a-query

--- a/config/locales/page_titles.en.yml
+++ b/config/locales/page_titles.en.yml
@@ -19,11 +19,8 @@ en:
     data_request_edit_page: Update page count
     destroy_case_page: Deleting a case - %{case_number} - Track-a-query
     edit_assignment_page: Accepting or rejecting a case - %{case_number} - Track-a-query
-    edit_bg: Edit Business group - %{team_name} - Track-a-query
-    edit_bu: Edit Business unit - %{team_name} - Track-a-query
-    edit_bu_areas: Edit Business unit - %{team_name} - Areas covered - Track-a-query
+    edit_org_entity: Edit %{team_type} - %{team_name} - Track-a-query
     edit_case_page: Editing a case - %{case_number} - Track-a-query
-    edit_dir: Edit Directorate - %{team_name} - Track-a-query
     extend_sar_deadline: Extend deadline for SAR - %{case_number}
     forgot_password: Forgot your password - Track-a-query
     linking_case_page: Linking to an existing case - %{case_number} - Track-a-query
@@ -31,11 +28,9 @@ en:
     mark_as_sent_page: Marking response as sent - %{case_number} - Track-a-query
     marking_response_as_sent: Mark response as sent
     my_cases: My open cases - Track-a-query
-    new_bg: New Business group - Track-a-query
-    new_dir: New Directorate - Track-a-query
-    new_bu: New Business unit - Track-a-query
-    new_bu_areas: New Business unit - %{team_name} - Areas covered - Track-a-query
+    bu_areas: Areas covered for %{team_name} - Track-a-query
     new_letter_page: Generate a letter - Track-a-query
+    new_org_entity: New %{team_type} - Track-a-query
     pit_extension_page: Extend for Public Interest Test (PIT) - %{case_number} - Track-a-query
     preview_cover_page: Preview cover page - %{case_number} - Track-a-query
     reassign_user_page: Change team member - %{case_number} - Track-a-query


### PR DESCRIPTION
## Description
Fix page titles for Add/Edit Business Group, Directorate and Business Unit pages

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3361

### Deployment
n/a

### Manual testing instructions
Try adding / editing business group/units/directorates and check page title is not gov.uk....
