### PR TITLE
Add fonts to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN addgroup --gid 1000 --system appgroup && \
 # Some app dependencies
 RUN apk add libreoffice clamav clamav-daemon freshclam
 
+RUN apk add libreoffice ttf-freefont ttf-opensans ttf-ubuntu-font-family ttf-inconsolata ttf-liberation ttf-dejavu
+
 # Note: .ruby-gemdeps libc-dev gcc libxml2-dev libxslt-dev make  postgresql-dev build-base - these help with bundle install issues
 RUN apk add --no-cache --virtual .ruby-gemdeps libc-dev gcc libxml2-dev libxslt-dev make  postgresql-dev build-base git nodejs zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ RUN addgroup --gid 1000 --system appgroup && \
     adduser --uid 1000 --system appuser --ingroup appgroup
 
 # Some app dependencies
-RUN apk add libreoffice clamav clamav-daemon freshclam
-
-RUN apk add libreoffice ttf-freefont ttf-opensans ttf-ubuntu-font-family ttf-inconsolata ttf-liberation ttf-dejavu
+RUN apk add libreoffice clamav clamav-daemon freshclam ttf-freefont ttf-opensans ttf-ubuntu-font-family ttf-inconsolata ttf-liberation ttf-dejavu
 
 # Note: .ruby-gemdeps libc-dev gcc libxml2-dev libxslt-dev make  postgresql-dev build-base - these help with bundle install issues
 RUN apk add --no-cache --virtual .ruby-gemdeps libc-dev gcc libxml2-dev libxslt-dev make  postgresql-dev build-base git nodejs zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN addgroup --gid 1000 --system appgroup && \
     adduser --uid 1000 --system appuser --ingroup appgroup
 
 # Some app dependencies
-RUN apk add libreoffice clamav clamav-daemon freshclam ttf-freefont ttf-opensans ttf-ubuntu-font-family ttf-inconsolata ttf-liberation ttf-dejavu
+RUN apk add libreoffice clamav clamav-daemon freshclam ttf-ubuntu-font-family
 
 # Note: .ruby-gemdeps libc-dev gcc libxml2-dev libxslt-dev make  postgresql-dev build-base - these help with bundle install issues
 RUN apk add --no-cache --virtual .ruby-gemdeps libc-dev gcc libxml2-dev libxslt-dev make  postgresql-dev build-base git nodejs zip


### PR DESCRIPTION
## Description
When word docs were converted to PDFs for preview purposes, the necessary fonts were not available at the point of conversion. Meaning that alpha chars were replaced with the  “Replacement Glyph” backstop character as specified in the [unicode standard](http://unicode.org/glossary/#replacement_glyph). 

This PR adds some more fonts to the Docker build so that fonts are available at the point of conversion from MS word format to PDF. 

Unfortunately, docs that have been converted previously will need to be re-uploaded as previews are cached rather than generated on the fly. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Sample file in Arial font demonstrating issue:
<img width="628" alt="Screenshot 2021-04-19 at 12 10 05" src="https://user-images.githubusercontent.com/13377553/115227408-56065d00-a108-11eb-9401-d7f7a5b53451.png">

With fonts available:
<img width="699" alt="Screenshot 2021-04-19 at 12 11 59" src="https://user-images.githubusercontent.com/13377553/115227524-77ffdf80-a108-11eb-9c41-176c89665a49.png">


### Related JIRA tickets
[CT-35-63](https://dsdmoj.atlassian.net/browse/CT-3563)

### Manual testing instructions
1. Create a new case that utilise doc upload (SAR for instance)
2. Upload various sample files with differing fonts (see Jira ticket for sample files)
3. Refresh page until 'view' option is available (can take a few seconds for background job to run)
4. Test that all alpha characters in preview docs look correct 👍 
