### PR TITLE
CT-3352 Add button to make upload form keyboard accessible

### DIFF
--- a/app/views/shared/_dropzone_form.html.slim
+++ b/app/views/shared/_dropzone_form.html.slim
@@ -1,4 +1,4 @@
-.dropzone{ tabindex="0"
+.dropzone{ 
            data-dz-template=render('shared/dropzone_js').gsub('"', '\'').html_safe
            data-form-data=s3_direct_post.fields.to_json
            data-url= s3_direct_post.url
@@ -13,5 +13,6 @@
     .column-one-half
     span.normal= "Drag and drop files here"
     .bold-normal= "or"
-    .button-secondary
+    button.button-secondary type="button"
       = t('common.choose_file')
+      


### PR DESCRIPTION
## Description
Add button in upload form so user can tab through with keyboard in natural way. The unnatural tab index was there but wasn't doing anything.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
![image](https://user-images.githubusercontent.com/22935203/123641077-c375ee80-d819-11eb-9bac-7ab663cd79c3.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3352

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Use keyboard to create FOI case that came by post
