### PR TITLE
Add covid_partial_response subtype

### DIFF
--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -42,6 +42,7 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
   }
 
   enum complaint_subtype: {
+    covid_partial_response: 'covid_partial_response',
     missing_data: 'missing_data',
     inaccurate_data: 'inaccurate_data',
     redacted_data: 'redacted_data',

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_complaint_type.rb
@@ -51,16 +51,12 @@ module PageObjects
           end
 
           def fill_in_complaint_subtype(kase)
-            if kase.missing_data?
-              choose('offender_sar_complaint_complaint_subtype_missing_data', visible: false)
-            elsif kase.inaccurate_data?
-              choose('offender_sar_complaint_complaint_subtype_inaccurate_data', visible: false)
-            elsif kase.redacted_data?
-              choose('offender_sar_complaint_complaint_subtype_redacted_data', visible: false)
-            elsif kase.timeliness?
-              choose('offender_sar_complaint_complaint_subtype_timeliness', visible: false)
-            elsif kase.not_applicable?
-              choose('offender_sar_complaint_complaint_subtype_not_applicable', visible: false)
+            possible_subtypes = Case::SAR::OffenderComplaint.complaint_subtypes.keys()
+
+            possible_subtypes.each do |subtype|
+              if kase.send((subtype + '?').to_sym)
+                choose("offender_sar_complaint_complaint_subtype_#{subtype}", visible: false)
+              end
             end
           end
 


### PR DESCRIPTION
Add covid_partial_response subtype for complaint cases.

Change is already covered by `features/offender_sar_compaint/case_creating_spec.rb` as it uses `.sample` to select a case type. 

see slack thread linked in Jira as to reason why we went with 'Covid' rather than 'COVID'

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-3618](https://dsdmoj.atlassian.net/browse/CT-3618)

### Manual testing instructions
1. create a new complaint case or find any existing case. 
2. Edit its subtype - there should be a 'Covid partial response' option
3. Save the case, it should be visible on the show page answering the question "What is the nature of the complaint?"



