### PR TITLE
CT-3357 Make label work for conversation box

### DIFF
--- a/app/assets/stylesheets/moj/component/_messages.scss
+++ b/app/assets/stylesheets/moj/component/_messages.scss
@@ -299,13 +299,14 @@
   padding-right: $gutter-half;
   padding-bottom: $gutter;
   padding-top: $gutter-half;
+  margin-top: $gutter;
   background-color: $grey-4;
-  label {
-    @include visually-hidden();
-  }
   textarea {
     width: 100%;
     background-color: #FFFFFF;
+  }
+  .button-secondary {
+    margin: 0;
   }
 }
 

--- a/app/views/cases/_case_messages.html.slim
+++ b/app/views/cases/_case_messages.html.slim
@@ -11,5 +11,9 @@ h2.request--heading Conversation
 - if policy(case_details).can_add_message_to_case?
   = form_for case_details, as: :case, url: case_messages_path(case_details), method: :post, class: "message-form" do |f|
     .message-form data-ws-case-id="#{case_details.id}"
-      = f.text_area :message_text
+      .form-group
+	      h3.request--heading
+	      	label for="case_message_text"
+	      	  = t('common.case.add_to_conversation')
+	      textarea#case_message_text.form-control name="case[message_text]"
       = f.submit "Add message", class: 'button-secondary'

--- a/app/views/cases/_case_messages.html.slim
+++ b/app/views/cases/_case_messages.html.slim
@@ -14,6 +14,6 @@ h2.request--heading Conversation
       .form-group
 	      h3.request--heading
 	      	label for="case_message_text"
-	      	  = t('common.case.add_to_conversation')
+	      	  = t('helpers.label.case.add_to_conversation')
 	      textarea#case_message_text.form-control name="case[message_text]"
       = f.submit "Add message", class: 'button-secondary'

--- a/app/views/cases/offender_sar/_case_notes.html.slim
+++ b/app/views/cases/offender_sar/_case_notes.html.slim
@@ -7,6 +7,6 @@
       .form-group
 	      h3.request--heading
 	      	label for="case_message_text"
-	      	  = t('common.case.add_note')
+	      	  = t('helpers.label.case.add_note')
 	      textarea#case_message_text.form-control name="case[message_text]"
       = f.submit t('button.add_to_case_history'), class: 'button'

--- a/app/views/cases/offender_sar/_case_notes.html.slim
+++ b/app/views/cases/offender_sar/_case_notes.html.slim
@@ -2,9 +2,11 @@
   = form_for case_details, as: :case, url: case_notes_path(case_details), method: :post, class: "message-form" do |f|
     .message-form data-ws-case-id="#{case_details.id}"
 
-      h2.request--heading
-        = t('common.case.add_note')
       = GovukElementsErrorsHelper.error_summary @case.object,
         "#{pluralize(@case.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""
-      = f.text_area :message_text, required: true
+      .form-group
+	      h3.request--heading
+	      	label for="case_message_text"
+	      	  = t('common.case.add_note')
+	      textarea#case_message_text.form-control name="case[message_text]"
       = f.submit t('button.add_to_case_history'), class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,6 +452,8 @@ en:
       team_property:
         value: Please provide one area at a time and be as concise as possible
     label:
+      add_to_conversation: Add to conversation
+      add_note: Add a note to this case
       bypass_approval_manager:
         press_office_approval:
           true_html: 'Yes'
@@ -688,7 +690,6 @@ en:
     alert_banner_html: "This service will be down for essential maintenance during the afternoon of Wednesday 14th April. You will not have access after 13.00 on this day and the site will resume service after business hours. Please contact <a href='mailto:correspondence@digital.justice.gov.uk'>correspondence@digital.justice.gov.uk</a> if you have any queries. Apologies for the inconvenience."
     case:
       actions: Actions
-      add_note: Add a note to this case
       answered_in_time: Answered in time
       answered_late: Answered late
       appeal_outcome: Appeal Outcome

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,8 +452,6 @@ en:
       team_property:
         value: Please provide one area at a time and be as concise as possible
     label:
-      add_to_conversation: Add to conversation
-      add_note: Add a note to this case
       bypass_approval_manager:
         press_office_approval:
           true_html: 'Yes'
@@ -484,6 +482,8 @@ en:
           responded: Closed - awaiting ICO decision
           closed: "Closed - %{ico_decision} by ICO"
       case:
+        add_to_conversation: Add to conversation
+        add_note: Add a note to this case
         linked_case_number: Case number For example 170131001
       data_request:
         location: Location


### PR DESCRIPTION
## Description
Make label work for conversation boxes on Offender SAR and FOIs - also update text as discussed and fix heading structure.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [x] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
before: 
![image](https://user-images.githubusercontent.com/22935203/116703093-c55e3580-a9c1-11eb-9421-08ec61cea9c3.png)
after
![image](https://user-images.githubusercontent.com/22935203/116716974-46bcc480-a9d0-11eb-99e9-4b46d8737e82.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3357

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to FOI case and scroll down to conversation - make sure that you can click on the heading to enter the textbox. And then make sure it still works.
Do the same for Offender SARS. Text is different but should work.
