### PR TITLE
CT-3375 make button green for case messages in non offender cases

### DIFF
--- a/app/views/cases/_case_messages.html.slim
+++ b/app/views/cases/_case_messages.html.slim
@@ -16,4 +16,4 @@ h2.request--heading Conversation
 	      	label for="case_message_text"
 	      	  = t('helpers.label.case.add_to_conversation')
 	      textarea#case_message_text.form-control name="case[message_text]"
-      = f.submit "Add message", class: 'button-secondary'
+      = f.submit "Add message", class: 'button'

--- a/spec/site_prism/page_objects/pages/cases/show_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/show_page.rb
@@ -84,7 +84,7 @@ module PageObjects
 
         section :new_message, '.message-form' do
           element :input, 'textarea'
-          element :add_button, '.button-secondary'
+          element :add_button, '.button'
         end
 
         section :offender_sar_subject_details, '.section-subject-details' do


### PR DESCRIPTION
## Description
Make button green for conversation in non-offender sar case - as with offender SAR case notes

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshot

before
![image](https://user-images.githubusercontent.com/22935203/119691673-b04eb800-be42-11eb-810c-5ae4f9de21c3.png)


AFTER:
![image](https://user-images.githubusercontent.com/22935203/119691611-a3ca5f80-be42-11eb-87e6-7e35126fc72c.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3375



### Manual testing instructions
Login as David Attenborough - got to any case and check the conversation box - button to add messages should be green instead of grey.
