### PR TITLE
CT-2146 Deactivate business group

### DIFF
--- a/app/views/teams/_business_group_detail.html.slim
+++ b/app/views/teams/_business_group_detail.html.slim
@@ -46,9 +46,8 @@ h2.heading-medium
   p
 p
 
-= link_to 'Add new directorate', new_team_path(team_type: 'dir', parent_id: @team.id), class: 'button'
-/ = link_to "Deactivate", team_path(@team.id),
-/                       data: {:confirm => t('.destroy')},
-/                       method: :delete,
-/                       class: 'button-secondary button-left-spacing',
-/                       id: 'deactivate-team-link'
+.grid-row
+  .column-full
+    = link_to 'Add new directorate', new_team_path(team_type: 'dir', parent_id: @team.id), class: 'button'
+hr
+= show_deactivate_link_or_info(current_user, @team)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -114,6 +114,7 @@ ignore_unused:
   - 'common.case.request'
   - 'nav.pages.teams.*'
   - 'teams.deactivate_info.*'
+  - 'teams.business_group_detail.destroy'
   - 'teams.directorate_detail.destroy'
   - 'teams.business_unit_detail.destroy'
   - users.show.heading_all_cases

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -499,7 +499,7 @@ en:
         Case::FOI::Standard: FOI
         Case::FOI::TimelinessReview: FOI - Internal review for timeliness
         Case::FOI::ComplianceReview: FOI - Internal review for compliance
-        Case::SAR::Standard: SAR - Non-offender 
+        Case::SAR::Standard: SAR - Non-offender
       foi:
         requester_type:
           academic_business_charity: Academic/Business/Charity
@@ -1239,6 +1239,8 @@ en:
   teams:
     browse_by_business_group: Browse by business group
     business_group: Business group
+    business_group_detail:
+      destroy: Are you sure you want to deactivate this business group?
     business_unit_list:
       team_members: Team members
     business_unit_detail:
@@ -1257,6 +1259,7 @@ en:
     deactivate_info:
       directorate: To deactivate this directorate you need to first deactivate all business units within it.
       business_unit: To deactivate this business unit you need to first deactivate all users within it.
+      business_group: To deactivate this business group you need to first deactivate all directorates within it.
     labels:
       select_business_group: Select a business group
       select_directorate: Select a directorate

--- a/spec/features/admin/deactivating_teams_spec.rb
+++ b/spec/features/admin/deactivating_teams_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
+feature 'deactivating business groups' do
+  given(:bg)             { create :business_group, name: "Group1" }
+  given(:manager)         { create :manager }
+
+  scenario 'manager deactivates a business group with no active children' do
+    login_as manager
+
+    teams_show_page.load(id: bg.id)
+    teams_show_page.deactivate_team_link.click
+
+    expect(teams_show_page.flash_notice.text).to eq(
+    "#{bg.name} business group has now been deactivated")
+  end
+end
+
 feature 'deactivating directorates' do
   given(:dir)             { create :dacu_directorate, name: "dir1" }
   given(:active_dir)      { create :dacu_directorate, name: "directorate"}


### PR DESCRIPTION
## Description
Small PR to restore the ability to deactivate business groups. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
![image](https://user-images.githubusercontent.com/1161161/119343029-c9face80-bc8d-11eb-92dd-16303da5b62e.png)
![image](https://user-images.githubusercontent.com/1161161/119343095-e3037f80-bc8d-11eb-877e-15b4aa16d264.png)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-2146

### Deployment
n/a

### Manual testing instructions
Signed in as David Attenborough, you can create an empty Business Group to test with - should be able to deactivate it now. 
If you create a Directorate within it, however, you should see an info message instead of the deactivate link. 
