### PR TITLE
CT-3347 case links text

### DIFF
--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -32,7 +32,7 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
     page = 1 if page.blank?
     
     if position.nil?
-      link_to span + case_number, case_path(kase.id, pos: page_offset + position)
+      link_to span + case_number, case_path(kase.id)
     else
       position += 1
       page_offset = Kaminari.config.default_per_page * (page.to_i - 1)

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -23,21 +23,20 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
   end
 
   def case_link_with_hash(kase, field, page, position)
-    page = 1 if page.blank?
-    if position.nil?
-      link_to 
-        content_tag(:span, 
+    span = content_tag(:span, 
           t('common.case_list.view_case'), 
-          class: 'visually-hidden') + kase.__send__(field), 
-        case_path(kase.id, pos: page_offset + position)
+          class: 'visually-hidden')
+
+    case_number = kase.__send__(field)
+    
+    page = 1 if page.blank?
+    
+    if position.nil?
+      link_to span + case_number, case_path(kase.id, pos: page_offset + position)
     else
       position += 1
       page_offset = Kaminari.config.default_per_page * (page.to_i - 1)
-      link_to 
-        content_tag(:span, 
-          t('common.case_list.view_case'), 
-          class: 'visually-hidden') + kase.__send__(field), 
-        case_path(kase.id, pos: page_offset + position)
+      link_to span + case_number, case_path(kase.id, pos: page_offset + position)
     end
   end
 

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -25,11 +25,19 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
   def case_link_with_hash(kase, field, page, position)
     page = 1 if page.blank?
     if position.nil?
-      link_to kase.__send__(field), case_path(kase.id)
+      link_to 
+        content_tag(:span, 
+          t('common.case_list.view_case'), 
+          class: 'visually-hidden') + kase.__send__(field), 
+        case_path(kase.id, pos: page_offset + position)
     else
       position += 1
       page_offset = Kaminari.config.default_per_page * (page.to_i - 1)
-      link_to kase.__send__(field), case_path(kase.id, pos: page_offset + position)
+      link_to 
+        content_tag(:span, 
+          t('common.case_list.view_case'), 
+          class: 'visually-hidden') + kase.__send__(field), 
+        case_path(kase.id, pos: page_offset + position)
     end
   end
 

--- a/app/views/cases/shared/_case_list.html.slim
+++ b/app/views/cases/shared/_case_list.html.slim
@@ -48,7 +48,7 @@
             td aria-label="#{t('common.case_list.number')}"
               span.visually-hidden
                 = t('common.case_list.view_case')
-              = case_link_with_hash(kase, :number, @page, position)
+              = case_link_with_hash(kase, :number, @page, nil)
             td aria-label="#{t('common.case_list.flag')}"
               = kase.highlight_flag
             td aria-label="#{t('common.case_list.type')}"

--- a/app/views/cases/shared/_case_list.html.slim
+++ b/app/views/cases/shared/_case_list.html.slim
@@ -46,9 +46,7 @@
         - @cases.each_with_index do |kase, position|
           tr.case_row
             td aria-label="#{t('common.case_list.number')}"
-              span.visually-hidden
-                = t('common.case_list.view_case')
-              = case_link_with_hash(kase, :number, @page, nil)
+              = case_link_with_hash(kase, :number, @page, position)
             td aria-label="#{t('common.case_list.flag')}"
               = kase.highlight_flag
             td aria-label="#{t('common.case_list.type')}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -945,7 +945,7 @@ en:
     index: &cases_list
       heading_all_cases: Cases
       heading_my_cases: My open cases
-      view_case: "Link to case "
+      view_case: "Case number "
       message_notification: Conversations
       number: Case number
       number_html: 'Case <abbr title="number">No.</abbr>'
@@ -978,10 +978,10 @@ en:
         number: Case number
         number_html: 'Case <abbr title="number">No.</abbr>'
         name-subject: Name/Subject
-        view_case: Link to case
+        view_case: Case number
       incoming:
         heading: New cases
