### PR TITLE
CT-3365 Deselect radio for hidden elements

### DIFF
--- a/app/assets/javascripts/modules/CustomReports.js
+++ b/app/assets/javascripts/modules/CustomReports.js
@@ -34,6 +34,13 @@ moj.Modules.CustomReports = {
         $('input[type="hidden"]', this).each(function() {
           $(this).prop('disabled', true);
         });
+
+        // Radios have the same name, so if a hidden radio is checked
+        // it will break the keyboard tabbing - since the keyboard
+        // tabbing defaults to the selected radio
+        $('input[type="radio"]', this).each(function() {
+          $(this).prop('checked', false);
+        });
       });
 
       var selected = $('input:checked', this.$correspondenceTypes);


### PR DESCRIPTION
## Description
Fix accessibility issue: Keyboard tabbing: Custom report page. When choosing case type then report type, then changing case type, pressing tab tabbing skips the report type and jumps to the date.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3365



### Manual testing instructions
Reports > Custom report > Choose FOi > press tab > choose report coverage of Business unit report -  then click on SAR above, and press tab. It goes to date when broken. When fixed it goes to report coverage section.
