### PR TITLE
CT-3353 Fix heading structure for teams page

### DIFF
--- a/app/views/assignments/_browse_teams.html.slim
+++ b/app/views/assignments/_browse_teams.html.slim
@@ -1,4 +1,4 @@
-p.bold-medium
+h2.heading-medium
   = t('teams.browse_by_business_group')
 
 ul.business-groups.list
@@ -16,7 +16,7 @@ ul.business-groups.list
       = all_option_for_new_team(kase, assignment, params)
 
 - if params[:business_group_id] || params[:show_all]
-  p.bold-medium
+  h2.bold-medium
     = filtered_group_heading(params)
 
 - if defined?(@business_units)

--- a/app/views/shared/_areas_covered_list.html.slim
+++ b/app/views/shared/_areas_covered_list.html.slim
@@ -1,17 +1,17 @@
 .grid-row
   .column-two-thirds
-    h3.bold-small
+    h4.bold-small
       = "Areas covered "
     ul.areas-covered.list.list-bullet
       - team.areas.each do | area |
         li
           = area.value
   .column-third
-    h3.bold-small
+    h4.bold-small
       = "Deputy Director"
     .deputy-director.team-lead-title
       = team.team_lead
     br
-    h3.bold-small Group email
+    h4.bold-small Group email
     .team-email
       = "#{team.email || '-'}"


### PR DESCRIPTION
## Description
Fix heading structure - replace heading paragraphs with H2s and reduce below H3s under business units to H4s

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
No rendering difference on styled view

Before

![image](https://user-images.githubusercontent.com/22935203/115039184-21a45e00-9ec8-11eb-964d-00bd1b9caa17.png)


After

![image](https://user-images.githubusercontent.com/22935203/115038790-c5d9d500-9ec7-11eb-85b6-dc343115a34d.png)



### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3353

### Deployment
n/a

### Manual testing instructions
Got to Assign an FOI - The headings for Browse by Business Group and Business group heading should both be H2s, under them H3s. Try viewing without styles to see the difference.
