### PR TITLE
CT-3356 do not show current team when changing team

### DIFF
--- a/app/views/assignments/_browse_teams.html.slim
+++ b/app/views/assignments/_browse_teams.html.slim
@@ -1,6 +1,6 @@
 h2.heading-medium
   = t('teams.browse_by_business_group')
-- console
+
 ul.business-groups.list
   - BusinessGroup.all.order(:name).each do |bg|
     li.business-group

--- a/app/views/assignments/_browse_teams.html.slim
+++ b/app/views/assignments/_browse_teams.html.slim
@@ -1,6 +1,6 @@
 h2.heading-medium
   = t('teams.browse_by_business_group')
-
+- console
 ul.business-groups.list
   - BusinessGroup.all.order(:name).each do |bg|
     li.business-group
@@ -22,17 +22,18 @@ ul.business-groups.list
 - if defined?(@business_units)
   ul.teams
     - @business_units.active.each do |team|
-      li.team
-        .team-details
-          h3
-            .team-unit-name
-              = team.name
-          = render partial: 'shared/areas_covered_list', locals: { team: team }
-        .team-actions
-          - if assignment.new_record?
-            = link_to t('button.assign', business_unit_name: team.name),
-                assign_to_responder_team_case_assignments_path(case_id: kase.id,
-                          team_id: team.id), class: 'button'
-          - else
-            = link_to t('button.assign', business_unit_name: team.name),
-                execute_assign_to_new_team_case_assignment_path(kase.id, assignment.id, team_id: team.id), class: 'button', method: :patch
+      - if team.name != kase.who_its_with
+        li.team
+          .team-details
+            h3
+              .team-unit-name
+                = team.name
+            = render partial: 'shared/areas_covered_list', locals: { team: team }
+          .team-actions
+            - if assignment.new_record?
+              = link_to t('button.assign', business_unit_name: team.name),
+                  assign_to_responder_team_case_assignments_path(case_id: kase.id,
+                            team_id: team.id), class: 'button'
+            - else            
+              = link_to t('button.assign', business_unit_name: team.name),
+                  execute_assign_to_new_team_case_assignment_path(kase.id, assignment.id, team_id: team.id), class: 'button', method: :patch

--- a/spec/views/assignments/new_page_spec.rb
+++ b/spec/views/assignments/new_page_spec.rb
@@ -34,7 +34,7 @@ describe 'assignments/new.html.slim', type: :view do
   context 'User has selected a specific business group or viewing all'  do
     it 'displays the new assignment page with business units' do
 
-      assign(:case, unassigned_case)
+      assign(:case, unassigned_case.decorate)
       assign(:assignment, unassigned_case.assignments.new)
       flash[:notice] = true
       assign(:creating_case, true)


### PR DESCRIPTION
## Description
When reassigning a business unit (London) then it shouldn't show the same business unit

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3356

### Deployment
n/a

### Manual testing instructions
Go to any case and click reassign to new team - then it shouldn't show the current team
