### PR TITLE
CT - 3711 remove smoke user credential from setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -213,8 +213,6 @@ global_navigation:
       teams:
 
 smoke_tests:
-  username: 'no-reply-smoke-test@digital.justice.gov.uk'
-  password: 'abcdefg'
   site_url: 'http://localhost:3000'
 
 enabled_features:

--- a/db/seeders/dev_user_seeder.rb
+++ b/db/seeders/dev_user_seeder.rb
@@ -65,7 +65,7 @@ class DevUserSeeder
 
           user = User.where(email: email).first
           if user.nil?
-            user = User.create!(full_name: user_name, email: email, password: 'correspondence')
+            user = User.create!(full_name: user_name, email: email, password: ENV['DEV_PASSWORD'] || SecureRandom.random_number(36**13).to_s(36))
             puts "User #{user.full_name} created with email #{user.email}"
           else
             puts "User with email #{email} already exists"

--- a/db/seeders/user_seeder.rb
+++ b/db/seeders/user_seeder.rb
@@ -90,7 +90,7 @@ class UserSeeder
     kilo_email = normalize_email(kilo_email, kilo_name)
     user = User.find_by(email: kilo_email)
     if user.nil?
-      user = User.create!(full_name: kilo_name, email: kilo_email, password: '7DvUVgRx7eoxQ3NTKc897BJtExBwCTFunT')
+      user = User.create!(full_name: kilo_name, email: kilo_email, password: SecureRandom.random_number(36**13).to_s(36))
       puts "Created user #{user.full_name} - #{user.email}"
     end
 

--- a/lib/cts/cases/create.rb
+++ b/lib/cts/cases/create.rb
@@ -502,7 +502,7 @@ module CTS::Cases
       user = User.create!(
         full_name: name,
         email: Faker::Internet.email(name: name),
-        password: 'correspondence'
+        password: SecureRandom.random_number(36**13).to_s(36)
       )
 
       TeamsUsersRole.create(

--- a/spec/controllers/devise/sessions_controller_spec.rb
+++ b/spec/controllers/devise/sessions_controller_spec.rb
@@ -5,7 +5,7 @@ describe Devise::SessionsController do
   describe 'signing in' do
 
     let(:email)                 { 'abc@moj.com' }
-    let(:password)              { '102PettyFrance'  }
+    let(:password)              { SecureRandom.random_number(36**13).to_s(36)  }
     let(:bad_pass)              { 'xxx' }
     let(:user)                  { create :user, email: email, password: password }
     let(:bad_user)              { create :user, email: email, password: password, failed_attempts: 3 }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe UsersController, type: :controller do
                                .and_return(7271817273818812)
       post :create, params: params
       user = User.last
-      expect(user.valid_password?('1zln6qk2ncs')).to be true
+      expect(user.valid_password?(SecureRandom.random_number(36**13).to_s(36))).to be true
     end
 
     it 'adds the user to the specified team' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -46,7 +46,8 @@ FactoryBot.define do
 
     # NB: when using either 'find' or 'find_or_create' strategies, the existing
     #     user that is found will have it's password set to 'nil'.
-    password { 'qwerty$123' }
+    ENV['TESTSPEC_LOGIN_PASSWORD'] = SecureRandom.random_number(36**13).to_s(36)
+    password { ENV['TESTSPEC_LOGIN_PASSWORD'] }
     sequence(:full_name) { |n| "#{identifier} #{n}" }
     email { Faker::Internet.email(name: full_name) }
 

--- a/spec/features/common/sign_in_spec.rb
+++ b/spec/features/common/sign_in_spec.rb
@@ -8,8 +8,8 @@ feature "Signing in" do
     login_page.load
 
     expect(login_page).to have_no_user_card
-
-    login_page.log_in(responder.email, 'qwerty$123')
+    
+    login_page.log_in(responder.email, ENV['TESTSPEC_LOGIN_PASSWORD'])
 
     expect(login_page).to have_user_card
     expect(login_page.user_card.greetings).to have_content(responder.full_name)
@@ -21,7 +21,7 @@ feature "Signing in" do
   scenario "Signing in using invalid email" do
     login_page.load
 
-    login_page.log_in(Faker::Internet.email, 'qwerty$123')
+    login_page.log_in(Faker::Internet.email, ENV['TESTSPEC_LOGIN_PASSWORD'])
 
     expect(login_page.error_message).to have_content 'Invalid email or password'
   end
@@ -36,7 +36,7 @@ feature "Signing in" do
 
   scenario "signing in as a deactivated user" do
     login_page.load
-    login_page.log_in(deactivated_user.email, 'qwerty$123')
+    login_page.log_in(deactivated_user.email, ENV['TESTSPEC_LOGIN_PASSWORD'])
     expect(login_page.error_message).to have_content 'Invalid email or password.'
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe User, type: :model do
     context 'long non-blackilsted password' do
       it 'does not error and changes the encrypted password' do
       original_encrypted_password = user.encrypted_password
-        user.password = '102pettyfrance'
+        user.password = SecureRandom.random_number(36**13).to_s(36)
         user.save
         expect(user).to be_valid
         expect(user.encrypted_password).not_to eq original_encrypted_password

--- a/spec/services/user_creation_service_spec.rb
+++ b/spec/services/user_creation_service_spec.rb
@@ -50,7 +50,7 @@ describe UserCreationService do
     end
 
     context 'the user already exists in this team' do
-      let!(:existing_user) { User.new(full_name: 'danny driver', email: 'dd@moj.com', password: '102pettyfrance') }
+      let!(:existing_user) { User.new(full_name: 'danny driver', email: 'dd@moj.com', password: SecureRandom.random_number(36**13).to_s(36)) }
       let!(:existing_user_role) { existing_user.team_roles << TeamsUsersRole.new(team: team, role: 'responder') }
       let!(:success) { existing_user.save }
 
@@ -76,7 +76,7 @@ describe UserCreationService do
 
     context 'when a user with the same email exists' do
       let!(:other_team) { find_or_create :responding_team, name: 'Another User Creation Team' }
-      let!(:existing_user) { User.new(full_name: 'danny driver', email: 'dd@moj.com', password: '102pettyfrance') }
+      let!(:existing_user) { User.new(full_name: 'danny driver', email: 'dd@moj.com', password: SecureRandom.random_number(36**13).to_s(36)) }
       let!(:existing_user_role) { existing_user.team_roles << TeamsUsersRole.new(team: other_team, role: 'responder') }
       let!(:success) { existing_user.save }
 

--- a/spec/support/features/steps/login_steps.rb
+++ b/spec/support/features/steps/login_steps.rb
@@ -1,7 +1,7 @@
 def login_step(user:)
   login_page.load
   login_page.username_field.set user.email
-  login_page.password_field.set 'qwerty$123'
+  login_page.password_field.set ENV['TESTSPEC_LOGIN_PASSWORD']
   login_page.signin.click
   expect(cases_page.user_card.greetings).to have_text user.full_name
 end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
2 changes
 - Removed the default smoke user's credential from settings
 - Changed the password for user creation in a lib to random string.  Although this code is used for non-production env, but it is better to remove all those visible plain password

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3711
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
