### PR TITLE
CT-3652 Fixed the issue of London disclosure team for uploading response

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,9 +140,9 @@ class User < ApplicationRecord
   end
 
   def case_team_for_event(kase, event)
-    # Return the team which have the permission for performing the even for 
+    # Return the team which have the permission for performing the event for 
     # a particular kase under current state. If multiple teams are found 
-    # the team with highest authroity will be returned
+    # the team with highest authority will be returned
     available_teams = kase.state_machine.teams_that_can_trigger_event_on_case(
       event_name: event, 
       user: self)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -139,6 +139,16 @@ class User < ApplicationRecord
     self.class.sort_teams_by_roles(case_teams).first
   end
 
+  def case_team_for_event(kase, event)
+    # Return the team which have the permission for performing the even for 
+    # a particular kase under current state. If multiple teams are found 
+    # the team with highest authroity will be returned
+    available_teams = kase.state_machine.teams_that_can_trigger_event_on_case(
+      event_name: event, 
+      user: self)
+    self.class.sort_teams_by_roles(available_teams).first
+  end
+
   # Note: Role Weightings can be very different depending on the event
   def self.sort_teams_by_roles(teams, role_weightings = ROLE_WEIGHTINGS)
     teams.sort do |a, b|

--- a/app/services/response_uploader_service.rb
+++ b/app/services/response_uploader_service.rb
@@ -72,7 +72,7 @@ class ResponseUploaderService
       case @action
       when 'upload', 'upload-flagged'
         @case.state_machine.add_responses!(acting_user: @current_user,
-                                           acting_team: @current_user.case_team(@case),
+                                           acting_team: @current_user.case_team_for_event(@case, 'add_responses'),
                                            filenames: filenames,
                                            message: @case.upload_comment)
       when 'upload-approve'

--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -244,7 +244,6 @@ module ConfigurableStateMachine
       if state_config.nil? || !state_config.to_hash.keys.include?(event)
         return false
       end
-      event_config = state_config[event]
       if !can_trigger_event?(
             event_name: event, 
             metadata: {:acting_user => user, :acting_team => acting_team},

--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -139,13 +139,6 @@ module ConfigurableStateMachine
       end
     end
 
-    # def get_next_target_state_for_event(event_name, metadata)
-    #   target_states = get_event_target_states!(event_name)
-    #   target_states.find do |target_state|
-    #     call_guards_for_target_state(target_state, metadata)
-    #   end
-    # end
-
     def call_guards_for_target_state(target_state, metadata)
       guards = target_state[:guards]
       guards.blank? ||
@@ -190,6 +183,16 @@ module ConfigurableStateMachine
       end
     end
 
+    def teams_that_can_trigger_event_on_case(event_name:, user:)
+      available_teams = []
+      user.teams_for_case(@kase).each do | team |
+        if can_trigger_event_for_the_case?(event_name: event_name, acting_team: team, user: user) 
+          available_teams << team
+        end
+      end
+      available_teams
+    end
+
     private
 
     def first_role_that_can_trigger_event_on_case(event_name:, metadata:, user:)
@@ -228,6 +231,27 @@ module ConfigurableStateMachine
       elsif config.if.nil? || predicate_is_true?(predicate: config.if, user: user)
         config
       end
+    end
+
+    def can_trigger_event_for_the_case?(event_name:, acting_team:, user:)
+      event = event_name.to_sym
+      role =  acting_team.role
+      user_role_config = @config.user_roles[role]
+      if user_role_config.nil?
+        return false
+      end
+      state_config = user_role_config.states[@kase.current_state]
+      if state_config.nil? || !state_config.to_hash.keys.include?(event)
+        return false
+      end
+      event_config = state_config[event]
+      if !can_trigger_event?(
+            event_name: event, 
+            metadata: {:acting_user => user, :acting_team => acting_team},
+            roles: [role])
+        return false
+      end
+      return true
     end
 
     # in a transaction, write the case transition record, and transition the case

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -187,6 +187,34 @@ RSpec.describe User, type: :model do
 
   end
 
+  describe '#case_team_for_event' do
+
+    context 'user is in one of the teams associated with the case' do
+      it 'returns the team link to user and case both' do
+        kase = create :accepted_case
+        new_team = create :business_unit, correspondence_type_ids: [foi.id]
+        check_user = kase.responder
+        check_user.team_roles << TeamsUsersRole.new(team: kase.managing_team, role: 'manager')
+        check_user.reload
+        expect(check_user.case_team_for_event(kase, 'add_responses')).to eq kase.responding_team
+      end
+    end
+
+    context 'user is in one of the teams associated with the case' do
+      it 'returns the team link to user and case both' do
+        kase = create :pending_dacu_clearance_case
+        new_team = create :business_unit, correspondence_type_ids: [foi.id]
+        check_user = kase.responder
+        approving_team = kase.approving_teams.first
+        check_user.team_roles << TeamsUsersRole.new(team: kase.approving_teams.first, role: 'approver')
+        check_user.reload
+        expect(check_user.teams_for_case(kase)).to match_array [approving_team, kase.responding_team]
+        expect(check_user.case_team_for_event(kase, 'reassign_user')).to eq approving_team
+      end
+    end
+
+  end
+
   describe '#roles_for_case' do
     context 'user has just one role for a case' do
       it 'returns an array of one role' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -199,8 +199,8 @@ RSpec.describe User, type: :model do
       end
     end
 
-    context 'user is in one of the teams associated with the case' do
-      it 'returns the team link to user and case both' do
+    context 'user is in multiple teams associated with the case' do
+      it 'returns the team link having highest authority to user and case both' do
         kase = create :pending_dacu_clearance_case
         check_user = kase.responder
         approving_team = kase.approving_teams.first

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -192,7 +192,6 @@ RSpec.describe User, type: :model do
     context 'user is in one of the teams associated with the case' do
       it 'returns the team link to user and case both' do
         kase = create :accepted_case
-        new_team = create :business_unit, correspondence_type_ids: [foi.id]
         check_user = kase.responder
         check_user.team_roles << TeamsUsersRole.new(team: kase.managing_team, role: 'manager')
         check_user.reload
@@ -203,7 +202,6 @@ RSpec.describe User, type: :model do
     context 'user is in one of the teams associated with the case' do
       it 'returns the team link to user and case both' do
         kase = create :pending_dacu_clearance_case
-        new_team = create :business_unit, correspondence_type_ids: [foi.id]
         check_user = kase.responder
         approving_team = kase.approving_teams.first
         check_user.team_roles << TeamsUsersRole.new(team: kase.approving_teams.first, role: 'approver')

--- a/spec/site_prism/page_objects/pages/cases/upload_responses_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/upload_responses_page.rb
@@ -25,6 +25,8 @@ module PageObjects
 
         # only shows up when using drop_in_dropzone
         element :uploaded_request_file_input, '#uploadedRequestFileInput'
+        elements :uploaded_request_file_inputs, 'input.case-uploaded-files',
+                 visible: false
 
         # Upload a file to Dropzone.js
         def drop_in_dropzone(file_path)


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to fix the issue of not being able to upload response if the responder of the case is also of the member of the managing team. The change I made is to add a new function in machine.rb and user.rb to narrow down the teams only relevant to the event for this case under current state, if multiple teams meet the criteria, only the one with highest authority will be turned. This change will guarantee the right acting_team for state change will have the permission.
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
