### PR TITLE
CT-3614 Remove the session as it is redundant

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,9 +9,6 @@ Sidekiq.configure_client do |config|
 end
 
 
-# the following prevents sidekiq web dashboard from killing the cookie
-# and forcing a new sign in for every page
-#
 require "sidekiq/web"
 
 # Requirement since Sidekiq 5+

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -13,7 +13,6 @@ end
 # and forcing a new sign in for every page
 #
 require "sidekiq/web"
-Sidekiq::Web.set(:sessions, { domain: ".example.com" })
 
 # Requirement since Sidekiq 5+
 Sidekiq::Extensions.enable_delay!


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to fix the warning message from Sidekiq.  The Sidekiq::Web.set(sessions) is not needed any more,  this part only affects the Sidekiq dashboard. 

After this removal, I tested the Sidekiq dashboard on QA (only admin can see this dashboard) , it works perfectly

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3614

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
