### PR TITLE
CT-3610 Add newlines to letter address

### DIFF
--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -44,7 +44,7 @@ class Letter
     when "dispatch"
       values.recipient_address
     when "acknowledgement"
-      values.requester_address
+      format_address(values.requester_address)
     end
   end
 
@@ -54,5 +54,15 @@ class Letter
 
   def company_name
     values.third_party_company_name if values.third_party_company_name.present?
+  end
+
+  private
+
+  def format_address(address)
+    if address.include?(",")
+      address.split(',').map{|word| word.strip }.join("\n") 
+    else
+      address
+    end
   end
 end

--- a/spec/models/letter_spec.rb
+++ b/spec/models/letter_spec.rb
@@ -140,4 +140,15 @@ RSpec.describe Letter, type: :model do
       end
     end
   end
+
+  describe '#format_address' do
+    let(:kase_two) { create(:offender_sar_case, name: 'Waylon Smithers', 
+                        subject_address: '22 Sample Address, Test Lane, Testingington, TE57ST') }
+
+    it 'formats address into new lines' do
+      letter = Letter.new(letter_template.id, kase_two)
+      address_with_newlines = letter.address
+      expect(address_with_newlines).to eq "22 Sample Address\nTest Lane\nTestingington\nTE57ST"
+    end
+  end
 end


### PR DESCRIPTION
## Description
Adds formatting to the addresses in the letter templates so they match what is described on the ticket.

Works if there are commas separating the fields. If addresses are just ended in a string with spacing, there is no way that I can think of to simply space them out over multiple lines. For instance:

"23 Fake Road Old Town Durham DU35GH"

So if addresses are entered like this without some sort of look up to a service that sends back a better formatted address I don't think they can be split over multiple lines accurately. 

Mostly addresses are separated by commas or newlines, which in the latter case are all ready correctly formatted - for instance:

23 Fake Road 
Old Town 
Durham 
DU35GH
 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Before:
<img width="384" alt="Screenshot 2021-06-15 at 13 50 34" src="https://user-images.githubusercontent.com/13377553/122055570-ab957800-cde0-11eb-9e3d-ffa2e7193185.png">

After:
<img width="159" alt="Screenshot 2021-06-15 at 13 49 36" src="https://user-images.githubusercontent.com/13377553/122055434-87d23200-cde0-11eb-8505-558a9170c277.png">

### Related JIRA tickets
[CT-3601](https://dsdmoj.atlassian.net/browse/CT-3610)

### Manual testing instructions
Look at a report and check that the address is on newlines.

