### PR TITLE
CT-3271 Added a task for adding missing pit extension flag to FOI cases

### DIFF
--- a/lib/tasks/add_pit_extension_to_cases.rake
+++ b/lib/tasks/add_pit_extension_to_cases.rake
@@ -1,0 +1,91 @@
+require 'csv'
+require 'json'
+
+namespace :cases do
+
+  namespace :pit_extension do 
+
+    desc "Add the pit extension flag if the case has been extended and the flag is missing"
+    task :perform, [] => :environment do |_task, args|
+      counter = 0
+      records = get_records_having_extension_events
+      records.each do | record |
+        result = check_record_extension_flag(record)
+        if result[:calculated_flag] != record.has_pit_extension?
+          puts "Found case #{record.number} has no has_pit_extension"
+          begin
+            record.has_pit_extension = result[:calculated_flag]
+            record.save!
+            counter += 1
+            puts "** Done case #{record.number} **"
+          rescue StandardError => err
+            puts "Failed to update the extension flag for case #{record.number} due to #{err.message}"
+          end
+        end
+      end
+      puts "Totally #{counter}cases have been updated with has_pit_extension flag."
+    end
+
+    desc "Get the list of cases which has been extended but no pit-extension flag"
+    task :check, [:file] => :environment do |_task, args|
+      raise "Must specify the csv file for outputing the result " if args[:file].blank?
+      CSV.open(args[:file], "wb") do |csv|
+        csv << ["case_id", 
+                "case_number", 
+                "type", 
+                "has flag?",
+                "number of extend_for_pit",
+                "number of remove_pit_extension",
+                "present_flag", 
+                "calculated_flag"
+        ]
+        counter = 0
+        records = get_records_having_extension_events
+        records.each do | record |
+          puts "Checking case #{record.number}"
+          counter += 1
+          result = check_record_extension_flag(record)
+          csv << [record.id, 
+                  record.number,
+                  record.type,
+                  record.properties["has_pit_extension"].present?,
+                  result[:num_extend_for_pit],
+                  result[:num_remove_pit_extension], 
+                  record.has_pit_extension?,
+                  result[:calculated_flag]
+                ]
+        end
+      end 
+      puts "Totally #{counter} extended FOI cases."
+    end
+
+    private 
+
+    def get_records_having_extension_events
+      case_ids = CaseTransition.where(event: ["extend_for_pit", "remove_pit_extension"])
+      .distinct(:case_id)
+      .pluck(:case_id)
+      Case::Base.where(id: case_ids)
+    end
+
+    def check_record_extension_flag(record)
+      calculated_flag = false
+      num_extend_for_pit = 0
+      num_remove_pit_extension = 0
+      record.transitions.order(:id).each do | transaction |
+        if transaction.event == 'extend_for_pit'
+          calculated_flag = true
+          num_extend_for_pit += 1
+        end
+        if transaction.event == 'remove_pit_extension'
+          calculated_flag = false
+          num_remove_pit_extension += 1
+        end
+      end
+      {:calculated_flag => calculated_flag, 
+        :num_extend_for_pit => num_extend_for_pit, 
+        :num_remove_pit_extension => num_remove_pit_extension}
+    end
+
+  end
+end

--- a/lib/tasks/add_pit_extension_to_cases.rake
+++ b/lib/tasks/add_pit_extension_to_cases.rake
@@ -6,7 +6,7 @@ namespace :cases do
   namespace :pit_extension do 
 
     desc "Add the pit extension flag if the case has been extended and the flag is missing"
-    task :perform, [] => :environment do |_task, args|
+    task :perform, [] => :environment do |_task, _|
       counter = 0
       records = get_records_having_extension_events
       records.each do | record |


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to add missing has_pit_extension to the FOI cases which were Created before this flag was introduced 2019
There are 2 tasks 
1 - check:   e.g. rake cases:pit_extension:check[check_result.csv],  get the list of FOI cases which have been extended
2 - perform:  e.g. rake cases:pit_extension:perform,  perform the updating action of adding missing flag

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-3271
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
