### PR TITLE
CT-3608 Take only first PNC / Prison number

### DIFF
--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -401,8 +401,18 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
   end
 
   def choose_cover_page_id_number(prison_number, pnc_number)
-    return pnc_number&.upcase if prison_number.nil?
-    return pnc_number&.upcase if prison_number.empty?
-    prison_number&.upcase
+    prison_number = get_first_number_in_string(prison_number) 
+    pnc_number = get_first_number_in_string(pnc_number)
+
+    return pnc_number if prison_number.nil?
+    return pnc_number if prison_number.empty?
+
+    prison_number
+  end
+
+  private 
+  def get_first_number_in_string(number_string)
+    return number_string.split(",").first&.upcase if number_string&.include?(",")
+    number_string&.upcase
   end
 end

--- a/spec/helpers/cases_helper_spec.rb
+++ b/spec/helpers/cases_helper_spec.rb
@@ -463,9 +463,23 @@ href="/cases/#{@case.id}/assignments/select_team?assignment_ids=#{@assignments.f
       expect(output_2).to eq 'PNCTEST1'
     end
   
-    it 'returns upcased prison number when if it is not blank or empty' do
+    it 'returns upcased prison number if it is not blank or empty' do
       prison_number = 'PrisonNum1'
       pnc_number = 'PncTest1'
+      output = choose_cover_page_id_number(prison_number, pnc_number)
+      expect(output).to eq 'PRISONNUM1'
+    end
+
+    it 'only returns the first pnc number if more than one is available' do
+      prison_number = ''
+      pnc_number = 'PncTest1, PncTest2, PncTest3'
+      output = choose_cover_page_id_number(prison_number, pnc_number)
+      expect(output).to eq 'PNCTEST1'
+    end
+
+    it 'only returns the first prison number if more than one is available' do
+      prison_number = 'PrisonNum1, PrisonNum2, PrisonNum3'
+      pnc_number = 'PncTest1, PncTest2, PncTest3'
       output = choose_cover_page_id_number(prison_number, pnc_number)
       expect(output).to eq 'PRISONNUM1'
     end


### PR DESCRIPTION
New criteria for this added to ticket. Means now that if there are comma
separated pnc or prison numbers only the first is taken for the cover
sheet + specs for this.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Related JIRA tickets
[CT-3608](https://dsdmoj.atlassian.net/browse/CT-3608)

### Manual testing instructions

- create case with multiple comma separated pnc / prison numbers. When loading the cover sheet only the first of these should be shown.
