### PR TITLE
Move saludations above bold heading in letter seeder

### DIFF
--- a/db/seeders/letter_template_seeder.rb
+++ b/db/seeders/letter_template_seeder.rb
@@ -20,9 +20,9 @@ class LetterTemplateSeeder
                 template_type: 'acknowledgement',
                 body: <<~EOF
                   <p>
+                  <br><br>Dear <%= values.requester_name %>
                   <br>
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
-                  <br><br>Dear <%= values.requester_name %>,
                   <br>
                   <br>Thank you for your Subject Access Request (SAR) dated <%= values.request_dated&.strftime('%e %B %Y') %>.
                   <br>
@@ -56,9 +56,9 @@ class LetterTemplateSeeder
                 template_type: 'acknowledgement',
                 body: <<~EOF
                   <p>
+                  <br><br>Dear <%= values.requester_name %>
                   <br>
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
-                  <br><br>Dear <%= values.requester_name %>,
                   <br>
                   <br>Thank you for your Subject Access Request (SAR) dated <%= values.request_dated&.strftime('%e %B %Y') %>.
                   <br>
@@ -92,10 +92,10 @@ class LetterTemplateSeeder
                 template_type: 'dispatch',
                 body: <<~EOF
                   <p>
+                  <br><br>Dear Colleague
                   <br>
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
                   <br><strong><%= values.subject_full_name&.upcase %> - <%= values.first_prison_number %></strong>
-                  <br><br>Dear Colleague,
                   <br>
                   <br>Please find enclosed documents relating to a Subject Access Request (SAR) made under the Data Protection Act 2018 by the above offender.
                   <br>
@@ -131,9 +131,9 @@ class LetterTemplateSeeder
                 template_type: 'dispatch',
                 body: <<~EOF
                   <p>
+                  <br><br>Dear <%= values.recipient_name %>
                   <br>
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
-                  <br><br>Dear <%= values.recipient_name %>,
                   <br>
                   <br>I am writing in response to your request for information made under the Data Protection Act 2018 (DPA).
                   <br>
@@ -174,9 +174,9 @@ class LetterTemplateSeeder
                 template_type: 'dispatch',
                 body: <<~EOF
                   <p>
+                  <br><br>Dear <%= values.recipient_name %>
                   <br>
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
-                  <br><br>Dear <%= values.recipient_name %>,
                   <br>
                   <br>I am writing in response to your request for information made under the Data Protection Act 2018 (DPA).
                   <br>
@@ -219,10 +219,10 @@ class LetterTemplateSeeder
                 template_type: 'acknowledgement',
                 body: <<~EOF
                   <p>
+                  <% if values.recipient == "requester_recipient" %><br><br>Dear Sirs<% end %>
                   <br>
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
                   <br><strong><%= values.subject_full_name&.upcase %> - <%= values.first_prison_number %></strong>
-                  <% if values.recipient == "requester_recipient" %><br><br>Dear Sirs,<% end %>
                   <br>
                   <br>Thank you for your subject access request (SAR) dated <%= values.request_dated&.strftime('%e %B %Y') %>.
                   <br>
@@ -256,10 +256,10 @@ class LetterTemplateSeeder
                 template_type: 'acknowledgement',
                 body: <<~EOF
                   <p>
+                  <% if values.recipient == "requester_recipient" %><br><br>Dear Sirs<% end %>
                   <br>
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
                   <br><strong><%= values.subject_full_name&.upcase %> - <%= values.first_prison_number %></strong>
-                  <% if values.recipient == "requester_recipient" %><br><br>Dear Sirs,<% end %>
                   <br>
                   <br>Thank you for your subject access request (SAR) dated <%= values.request_dated&.strftime('%e %B %Y') %>.
                   <br>
@@ -293,10 +293,10 @@ class LetterTemplateSeeder
                 template_type: 'dispatch',
                 body: <<~EOF
                   <p>
+                  <br><br><% if values.recipient == "requester_recipient" %>Dear Sirs <% else %>Dear <%= values.recipient_name %> <% end %>
                   <br>
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
                   <br><strong><%= values.subject_full_name&.upcase %> - <%= values.first_prison_number %></strong>
-                  <br><br><% if values.recipient == "requester_recipient" %>Dear Sirs, <% else %>Dear <%= values.recipient_name %>, <% end %>
                   <br>
                   <br>I am writing in response to your request for information made under the Data Protection Act 2018 (DPA) for the above person.
                   <br>
@@ -337,10 +337,10 @@ class LetterTemplateSeeder
                 template_type: 'dispatch',
                 body: <<~EOF
                   <p>
+                  <br><br><% if values.recipient == "requester_recipient" %>Dear Sirs <% else %>Dear <%= values.recipient_name %> <% end %>
                   <br>
                   <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
                   <br><strong><%= values.subject_full_name&.upcase %> - <%= values.first_prison_number %></strong>
-                  <br><br><% if values.recipient == "requester_recipient" %>Dear Sirs, <% else %>Dear <%= values.recipient_name %>, <% end %>
                   <br>
                   <br>I am writing in response to your request for information made under the Data Protection Act 2018 (DPA).
                   <br>


### PR DESCRIPTION
## Description
Move salutations above bold heading in letter seeder as set out in ticket.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Related JIRA tickets
[CT-3610](https://dsdmoj.atlassian.net/browse/CT-3610)


### Manual testing instructions
- run letter seeder locally ` rails db:seed:dev:letter_templates`
- choose a Branston case, change state till ack letters are available, check format is correct.
