### PR TITLE
CT-3717 Stop select and copy of hidden elements

### DIFF
--- a/app/assets/stylesheets/moj/_govuk_overrides.scss
+++ b/app/assets/stylesheets/moj/_govuk_overrides.scss
@@ -129,3 +129,7 @@ td {
     overflow-wrap: break-word;
   }
 }
+
+.visually-hidden {
+  user-select: none;
+}

--- a/app/assets/stylesheets/moj/_helpers.scss
+++ b/app/assets/stylesheets/moj/_helpers.scss
@@ -1,16 +1,5 @@
 // Hide only visually, but have it available for screen readers:
 // http://snook.ca/archives/html_and_css/hiding-content-for-accessibility
-@mixin visually-hidden {
-  clip: rect(0, 0, 0, 0);
-  overflow: hidden !important;
-  position: absolute !important;
-  opacity: 0 !important;
-  padding: 0 !important;
-  margin: 0 !important;
-  width: 1px;
-  height: 1px;
-}
-
 @mixin clearfix {
   zoom: 1;
   &:before, &:after {


### PR DESCRIPTION
## Description
When you copy a case number it adds the word "number" due to hidden text. This stops this from happening.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
n/a

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3717

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Try copy and pasting a case number from the case page title, or from the case link