-        view_case: Link to case
+        view_case: Case number
         number: Case number
         number_html: 'Case <abbr title="number">No.</abbr>'
         request: Request

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -812,7 +812,7 @@ en:
       request_detail: Request detail
       status: Status
       type: 'Type'
-      view_case: "Link to case "
+      view_case: "Case number "
       who_its_with: With
     choose: Choose...
     choose_file: Choose a file
@@ -828,7 +828,7 @@ en:
     signout: Sign out
     stats_custom_button: Create report
     summary_error: 'prevented this form from being submitted:'
-    view_case: "Link to case "
+    view_case: "Case number "
 
   admin:
     cases:

--- a/spec/helpers/cases_helper_spec.rb
+++ b/spec/helpers/cases_helper_spec.rb
@@ -275,14 +275,14 @@ href="/cases/#{@case.id}/assignments/select_team?assignment_ids=#{@assignments.f
     context 'query hash instance variable exists' do
       context 'page parameters exists' do
         it 'shows link with hash and position parameters' do
-          expected_link = "<a href=\"/cases/25?pos=35\">180425001</a>"
+          expected_link = "<a href=\"/cases/25?pos=35\"><span class=\"visually-hidden\">Case number </span>180425001</a>"
           expect(case_link_with_hash(kase, :number, 2, 14)).to eq expected_link
         end
       end
 
       context 'page number does not exist' do
         it 'shows link with hash and position parameters based on page 1' do
-          expected_link = "<a href=\"/cases/25?pos=15\">180425001</a>"
+          expected_link = "<a href=\"/cases/25?pos=15\"><span class=\"visually-hidden\">Case number </span>180425001</a>"
           expect(case_link_with_hash(kase, :number, '', 14)).to eq expected_link
         end
       end

--- a/spec/site_prism/page_objects/pages/cases/incoming_cases_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/incoming_cases_page.rb
@@ -32,13 +32,13 @@ module PageObjects
 
         def case_numbers
           case_list.map do |row|
-            row.number.text.delete('Link to case').delete("\n")
+            row.number.text.delete('Case number').delete("\n")
           end
         end
 
         def row_for_case_number(number)
           case_list.find do |row|
-            row.number.text.delete('Link to case').delete("\n") == number
+            row.number.text.delete('Case number').delete("\n") == number
           end
         end
       end

--- a/spec/site_prism/page_objects/pages/cases_page.rb
+++ b/spec/site_prism/page_objects/pages/cases_page.rb
@@ -48,7 +48,7 @@ module PageObjects
 
       def case_numbers
         case_list.map do |row|
-          row.number.text.delete('Link to case').delete("\n")
+          row.number.text.delete('Case number').delete("\n")
         end
       end
 
@@ -60,7 +60,7 @@ module PageObjects
         begin
           Capybara.ignore_hidden_elements = false
           case_list.find { |row|
-            row.number.text == "Link to case #{number}"
+            row.number.text == "Case number #{number}"
           }
         ensure
           Capybara.ignore_hidden_elements = true

--- a/spec/views/cases/_linked_cases_html_slim_spec.rb
+++ b/spec/views/cases/_linked_cases_html_slim_spec.rb
@@ -61,7 +61,7 @@ describe 'cases/linked_cases.html.slim', type: :view do
 
         main_case.linked_cases.each_with_index do | linked_case, index|
           row = partial.linked_records[index]
-          expect(row.link.text).to eq "Link to case #{linked_case.number}"
+          expect(row.link.text).to eq "Case number #{linked_case.number}"
           expect(row.link['href']).to eq case_path(linked_case.id)
           expect(row.case_type.text).to eq 'FOI '
           expect(row.request.text)
@@ -85,7 +85,7 @@ describe 'cases/linked_cases.html.slim', type: :view do
 
         main_case.linked_cases.each_with_index do | linked_case, index|
           row = partial.linked_records[index]
-          expect(row.link.text).to eq "Link to case #{linked_case.number}"
+          expect(row.link.text).to eq "Case number #{linked_case.number}"
           expect(row.link['href']).to eq case_path(linked_case.id)
           expect(row.case_type.text).to eq 'FOI '
           expect(row.request.text)

