### PR TITLE
CT-3553 dry out env vars in k8

### DIFF
--- a/config/kubernetes/demo/configmap.yaml
+++ b/config/kubernetes/demo/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  ENV: 'demo'
+  RAILS_ENV: 'production'
+  RAILS_SERVE_STATIC_FILES: 'true'
+  SENTRY_ENVIRONMENT: 'demo'
+kind: ConfigMap
+metadata:
+  name: environment-variables

--- a/config/kubernetes/demo/deployment.yaml
+++ b/config/kubernetes/demo/deployment.yaml
@@ -24,51 +24,6 @@ spec:
             - containerPort: 3000
           command: ["./config/docker/entrypoint-webapp.sh"]
           env:
-            - name: ENV
-              value: 'demo'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: SENTRY_ENVIRONMENT
-              value: 'demo'
-            - name: PROJECT
-              value: 'correspondence-staff'
-            - name: RAILS_SERVE_STATIC_FILES
-              value: 'true'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -104,6 +59,11 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -130,47 +90,6 @@ spec:
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-background-jobs.sh"]
           env:
-            - name: ENV
-              value: 'demo'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-jobs'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -206,51 +125,15 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
         - name: uploads
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-uploads.sh"]
           env:
-            - name: ENV
-              value: 'demo'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-uploads'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -286,3 +169,8 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets

--- a/config/kubernetes/development/configmap.yaml
+++ b/config/kubernetes/development/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  ENV: 'dev'
+  RAILS_ENV: 'production'
+  RAILS_SERVE_STATIC_FILES: 'true'
+  SENTRY_ENVIRONMENT: 'development'
+kind: ConfigMap
+metadata:
+  name: environment-variables
+  

--- a/config/kubernetes/development/configmap.yaml
+++ b/config/kubernetes/development/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 data:
-  ENV: 'qa'
+  ENV: 'dev'
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: 'true'
-  SENTRY_ENVIRONMENT: 'qa'
+  SENTRY_ENVIRONMENT: 'development'
 kind: ConfigMap
 metadata:
   name: environment-variables

--- a/config/kubernetes/development/deployment.yaml
+++ b/config/kubernetes/development/deployment.yaml
@@ -25,51 +25,6 @@ spec:
             - containerPort: 3000
           command: ["./config/docker/entrypoint-webapp.sh"]
           env:
-            - name: ENV
-              value: 'dev'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff'
-            - name: RAILS_SERVE_STATIC_FILES
-              value: 'true'
-            - name: SENTRY_ENVIRONMENT
-              value: 'development'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -105,6 +60,11 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -131,47 +91,6 @@ spec:
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-background-jobs.sh"]
           env:
-            - name: ENV
-              value: 'dev'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-jobs'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -207,51 +126,15 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
         - name: uploads
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-uploads.sh"]
           env:
-            - name: ENV
-              value: 'dev'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-uploads'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -287,3 +170,8 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets

--- a/config/kubernetes/production/configmap.yaml
+++ b/config/kubernetes/production/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  ENV: 'prod'
+  RAILS_ENV: 'production'
+  RAILS_SERVE_STATIC_FILES: 'true'
+  SENTRY_ENVIRONMENT: 'production'
+kind: ConfigMap
+metadata:
+  name: environment-variables

--- a/config/kubernetes/production/deployment.yaml
+++ b/config/kubernetes/production/deployment.yaml
@@ -24,51 +24,6 @@ spec:
           - containerPort: 3000
           command: ["./config/docker/entrypoint-webapp.sh"]
           env:
-            - name: ENV
-              value: 'prod'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: SENTRY_ENVIRONMENT
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff'
-            - name: RAILS_SERVE_STATIC_FILES
-              value: 'true'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -104,6 +59,11 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -130,47 +90,6 @@ spec:
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-background-jobs.sh"]
           env:
-            - name: ENV
-              value: 'prod'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-jobs'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -206,51 +125,15 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
         - name: uploads
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-uploads.sh"]
           env:
