### PR TITLE
CT-3742 added the feature of sorting search result

### DIFF
--- a/app/assets/stylesheets/moj/_typography.scss
+++ b/app/assets/stylesheets/moj/_typography.scss
@@ -146,6 +146,15 @@ table caption{
   }
 }
 
+.search-results-order {
+  font-size: 110%;
+  margin-top: $gutter-half;
+  margin-bottom: $gutter;
+  strong {
+    font-size: 120%;
+  }
+}
+
 @media (min-width: 641px) {
   .download-cases-link {
     text-align: right;

--- a/app/controllers/cases/filters_controller.rb
+++ b/app/controllers/cases/filters_controller.rb
@@ -138,7 +138,8 @@ module Cases
       service = CaseSearchService.new(
         user: current_user,
         query_type: :list,
-        query_params: query_list_params
+        query_params: query_list_params,
+        order: cookies[:search_result_order]
       )
       service.call(full_list_of_cases)
       service

--- a/app/controllers/cases/filters_controller.rb
+++ b/app/controllers/cases/filters_controller.rb
@@ -138,10 +138,9 @@ module Cases
       service = CaseSearchService.new(
         user: current_user,
         query_type: :list,
-        query_params: query_list_params,
-        order: cookies[:search_result_order]
+        query_params: query_list_params
       )
-      service.call(full_list_of_cases)
+      service.call(full_list_of_cases, order: cookies[:search_result_order])
       service
     end
 

--- a/app/controllers/cases/searches_controller.rb
+++ b/app/controllers/cases/searches_controller.rb
@@ -8,10 +8,12 @@ module Cases
       set_url
       @state_selector = StateSelector.new(params)
 
+      set_cookie_order_flag
       service = CaseSearchService.new(
         user: current_user,
         query_type: :search,
-        query_params: search_params
+        query_params: search_params,
+        order: cookies[:search_result_order]
       )
       service.call
       @query = service.query
@@ -40,5 +42,14 @@ module Cases
         format.csv { send_csv_cases 'search' }
       end
     end
+
+    private
+
+    def set_cookie_order_flag
+      if params["order"].present?
+        cookies[:search_result_order] = params["order"]
+      end
+    end
+
   end
 end

--- a/app/controllers/cases/searches_controller.rb
+++ b/app/controllers/cases/searches_controller.rb
@@ -12,10 +12,9 @@ module Cases
       service = CaseSearchService.new(
         user: current_user,
         query_type: :search,
-        query_params: search_params,
-        order: cookies[:search_result_order]
+        query_params: search_params
       )
-      service.call
+      service.call(order: cookies[:search_result_order])
       @query = service.query
 
       if service.error?

--- a/app/controllers/cases/searches_controller.rb
+++ b/app/controllers/cases/searches_controller.rb
@@ -47,7 +47,7 @@ module Cases
 
     def set_cookie_order_flag
       if params["order"].present?
-        cookies[:search_result_order] = params["order"]
+        cookies[:search_result_order] = {:value => params["order"], :secure => true }
       end
     end
 

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -18,6 +18,19 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
     link_to download_link_name || 'Download cases', csv_path
   end
 
+  def get_cases_order_option_url(original_uri, current_order_option)
+    if current_order_option == 'search_result_order_by_newest_first'
+      new_option = 'search_result_order_by_oldest_first'
+    else
+      new_option = 'search_result_order_by_newest_first'
+    end
+    uri = URI.parse(original_uri)
+    hash_params = Hash[URI.decode_www_form(uri.query || '')]
+    hash_params["order"] = new_option
+    uri.query = URI.encode_www_form(hash_params)
+    link_to t("common.show_#{new_option}"), uri.to_s
+  end
+
   def accepted_case_attachment_types
     Settings.case_uploads_accepted_types.join ','
   end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,0 +1,10 @@
+module SearchHelper
+
+  SEARCH_SCOPE_SET = [
+    {"name" => :search_result_order_by_oldest_first, "order" => "cases.received_date ASC"},
+    {"name" => :search_result_order_by_newest_first, "order" => "cases.received_date DESC"},
+  ]
+
+  DEFAULT_SEARCH_RESULT_ORDER_FLAG = "search_result_order_by_oldest_first"
+
+end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -2,7 +2,7 @@ module SearchHelper
 
   SEARCH_SCOPE_SET = {
     :search_result_order_by_oldest_first => { "order" => "cases.id ASC"},
-    :search_result_order_by_newest_first => {"order" => "cases.received_date DESC"},
+    :search_result_order_by_newest_first => {"order" => "cases.received_date DESC, cases.id DESC"},
     :search => {"order" => nil}
   }
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -3,6 +3,7 @@ module SearchHelper
   SEARCH_SCOPE_SET = [
     {"name" => :search_result_order_by_oldest_first, "order" => "cases.id ASC"},
     {"name" => :search_result_order_by_newest_first, "order" => "cases.received_date DESC"},
+    {"name" => :search, "order" => nil}
   ]
 
   DEFAULT_SEARCH_RESULT_ORDER_FLAG = "search_result_order_by_oldest_first"

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,11 +1,24 @@
 module SearchHelper
 
-  SEARCH_SCOPE_SET = [
-    {"name" => :search_result_order_by_oldest_first, "order" => "cases.id ASC"},
-    {"name" => :search_result_order_by_newest_first, "order" => "cases.received_date DESC"},
-    {"name" => :search, "order" => nil}
-  ]
+  SEARCH_SCOPE_SET = {
+    :search_result_order_by_oldest_first => { "order" => "cases.id ASC"},
+    :search_result_order_by_newest_first => {"order" => "cases.received_date DESC"},
+    :search => {"order" => nil}
+  }
 
   DEFAULT_SEARCH_RESULT_ORDER_FLAG = "search_result_order_by_oldest_first"
+
+  def self.get_order_option(search_order_choice)
+    if SEARCH_SCOPE_SET[search_order_choice.to_sym].present?
+      chosen_scope = search_order_choice
+    else
+      chosen_scope = DEFAULT_SEARCH_RESULT_ORDER_FLAG
+    end
+  end
+
+  def self.get_order_fields(search_order_choice)
+    chosen_scope = SEARCH_SCOPE_SET[search_order_choice.to_sym] || SEARCH_SCOPE_SET[DEFAULT_SEARCH_RESULT_ORDER_FLAG]
+    chosen_scope["order"]
+  end
 
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -14,6 +14,7 @@ module SearchHelper
     else
       chosen_scope = DEFAULT_SEARCH_RESULT_ORDER_FLAG
     end
+    chosen_scope
   end
 
   def self.get_order_fields(search_order_choice)

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,7 +1,7 @@
 module SearchHelper
 
   SEARCH_SCOPE_SET = [
-    {"name" => :search_result_order_by_oldest_first, "order" => "cases.received_date ASC"},
+    {"name" => :search_result_order_by_oldest_first, "order" => "cases.id ASC"},
     {"name" => :search_result_order_by_newest_first, "order" => "cases.received_date DESC"},
   ]
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -21,15 +21,6 @@ module Searchable
                             }
     end
 
-    pg_search_scope :search,
-                    against: searchable_fields_and_ranks,
-                    using: { tsearch: {
-                               any_word: false,
-                               dictionary: 'english',
-                               tsvector_column: searchable_document_tsvector,
-                               prefix: true,
-                             }
-                           }
   end
 
   class_methods do

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -8,10 +8,10 @@ module Searchable
 
     self.ignored_columns = self.ignored_columns + [searchable_document_tsvector]
 
-    SearchHelper::SEARCH_SCOPE_SET.each do | scope_item |
-      pg_search_scope scope_item["name"],
+    SearchHelper::SEARCH_SCOPE_SET.keys().each do | scope_key |
+      pg_search_scope scope_key,
                       against: searchable_fields_and_ranks,
-                      order_within_rank: scope_item["order"],
+                      order_within_rank: SearchHelper::SEARCH_SCOPE_SET[scope_key]["order"],
                       using: { tsearch: {
                                 any_word: false,
                                 dictionary: 'english',

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -1,10 +1,25 @@
 module Searchable
   extend ActiveSupport::Concern
 
+  include SearchHelper
+  
   included do
     include PgSearch::Model
 
     self.ignored_columns = self.ignored_columns + [searchable_document_tsvector]
+
+    SearchHelper::SEARCH_SCOPE_SET.each do | scope_item |
+      pg_search_scope scope_item["name"],
+                      against: searchable_fields_and_ranks,
+                      order_within_rank: scope_item["order"],
+                      using: { tsearch: {
+                                any_word: false,
+                                dictionary: 'english',
+                                tsvector_column: searchable_document_tsvector,
+                                prefix: true,
+                              }
+                            }
+    end
 
     pg_search_scope :search,
                     against: searchable_fields_and_ranks,

--- a/app/models/search_query.rb
+++ b/app/models/search_query.rb
@@ -167,7 +167,7 @@ class SearchQuery < ApplicationRecord
     if root.query_type == 'search'
 
       cases_list ||= Pundit.policy_scope(user, Case::Base.all)
-      cases_list = cases_list.__send__(get_search_scope(search_scope), search_text)
+      cases_list = cases_list.__send__(get_search_scope(search_scope.to_s), search_text)
     elsif cases_list.nil?
       raise ArgumentError.new("cannot perform filters without list of cases")
     end

--- a/app/models/search_query.rb
+++ b/app/models/search_query.rb
@@ -222,7 +222,6 @@ class SearchQuery < ApplicationRecord
   end
 
   def get_search_scope(search_scope)
-    search_scope_flag = nil
     available_search_names = []
     Searchable::SEARCH_SCOPE_SET.each do | item |
       available_search_names << item["name"]

--- a/app/services/case_search_service.rb
+++ b/app/services/case_search_service.rb
@@ -8,9 +8,8 @@ class CaseSearchService
               :query_params,
               :search_query
 
-  def initialize(user:, query_type:, query_params:, order: nil)
+  def initialize(user:, query_type:, query_params:)
     begin
-      @order = order
       @query_params = process_params(query_params)
       @current_user = user
       @query_type = query_type
@@ -25,9 +24,9 @@ class CaseSearchService
     end
   end
 
-  def call(full_list_of_cases = nil)
+  def call(full_list_of_cases = nil, order: nil)
     if @error == false && @query.valid?
-      @result_set = @query.results(full_list_of_cases, @order)
+      @result_set = @query.results(full_list_of_cases, order)
       @query.update num_results: @result_set.size
     else
       @result_set = Case::Base.none

--- a/app/services/case_search_service.rb
+++ b/app/services/case_search_service.rb
@@ -27,7 +27,7 @@ class CaseSearchService
 
   def call(full_list_of_cases = nil)
     if @error == false && @query.valid?
-      @result_set = @query.results(full_list_of_cases, search_scope=@order)
+      @result_set = @query.results(full_list_of_cases, @order)
       @query.update num_results: @result_set.size
     else
       @result_set = Case::Base.none

--- a/app/services/case_search_service.rb
+++ b/app/services/case_search_service.rb
@@ -8,7 +8,7 @@ class CaseSearchService
               :query_params,
               :search_query
 
-  def initialize(user:, query_type:, query_params:, order:)
+  def initialize(user:, query_type:, query_params:, order: nil)
     begin
       @order = order
       @query_params = process_params(query_params)

--- a/app/services/case_search_service.rb
+++ b/app/services/case_search_service.rb
@@ -8,8 +8,9 @@ class CaseSearchService
               :query_params,
               :search_query
 
-  def initialize(user:, query_type:, query_params:)
+  def initialize(user:, query_type:, query_params:, order:)
     begin
+      @order = order
       @query_params = process_params(query_params)
       @current_user = user
       @query_type = query_type
@@ -26,7 +27,7 @@ class CaseSearchService
 
   def call(full_list_of_cases = nil)
     if @error == false && @query.valid?
-      @result_set = @query.results(full_list_of_cases)
+      @result_set = @query.results(full_list_of_cases, search_scope=@order)
       @query.update num_results: @result_set.size
     else
       @result_set = Case::Base.none

--- a/app/views/cases/filters/index.html.slim
+++ b/app/views/cases/filters/index.html.slim
@@ -24,6 +24,9 @@ section.govuk-tabs__panel
                          clear_params: {} }
 
   - if @global_nav_manager.current_page.tabs.present?
+    
+    = get_cases_order_option_url(request.fullpath, cookies[:search_result_order])
+
     .grid-row
       .column-full
         nav.section-tabs

--- a/app/views/cases/shared/_case_list.html.slim
+++ b/app/views/cases/shared/_case_list.html.slim
@@ -13,19 +13,20 @@
         col
       caption
         .grid-row
-          .search-results-summary.column-half
+          .search-results-summary.column-one-third
             strong
               = @cases.total_count
             = " #{ 'case'.pluralize(@cases.total_count)} found" 
 
-          - if @query[:search_text].present?
-            - if cookies[:search_result_order] == 'search_result_order_by_newest_first'
-              = link_to t('common.show_search_result_order_by_oldest_first'), "#{request.fullpath}&order=search_result_order_by_oldest_first"
-            - else
-              = link_to t('common.show_search_result_order_by_newest_first'), "#{request.fullpath}&order=search_result_order_by_newest_first"
+          .search-results-summary.column-one-third
+            - if @query[:search_text].present?
+              - if cookies[:search_result_order] == 'search_result_order_by_newest_first'
+                = link_to t('common.show_search_result_order_by_oldest_first'), "#{request.fullpath}&order=search_result_order_by_oldest_first"
+              - else
+                = link_to t('common.show_search_result_order_by_newest_first'), "#{request.fullpath}&order=search_result_order_by_newest_first"
 
           - (@available_reports || []).each do |report_type|
-            .download-cases-link
+            .download-cases-link.column-one-third
               = download_csv_link(request.fullpath, report_type.abbr)
               | &nbsp;(.csv file)
 

--- a/app/views/cases/shared/_case_list.html.slim
+++ b/app/views/cases/shared/_case_list.html.slim
@@ -19,11 +19,7 @@
             = " #{ 'case'.pluralize(@cases.total_count)} found" 
 
           .search-results-order.column-one-third
-            - if @query[:search_text].present?
-              - if cookies[:search_result_order] == 'search_result_order_by_newest_first'
-                = link_to t('common.show_search_result_order_by_oldest_first'), "#{request.fullpath}&order=search_result_order_by_oldest_first"
-              - else
-                = link_to t('common.show_search_result_order_by_newest_first'), "#{request.fullpath}&order=search_result_order_by_newest_first"
+            = get_cases_order_option_url(request.fullpath, cookies[:search_result_order])
 
           - (@available_reports || []).each do |report_type|
             .download-cases-link.column-one-third

--- a/app/views/cases/shared/_case_list.html.slim
+++ b/app/views/cases/shared/_case_list.html.slim
@@ -16,7 +16,14 @@
           .search-results-summary.column-half
             strong
               = @cases.total_count
-            = " #{ 'case'.pluralize(@cases.total_count)} found"
+            = " #{ 'case'.pluralize(@cases.total_count)} found" 
+
+          - if @query[:search_text].present?
+            - if cookies[:search_result_order] == 'search_result_order_by_newest_first'
+              = link_to t('common.show_search_result_order_by_oldest_first'), "#{request.fullpath}&order=search_result_order_by_oldest_first"
+            - else
+              = link_to t('common.show_search_result_order_by_newest_first'), "#{request.fullpath}&order=search_result_order_by_newest_first"
+
           - (@available_reports || []).each do |report_type|
             .download-cases-link
               = download_csv_link(request.fullpath, report_type.abbr)

--- a/app/views/cases/shared/_case_list.html.slim
+++ b/app/views/cases/shared/_case_list.html.slim
@@ -18,7 +18,7 @@
               = @cases.total_count
             = " #{ 'case'.pluralize(@cases.total_count)} found" 
 
-          .search-results-summary.column-one-third
+          .search-results-order.column-one-third
             - if @query[:search_text].present?
               - if cookies[:search_result_order] == 'search_result_order_by_newest_first'
                 = link_to t('common.show_search_result_order_by_oldest_first'), "#{request.fullpath}&order=search_result_order_by_oldest_first"

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -127,6 +127,8 @@ ignore_unused:
   - stats.show.waiting
   - stats.create*
   - stats.download_custom*
+  - common.show_search_result_order_by_newest_first
+  - common.show_search_result_order_by_oldest_first
 
 
 ## Consider these keys used:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -885,8 +885,8 @@ en:
     links:
       change: Change
     new_case_button: Create case
-    show_search_result_order_by_newest_first: show newest cases first
-    show_search_result_order_by_oldest_first: show oldest cases first
+    show_search_result_order_by_newest_first: Show newest cases first
+    show_search_result_order_by_oldest_first: Show oldest cases first
     phase_banner: |
       This is a new service.
     service_name: Track a query

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -885,6 +885,8 @@ en:
     links:
       change: Change
     new_case_button: Create case
+    show_search_result_order_by_newest_first: show newest cases first
+    show_search_result_order_by_oldest_first: show oldest cases first
     phase_banner: |
       This is a new service.
     service_name: Track a query

--- a/spec/controllers/cases/filters_controller/open_spec.rb
+++ b/spec/controllers/cases/filters_controller/open_spec.rb
@@ -86,7 +86,7 @@ describe Cases::FiltersController, type: :controller do
 
       it 'calls CaseSearchService with results of GlobalNavManager' do
         get :open
-        expect(case_search_service).to have_received(:call).with(open_cases)
+        expect(case_search_service).to have_received(:call).with(open_cases, order: nil)
       end
 
       it 'assigns the result set from the CaseFinderService' do

--- a/spec/features/cases/foi/case_search_spec.rb
+++ b/spec/features/cases/foi/case_search_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 feature 'Searching for cases' do
-  given(:approver)  { find_or_create :disclosure_specialist }
-  given(:manager)   { find_or_create :disclosure_bmt_user }
-  given(:responder) { kase.responder }
-  given!(:kase)     { create :case_being_drafted, name: 'testing' }
-  given!(:kase_earlier)     { create :case_being_drafted, name: 'testing', received_date: 3.days.ago}
+  given(:approver)        { find_or_create :disclosure_specialist }
+  given(:manager)         { find_or_create :disclosure_bmt_user }
+  given(:responder)       { kase.responder }
+  given!(:kase_earlier)   { create :case_being_drafted, name: 'testing', received_date: 1.month.ago}
+  given!(:kase)           { create :case_being_drafted, name: 'testing' }
 
   scenario 'searching by case number' do
     login_as manager
@@ -65,15 +65,15 @@ feature 'Searching for cases' do
     expect(cases_search_page).not_to have_notices
     expect(cases_search_page.search_results_count.text).to eq "2 cases found"
     expect(cases_search_page.case_list.count).to eq 2
-    expect(cases_search_page.case_list.first.number).to have_text kase.number
-    expect(cases_search_page.case_list.second.number).to have_text kase_earlier.number
+    expect(cases_search_page.case_list.first.number).to have_text kase_earlier.number
+    expect(cases_search_page.case_list.second.number).to have_text kase.number
 
     click_on "Show newest cases first"
 
     expect(cases_search_page.search_results_count.text).to eq "2 cases found"
     expect(cases_search_page.case_list.count).to eq 2
-    expect(cases_search_page.case_list.first.number).to have_text kase_earlier.number
-    expect(cases_search_page.case_list.second.number).to have_text kase.number
+    expect(cases_search_page.case_list.first.number).to have_text kase.number
+    expect(cases_search_page.case_list.second.number).to have_text kase_earlier.number
   end
 
 end

--- a/spec/features/cases/foi/case_search_spec.rb
+++ b/spec/features/cases/foi/case_search_spec.rb
@@ -4,7 +4,8 @@ feature 'Searching for cases' do
   given(:approver)  { find_or_create :disclosure_specialist }
   given(:manager)   { find_or_create :disclosure_bmt_user }
   given(:responder) { kase.responder }
-  given!(:kase)     { create :case_being_drafted }
+  given!(:kase)     { create :case_being_drafted, name: 'testing' }
+  given!(:kase_earlier)     { create :case_being_drafted, name: 'testing', received_date: 3.days.ago}
 
   scenario 'searching by case number' do
     login_as manager
@@ -51,4 +52,28 @@ feature 'Searching for cases' do
     expect(cases_search_page.search_results_count.text).to eq "1 case found"
     expect(cases_search_page.case_list.first.number).to have_text kase.number
   end
+
+  scenario 'searching by case name with choice of ordering the search result' do
+    login_as manager
+
+    cases_page.load
+    kase.update_index
+    kase_earlier.update_index
+    cases_search_page.search_query.set "testing"
+    cases_search_page.search_button.click
+    expect(cases_search_page).to be_displayed
+    expect(cases_search_page).not_to have_notices
+    expect(cases_search_page.search_results_count.text).to eq "2 cases found"
+    expect(cases_search_page.case_list.count).to eq 2
+    expect(cases_search_page.case_list.first.number).to have_text kase.number
+    expect(cases_search_page.case_list.second.number).to have_text kase_earlier.number
+
+    click_on "Show newest cases first"
+
+    expect(cases_search_page.search_results_count.text).to eq "2 cases found"
+    expect(cases_search_page.case_list.count).to eq 2
+    expect(cases_search_page.case_list.first.number).to have_text kase_earlier.number
+    expect(cases_search_page.case_list.second.number).to have_text kase.number
+  end
+
 end

--- a/spec/features/cases/foi/case_viewing_spec.rb
+++ b/spec/features/cases/foi/case_viewing_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+feature 'Viewing for cases' do
+  given(:manager)         { find_or_create :disclosure_bmt_user }
+  given!(:kase_earlier)   { create :case_being_drafted, name: 'testing', received_date: 20.days.ago}
+  given!(:kase)           { create :case_being_drafted, name: 'testing' }
+  given(:responder)       { kase.responder }
+
+  scenario 'View open-cases tab - choice of ordering the result' do
+    login_as manager
+
+    cases_page.load
+    cases_page.primary_navigation.all_open_cases.click
+    expect(cases_page.case_list.count).to eq 2
+    expect(cases_page.case_list.first.number).to have_text kase_earlier.number
+    expect(cases_page.case_list.second.number).to have_text kase.number
+
+    click_on "Show newest cases first"
+
+    expect(cases_page.case_list.count).to eq 2
+    expect(cases_page.case_list.first.number).to have_text kase.number
+    expect(cases_page.case_list.second.number).to have_text kase_earlier.number
+  end
+
+  scenario 'View my-open-cases tab - choice of ordering the result' do
+    login_as responder
+
+    cases_page.load
+    cases_page.primary_navigation.my_open_in_time.click
+    expect(cases_page.case_list.count).to eq 2
+    expect(cases_page.case_list.first.number).to have_text kase_earlier.number
+    expect(cases_page.case_list.second.number).to have_text kase.number
+
+    click_on "Show newest cases first"
+
+    expect(cases_page.case_list.count).to eq 2
+    expect(cases_page.case_list.first.number).to have_text kase.number
+    expect(cases_page.case_list.second.number).to have_text kase_earlier.number
+  end
+
+end

--- a/spec/features/cases/offender_sar/case_search_spec.rb
+++ b/spec/features/cases/offender_sar/case_search_spec.rb
@@ -6,7 +6,7 @@ feature 'Searching for cases' do
 
   given!(:kase) { create :case_being_drafted, subject: "Common text" }
   given!(:offender_sar_case) { create :offender_sar_case, subject_full_name: "Common text" }
-  given!(:offender_sar_case_bill) { create :offender_sar_case, subject_full_name: "Bill", date_of_birth: Date.new(1970, 8, 21) }
+  given!(:offender_sar_case_bill) { create :offender_sar_case, subject_full_name: "Bill", date_of_birth: Date.new(1970, 8, 21), received_date: 3.days.ago}
   given!(:offender_sar_case_bill_1980) { create :offender_sar_case, subject_full_name: "Bill", date_of_birth: Date.new(1980, 8, 21) }
   given!(:offender_sar_case_ted) { create :offender_sar_case, subject_full_name: "Terrence", date_of_birth: Date.new(1970, 8, 21) }
 
@@ -66,12 +66,25 @@ feature 'Searching for cases' do
     let(:searcher) { responder }
     let(:search_term) { "Bill" }
 
-    scenario 'finds two cases' do
+    scenario 'finds two cases with default order: oldest cases first' do
       expect(cases_search_page.search_results_count.text).to eq "2 cases found"
       expect(cases_search_page.case_list.count).to eq 2
       expect(cases_search_page.case_list.first.number).to have_text offender_sar_case_bill.number
       expect(cases_search_page.case_list.last.number).to have_text offender_sar_case_bill_1980.number
     end
+
+    scenario 'finds two cases with newest cases first' do
+      expect(cases_search_page.search_results_count.text).to eq "2 cases found"
+      expect(cases_search_page.case_list.count).to eq 2
+      expect(cases_search_page.case_list.first.number).to have_text offender_sar_case_bill.number
+      expect(cases_search_page.case_list.last.number).to have_text offender_sar_case_bill_1980.number
+
+      click_on "Show newest cases first"
+      expect(cases_search_page.case_list.count).to eq 2
+      expect(cases_search_page.case_list.first.number).to have_text offender_sar_case_bill_1980.number
+      expect(cases_search_page.case_list.last.number).to have_text offender_sar_case_bill.number
+    end
+
   end
 
   context 'searching multiple terms narrows the search' do

--- a/spec/features/cases/offender_sar/case_viewing_spec.rb
+++ b/spec/features/cases/offender_sar/case_viewing_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+feature 'Viewing for cases' do
+
+  given!(:responder)    { find_or_create :branston_user}
+  given!(:kase_earlier) { create :offender_sar_case, received_date: 3.days.ago}
+  given!(:kase)         { create :offender_sar_case }
+
+  scenario 'View open-cases tab - choice of ordering the result' do
+    login_as responder
+
+    cases_page.load
+    cases_page.primary_navigation.all_open_cases.click
+    expect(cases_page.case_list.count).to eq 2
+    expect(cases_page.case_list.first.number).to have_text kase_earlier.number
+    expect(cases_page.case_list.second.number).to have_text kase.number
+
+    click_on "Show newest cases first"
+
+    expect(cases_page.case_list.count).to eq 2
+    expect(cases_page.case_list.first.number).to have_text kase.number
+    expect(cases_page.case_list.second.number).to have_text kase_earlier.number
+  end
+
+end

--- a/spec/models/search_query_spec.rb
+++ b/spec/models/search_query_spec.rb
@@ -328,6 +328,26 @@ describe SearchQuery do
                                             @setup.std_draft_irt]
       end
 
+      it 'returns the result of searching for search_text with newest case first' do
+        search_query = create :search_query,
+                              user_id: user.id,
+                              search_text: 'std_draft_foi'
+        expect(search_query.results(nil, 'search_result_order_by_newest_first'))
+          .to eq [@setup.std_draft_foi,
+                  @setup.std_draft_foi_late,
+                  @setup.std_draft_irt]
+      end
+
+      it 'returns the result of searching for search_text with oldest case first' do
+        search_query = create :search_query,
+                              user_id: user.id,
+                              search_text: 'std_draft'
+        expect(search_query.results(nil, 'search_result_order_by_oldest_first'))
+          .to eq [@setup.std_draft_foi,
+                  @setup.std_draft_irt,
+                  @setup.std_draft_foi_late]
+      end
+
       it 'returns the result of filtering for sensitivity' do
         search_query = create :search_query,
                               user_id: user.id,

--- a/spec/site_prism/page_objects/pages/cases/search_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/search_page.rb
@@ -10,6 +10,7 @@ module PageObjects
           element :heading, '.notice-summary-heading'
         end
 
+        
         element :search_query, 'input[type="search"]'
         element :search_button, 'input.button#search-button'
 

--- a/spec/site_prism/page_objects/pages/cases/search_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/search_page.rb
@@ -10,7 +10,6 @@ module PageObjects
           element :heading, '.notice-summary-heading'
         end
 
-        
         element :search_query, 'input[type="search"]'
         element :search_button, 'input.button#search-button'
 

--- a/spec/site_prism/page_objects/sections/primary_navigation_section.rb
+++ b/spec/site_prism/page_objects/sections/primary_navigation_section.rb
@@ -7,6 +7,7 @@ module PageObjects
       element :search, 'a[href="/cases/search"]'
       element :settings, 'a[href="/teams"]'
       element :stats, 'a[href="/stats"]'
+      element :my_open_in_time, 'a[href="/cases/my_open/in_time"]'
     end
   end
 end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to add option for user to sorting search result,  
 - This feature is available for London and Branson team
 - The default order is the existing implementation:  oldest cases first
 - User can click 'Show newest cases first' to change the order of search result
 - The option is stored in cookies, so user can have the same order choices for future searches unless he/she changes it again 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->
1 - default order: oldest cases first
<img width="726" alt="Screenshot 2021-09-06 at 16 56 50" src="https://user-images.githubusercontent.com/26111671/132241934-58990274-5d14-45a7-b835-32b0b76c0c60.png">

2 - change to newest cases first
<img width="809" alt="Screenshot 2021-09-06 at 16 56 41" src="https://user-images.githubusercontent.com/26111671/132241941-6e7c6edb-10a1-4206-949c-21d880dd586d.png">

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3742
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