--- a/spec/views/cases/filters/closed_cases_html_slim_spec.rb
+++ b/spec/views/cases/filters/closed_cases_html_slim_spec.rb
@@ -38,12 +38,12 @@ describe 'cases/filters/closed.html.slim' do
     expect(page.closed_case_report.table_body.closed_case_rows.size).to eq 2
 
     row = page.closed_case_report.table_body.closed_case_rows.first
-    expect(row.case_number.text).to eq "Link to case #{case_1.number}"
+    expect(row.case_number.text).to eq "Case number #{case_1.number}"
     expect(row.subject_name.name.text).to eq case_1.name
     expect(row.subject_name.subject.text).to eq case_1.subject
 
     row = page.closed_case_report.table_body.closed_case_rows.last
-    expect(row.case_number.text).to eq "Link to case #{case_2.number}"
+    expect(row.case_number.text).to eq "Case number #{case_2.number}"
     expect(row.subject_name.name.text).to eq case_2.name
     expect(row.subject_name.subject.text).to eq case_2.subject
 

--- a/spec/views/cases/filters/incoming_cases_html_slim_spec.rb
+++ b/spec/views/cases/filters/incoming_cases_html_slim_spec.rb
@@ -50,7 +50,7 @@ describe 'cases/filters/incoming.html.slim', type: :view do
     incoming_cases_page.load(rendered)
 
     first_case = incoming_cases_page.case_list[0]
-    expect(first_case.number.text).to eq "Link to case #{case1.number}"
+    expect(first_case.number.text).to eq "Case number #{case1.number}"
     expect(first_case.request.name.text).to eq 'Joe Smith | Member of the public'
     expect(first_case.request.subject.text).to eq 'Prison Reform'
     expect(first_case.request.message.text).to eq 'message number 1'
@@ -58,7 +58,7 @@ describe 'cases/filters/incoming.html.slim', type: :view do
     expect(first_case.actions.de_escalate_link.text).to eq 'De-escalate'
 
     second_case = incoming_cases_page.case_list[1]
-    expect(second_case.number.text).to eq "Link to case #{case2.number}"
+    expect(second_case.number.text).to eq "Case number #{case2.number}"
     expect(second_case.request.name.text).to eq 'Jane Doe | Member of the public'
     expect(second_case.request.subject.text).to eq 'Court Reform'
     expect(second_case.request.message.text).to eq 'message number 2'
@@ -66,7 +66,7 @@ describe 'cases/filters/incoming.html.slim', type: :view do
     expect(second_case.actions.de_escalate_link.text).to eq 'De-escalate'
 
     third_case = incoming_cases_page.case_list[2]
-    expect(third_case.number.text).to eq "Link to case #{further_clearance_case.number}"
+    expect(third_case.number.text).to eq "Case number #{further_clearance_case.number}"
     expect(third_case.request.name.text).to eq 'Questioning Jim | Member of the public'
     expect(third_case.request.subject.text).to eq 'Reform Reform'
     expect(third_case.request.message.text).to eq 'message number 3'


### PR DESCRIPTION
## Description
Change the link hidden text to "Case number " and make it part of the link so screen readers reads it as "Link to case number xxx" rather than xxx or Case number link to xxx - depends on reader.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
was:
![image](https://user-images.githubusercontent.com/22935203/117019624-7c71ee00-aced-11eb-9bfb-3133c9066eda.png)
![image](https://user-images.githubusercontent.com/22935203/117019680-898edd00-aced-11eb-8f26-e800675cf06b.png)


is:
![image](https://user-images.githubusercontent.com/22935203/117019490-59473e80-aced-11eb-9f63-5e6db61d073e.png)
![image](https://user-images.githubusercontent.com/22935203/117019559-6b28e180-aced-11eb-9c2a-586df77abd78.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3347

### Deployment
n/a

### Manual testing instructions
Non - styled view should show "Case number xxx" as part of link instead of "Link to case xxx" - and in both cases it should be part of the link.
