### PR TITLE
CT-3354 Change assign buttons in list to include business unit name

### DIFF
--- a/app/views/assignments/_browse_teams.html.slim
+++ b/app/views/assignments/_browse_teams.html.slim
@@ -30,9 +30,9 @@ ul.business-groups.list
           = render partial: 'shared/areas_covered_list', locals: { team: team }
         .team-actions
           - if assignment.new_record?
-            = link_to t('button.assign'),
+            = link_to t('button.assign', business_unit_name: team.name),
                 assign_to_responder_team_case_assignments_path(case_id: kase.id,
                           team_id: team.id), class: 'button'
           - else
-            = link_to t('button.assign'),
+            = link_to t('button.assign', business_unit_name: team.name),
                 execute_assign_to_new_team_case_assignment_path(kase.id, assignment.id, team_id: team.id), class: 'button', method: :patch

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -330,7 +330,7 @@ en:
 
   button:
     add_to_case_history: Add to case history
-    assign: Assign to this unit
+    assign: Assign to %{business_unit_name}
     move: Move to this directorate
     confirm: Confirm
     create_case: Create case

--- a/spec/views/assignments/new_page_spec.rb
+++ b/spec/views/assignments/new_page_spec.rb
@@ -63,7 +63,7 @@ describe 'assignments/new.html.slim', type: :view do
 
         expect(page_team.deputy_director.text).to eq bu.team_lead
 
-        expect(page_team.assign_link.text).to eq "Assign to this unit"
+        expect(page_team.assign_link.text).to eq "Assign to #{bu.name}"
         expect(page_team.assign_link[:href])
             .to eq assign_to_responder_team_case_assignments_path(
               unassigned_case,


### PR DESCRIPTION
## Description
Add business unit name to button for accessibility incase user cycles through links.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
before:
![image](https://user-images.githubusercontent.com/22935203/116097503-1c05ff80-a6a2-11eb-87bf-eec5be948e67.png)

after:
![image](https://user-images.githubusercontent.com/22935203/116097296-eeb95180-a6a1-11eb-8841-7f983b1befbf.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3354

### Deployment
n/a

### Manual testing instructions
Green buttons for reassigning to Business unit should show business unit name and look good on mobile as well.
