### PR TITLE
CT-3360 make title style consistentwhen adding teams

### DIFF
--- a/app/views/teams/new.html.slim
+++ b/app/views/teams/new.html.slim
@@ -6,7 +6,7 @@
 
 - if @team.parent.present?
   - content_for :sub_heading
-  = "#{@team.parent.pretty_type}: #{@team.parent.name}"
+    = "#{@team.parent.pretty_type}: #{@team.parent.name}"
 
 = render partial: 'layouts/header'
 


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
Bad:

![image](https://user-images.githubusercontent.com/22935203/126768172-e5acec4a-d9af-4b8e-bcc0-a0ba4dab232c.png)


Good:

![image](https://user-images.githubusercontent.com/22935203/126768088-cfb1c866-a049-4b79-948f-7e572366b30a.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3360

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Subheading should be grey and part of H1 when adding Directorate or business unit