-            - name: ENV
-              value: 'prod'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-uploads'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -286,3 +169,8 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets

--- a/config/kubernetes/qa/configmap.yaml
+++ b/config/kubernetes/qa/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 data:
-  ENV: 'prod'
+  ENV: 'qa'
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: 'true'
-  SENTRY_ENVIRONMENT: 'production'
+  SENTRY_ENVIRONMENT: 'qa'
 kind: ConfigMap
 metadata:
   name: environment-variables

--- a/config/kubernetes/qa/configmap.yaml
+++ b/config/kubernetes/qa/configmap.yaml
@@ -1,10 +1,9 @@
 apiVersion: v1
 data:
-  ENV: 'qa'
+  ENV: 'prod'
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: 'true'
-  SENTRY_ENVIRONMENT: 'qa'
+  SENTRY_ENVIRONMENT: 'production'
 kind: ConfigMap
 metadata:
   name: environment-variables
-  

--- a/config/kubernetes/qa/deployment.yaml
+++ b/config/kubernetes/qa/deployment.yaml
@@ -24,51 +24,6 @@ spec:
           - containerPort: 3000
           command: ["./config/docker/entrypoint-webapp.sh"]
           env:
-            - name: ENV
-              value: 'qa'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: SENTRY_ENVIRONMENT
-              value: 'qa'
-            - name: PROJECT
-              value: 'correspondence-staff'
-            - name: RAILS_SERVE_STATIC_FILES
-              value: 'true'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -104,6 +59,11 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -130,47 +90,6 @@ spec:
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-background-jobs.sh"]
           env:
-            - name: ENV
-              value: 'qa'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-jobs'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -206,51 +125,15 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
         - name: uploads
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-uploads.sh"]
           env:
-            - name: ENV
-              value: 'qa'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-uploads'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -286,3 +169,9 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
+

--- a/config/kubernetes/staging/configmap.yaml
+++ b/config/kubernetes/staging/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 data:
-  ENV: 'qa'
+  ENV: 'staging'
   RAILS_ENV: 'production'
   RAILS_SERVE_STATIC_FILES: 'true'
-  SENTRY_ENVIRONMENT: 'qa'
+  SENTRY_ENVIRONMENT: 'staging'
 kind: ConfigMap
 metadata:
   name: environment-variables

--- a/config/kubernetes/staging/deployment.yaml
+++ b/config/kubernetes/staging/deployment.yaml
@@ -24,51 +24,6 @@ spec:
             - containerPort: 3000
           command: ["./config/docker/entrypoint-webapp.sh"]
           env:
-            - name: ENV
-              value: 'staging'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: SENTRY_ENVIRONMENT
-              value: 'staging'
-            - name: PROJECT
-              value: 'correspondence-staff'
-            - name: RAILS_SERVE_STATIC_FILES
-              value: 'true'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -104,6 +59,11 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
           readinessProbe:
             httpGet:
               path: /healthcheck
@@ -130,47 +90,6 @@ spec:
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-background-jobs.sh"]
           env:
-            - name: ENV
-              value: 'staging'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-jobs'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -206,51 +125,15 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets
         - name: uploads
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:latest
           command: ["./config/docker/entrypoint-uploads.sh"]
           env:
-            - name: ENV
-              value: 'staging'
-            - name: RAILS_ENV
-              value: 'production'
-            - name: PROJECT
-              value: 'correspondence-staff-uploads'
-            - name: GA_TRACKING_ID
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: GA_TRACKING_ID
-            - name: SETTINGS__CTS_EMAIL_URL
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__CTS_EMAIL_URL
-            - name: SETTINGS__GOVUK_NOTIFY_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__GOVUK_NOTIFY_API_KEY
-            - name: SETTINGS__SMOKE_TESTS__USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__USERNAME
-            - name: SETTINGS__SMOKE_TESTS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SETTINGS__SMOKE_TESTS__PASSWORD
-            - name: SECRET_KEY_BASE
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SECRET_KEY_BASE
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: app-secrets
-                  key: SENTRY_DSN
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
@@ -286,3 +169,8 @@ spec:
                 secretKeyRef:
                   name: track-a-query-s3-output
                   key: secret_access_key
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+            - secretRef:
+                name: app-secrets

