### PR TITLE
Add less cmd tool into build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apk add libreoffice clamav clamav-daemon freshclam ttf-ubuntu-font-family
 # Note: .ruby-gemdeps libc-dev gcc libxml2-dev libxslt-dev make  postgresql-dev build-base - these help with bundle install issues
 RUN apk add --no-cache --virtual .ruby-gemdeps libc-dev gcc libxml2-dev libxslt-dev make  postgresql-dev build-base git nodejs zip postgresql-client
 
+RUN apk --update add less
+
 WORKDIR /usr/src/app/
 
 RUN apk -U upgrade


### PR DESCRIPTION
Adds less into Dockerfile. Rails console "rails c" depends on pry which
in turn depends on less. Without this it means we can't use a lot of
rails console stuff in environments.

For instance Model.where(something: "thing") does not work.

Adding back this into the build to try to fix this issue.

See: https://github.com/pry/pry/issues/1248#issuecomment-366056015

## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
1. try to run `Model.where(something: "thing")` in rails console in dev - you should get an `less: unrecognized option: X ....` error.
2. build and deploy this branch to dev
3. run the same command in the rails console - it should be okay now.