--- a/deploy.sh
+++ b/deploy.sh
@@ -123,7 +123,7 @@ function _deploy() {
 
   # Apply config map updates
   kubectl apply \
-    -f config/kubernetes/${environment}/config_map.yaml -n $namespace
+    -f config/kubernetes/${environment}/configmap.yaml -n $namespace
 
   # Apply image specific config
   kubectl set image -f config/kubernetes/${environment}/deployment.yaml \

--- a/deploy.sh
+++ b/deploy.sh
@@ -121,6 +121,10 @@ function _deploy() {
   # kubectl config set-context ${context} --namespace=$namespace
   # kubectl config use-context ${context}
 
+  # Apply config map updates
+  kubectl apply \
+    -f config/kubernetes/${environment}/config_map.yaml -n $namespace
+
   # Apply image specific config
   kubectl set image -f config/kubernetes/${environment}/deployment.yaml \
           webapp=${docker_image_tag} \

--- a/spec/lib/host_env_spec.rb
+++ b/spec/lib/host_env_spec.rb
@@ -92,8 +92,8 @@ describe HostEnv do
 
   describe '5 cloud platform infrastructure environments' do
     before(:each) do
-      k8s_settings = YAML.load_file("config/kubernetes/#{namespace}/deployment.yaml")
-      @envvars = k8s_settings.dig('spec', 'template', 'spec', 'containers')[0]['env']
+      k8s_settings = YAML.load_file("config/kubernetes/#{namespace}/configmap.yaml")
+      @envvars = k8s_settings.dig('data','env')
     end
 
     context '1. demo server' do

--- a/spec/lib/host_env_spec.rb
+++ b/spec/lib/host_env_spec.rb
@@ -93,7 +93,7 @@ describe HostEnv do
   describe '5 cloud platform infrastructure environments' do
     before(:each) do
       k8s_settings = YAML.load_file("config/kubernetes/#{namespace}/configmap.yaml")
-      @envvars = k8s_settings.dig('data','env')
+      @envvars = k8s_settings.dig('data')
     end
 
     context '1. demo server' do
@@ -254,8 +254,8 @@ describe HostEnv do
     end
 
     def expect_k8s_settings
-      expect(env_value_for(name: 'RAILS_ENV')).to eq ENV['RAILS_ENV']
-      expect(env_value_for(name: 'ENV')).to eq ENV['ENV']
+      expect(@envvars['RAILS_ENV']).to eq ENV['RAILS_ENV']
+      expect(@envvars['ENV']).to eq ENV['ENV']
     end
 
     def env_value_for(name:)

--- a/spec/lib/host_env_spec.rb
+++ b/spec/lib/host_env_spec.rb
@@ -257,9 +257,5 @@ describe HostEnv do
       expect(@envvars['RAILS_ENV']).to eq ENV['RAILS_ENV']
       expect(@envvars['ENV']).to eq ENV['ENV']
     end
-
-    def env_value_for(name:)
-      @envvars.find { |envvar| envvar['name'] == name.upcase }['value']
-    end
   end
 end


### PR DESCRIPTION
## Description
Dry out environmental vars for Kubernetes using shared configmap and secrets (repo secrets only)

Related PRs to allow configmaps:
https://github.com/ministryofjustice/cloud-platform-environments/pull/5021
https://github.com/ministryofjustice/cloud-platform-environments/pull/5024
https://github.com/ministryofjustice/cloud-platform-environments/pull/5025
https://github.com/ministryofjustice/cloud-platform-environments/pull/5026
https://github.com/ministryofjustice/cloud-platform-environments/pull/5027 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3553

### Deployment
Needs to be tested on all non-prod envs - and backup should be planned

### Manual testing instructions
very basic regression
