### PR TITLE
CT-3805 bug: deactivating user who has some live cases and some responded cases (London team)

### DIFF
--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -826,6 +826,10 @@ class Case::Base < ApplicationRecord
     flagged? ? 'trigger': 'non_trigger'
   end
 
+  def has_responded?
+    self.current_state == 'closed' || self.current_state ==  'responded'
+  end
+
   # predicate methods
   #
   def foi?;                    false;  end

--- a/app/services/user_deletion_service.rb
+++ b/app/services/user_deletion_service.rb
@@ -41,9 +41,11 @@ class UserDeletionService
 
   def unassign_cases
     @target_user.cases.opened.each do |kase|
-      kase.responder_assignment.update!(state: 'pending', team_id: @team.id, user_id: nil)
-      kase.state_machine.unassign_from_user!(acting_user: @acting_user, acting_team: kase.managing_team)
-      NotifyNewAssignmentService.new(team: @team, assignment: kase.responder_assignment).run
+      if !kase.has_responded?
+        kase.responder_assignment.update!(state: 'pending', team_id: @team.id, user_id: nil)
+        kase.state_machine.unassign_from_user!(acting_user: @acting_user, acting_team: kase.managing_team)
+        NotifyNewAssignmentService.new(team: @team, assignment: kase.responder_assignment).run
+      end
     end
   end
 end

--- a/spec/features/admin/deactivating_users_spec.rb
+++ b/spec/features/admin/deactivating_users_spec.rb
@@ -1,12 +1,16 @@
 require 'rails_helper'
 
 feature 'deactivating users' do
-  given!(:team_admin)        { find_or_create :team_admin }
-  given!(:manager)        { find_or_create :disclosure_bmt_user }
-  given!(:responder)      { create :responder, responding_teams: [bu] }
-  given!(:user_with_cases){ find_or_create :foi_responder }
-  given!(:live_case)      { create :accepted_case }
-  given!(:bu)             { find_or_create :foi_responding_team }
+  given!(:team_admin)       { find_or_create :team_admin }
+  given!(:manager)          { find_or_create :disclosure_bmt_user }
+  given!(:responder)        { create :responder, responding_teams: [bu] }
+  given!(:user_with_cases)  { find_or_create :foi_responder }
+  given!(:live_case)        { create :accepted_case }
+  given!(:responded_case)   { create :responded_case,
+                                responder: user_with_cases,
+                                responding_team: bu,
+                                received_date: 5.days.ago }
+  given!(:bu)               { find_or_create :foi_responding_team }
 
   before do
     bu.team_admins << team_admin
@@ -34,6 +38,9 @@ feature 'deactivating users' do
 
   scenario 'manager deactivates responder with live cases' do
     login_as manager
+    
+    check_key_fields_before_deactivate_user_for_open_case
+    check_key_fields_for_responded_case
 
     teams_show_page.load(id: bu.id)
     information_officer = teams_show_page.row_for_information_officer(user_with_cases.email)
@@ -46,6 +53,9 @@ feature 'deactivating users' do
     expect(teams_show_page).to be_displayed
     expect(teams_show_page.flash_notice.text).to eq "Team member has been deactivated"
     expect(information_officer).not_to eq user_with_cases
+
+    check_key_fields_after_deactivate_user_for_open_case
+    check_key_fields_for_responded_case
 
     # A deactivated user cannot sign in
     cases_page.user_card.signout.click
@@ -76,6 +86,9 @@ feature 'deactivating users' do
   scenario 'user manaing team members deactivates responder with live cases' do
     login_as team_admin
 
+    check_key_fields_before_deactivate_user_for_open_case
+    check_key_fields_for_responded_case
+
     teams_show_page.load(id: bu.id)
     information_officer = teams_show_page.row_for_information_officer(user_with_cases.email)
     information_officer.actions.click
@@ -88,9 +101,38 @@ feature 'deactivating users' do
     expect(teams_show_page.flash_notice.text).to eq "Team member has been deactivated"
     expect(information_officer).not_to eq user_with_cases
 
+    check_key_fields_after_deactivate_user_for_open_case
+    check_key_fields_for_responded_case
+
     # A deactivated user cannot sign in
     cases_page.user_card.signout.click
     login_page.log_in(user_with_cases.email, user_with_cases.password)
     expect(login_page.error_message).to have_content 'Invalid email or password.'
   end
+
+  private 
+
+  def check_key_fields_before_deactivate_user_for_open_case
+    expect(live_case.responder_assignment.state).to eq "accepted"
+    expect(live_case.responder).to eq user_with_cases
+    expect(live_case.current_state).to eq "drafting"
+    expect(live_case.responding_team).to eq bu
+  end
+
+  def check_key_fields_after_deactivate_user_for_open_case
+    live_case.reload
+    expect(live_case.responder_assignment.state).to eq "pending"
+    expect(live_case.responding_team).to eq bu
+    expect(live_case.responder).to eq nil
+    expect(live_case.current_state).to eq 'awaiting_responder'
+end
+
+  def check_key_fields_for_responded_case
+    responded_case.reload
+    expect(responded_case.responder_assignment.state).to eq "accepted"
+    expect(responded_case.responder).to eq user_with_cases
+    expect(responded_case.current_state).to eq "responded"
+    expect(responded_case.responder_assignment.state).to eq "accepted"
+  end
+
 end

--- a/spec/features/admin/deactivating_users_spec.rb
+++ b/spec/features/admin/deactivating_users_spec.rb
@@ -125,7 +125,7 @@ feature 'deactivating users' do
     expect(live_case.responding_team).to eq bu
     expect(live_case.responder).to eq nil
     expect(live_case.current_state).to eq 'awaiting_responder'
-end
+  end
 
   def check_key_fields_for_responded_case
     responded_case.reload

--- a/spec/features/admin/deactivating_users_spec.rb
+++ b/spec/features/admin/deactivating_users_spec.rb
@@ -3,23 +3,23 @@ require 'rails_helper'
 feature 'deactivating users' do
   given!(:team_admin)       { find_or_create :team_admin }
   given!(:manager)          { find_or_create :disclosure_bmt_user }
-  given!(:responder)        { create :responder, responding_teams: [bu] }
+  given!(:business_unit)    { find_or_create :foi_responding_team }
+  given!(:responder)        { create :responder, responding_teams: [business_unit] }
   given!(:user_with_cases)  { find_or_create :foi_responder }
   given!(:live_case)        { create :accepted_case }
   given!(:responded_case)   { create :responded_case,
                                 responder: user_with_cases,
-                                responding_team: bu,
+                                responding_team: business_unit,
                                 received_date: 5.days.ago }
-  given!(:bu)               { find_or_create :foi_responding_team }
 
   before do
-    bu.team_admins << team_admin
+    business_unit.team_admins << team_admin
   end
 
   scenario 'manager deactivates a responder with no live cases' do
     login_as manager
 
-    teams_show_page.load(id: bu.id)
+    teams_show_page.load(id: business_unit.id)
     information_officer = teams_show_page.row_for_information_officer(responder.email)
     information_officer.actions.click
 
@@ -42,7 +42,7 @@ feature 'deactivating users' do
     check_key_fields_before_deactivate_user_for_open_case
     check_key_fields_for_responded_case
 
-    teams_show_page.load(id: bu.id)
+    teams_show_page.load(id: business_unit.id)
     information_officer = teams_show_page.row_for_information_officer(user_with_cases.email)
     information_officer.actions.click
 
@@ -66,7 +66,7 @@ feature 'deactivating users' do
   scenario 'user manaing team members deactivates a responder with no live cases' do
     login_as team_admin
 
-    teams_show_page.load(id: bu.id)
+    teams_show_page.load(id: business_unit.id)
     information_officer = teams_show_page.row_for_information_officer(responder.email)
     information_officer.actions.click
 
@@ -89,7 +89,7 @@ feature 'deactivating users' do
     check_key_fields_before_deactivate_user_for_open_case
     check_key_fields_for_responded_case
 
-    teams_show_page.load(id: bu.id)
+    teams_show_page.load(id: business_unit.id)
     information_officer = teams_show_page.row_for_information_officer(user_with_cases.email)
     information_officer.actions.click
 
@@ -116,13 +116,13 @@ feature 'deactivating users' do
     expect(live_case.responder_assignment.state).to eq "accepted"
     expect(live_case.responder).to eq user_with_cases
     expect(live_case.current_state).to eq "drafting"
-    expect(live_case.responding_team).to eq bu
+    expect(live_case.responding_team).to eq business_unit
   end
 
   def check_key_fields_after_deactivate_user_for_open_case
     live_case.reload
     expect(live_case.responder_assignment.state).to eq "pending"
-    expect(live_case.responding_team).to eq bu
+    expect(live_case.responding_team).to eq business_unit
     expect(live_case.responder).to eq nil
     expect(live_case.current_state).to eq 'awaiting_responder'
   end

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe Case::Base, type: :model do
   
   let(:trigger_foi)        { create :case,
                               :flagged,
-                              received_date: Date.today - 6.months # Valid if within 1 year of today
-                            }
+                              # Valid if within 1 year of today
+                              received_date: Date.today - 6.months }
 
   let(:ot_ico_foi_draft)   { create :ot_ico_foi_noff_draft }
   let(:ot_ico_sar_draft)   { create :ot_ico_sar_noff_draft }
@@ -1653,7 +1653,6 @@ RSpec.describe Case::Base, type: :model do
     end
 
     it 'is true for a responded case' do
-      kase = create :closed_case
       expect(responded_case.has_responded?).to eq true
     end
 

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -56,15 +56,21 @@ RSpec.describe Case::Base, type: :model do
                                             approving_team: approving_team }
   let(:case_being_drafted_trigger) { create :case_being_drafted, :flagged_accepted }
 
-  let(:trigger_foi) {
-    create :case,
-    :flagged,
-    received_date: Date.today - 6.months # Valid if within 1 year of today
-  }
+  let(:responded_case)     { create :responded_case,
+                              responder: responder,
+                              responding_team: responding_team,
+                              received_date: 5.days.ago }
+  
+  let(:trigger_foi)        { create :case,
+                              :flagged,
+                              received_date: Date.today - 6.months # Valid if within 1 year of today
+                            }
 
   let(:ot_ico_foi_draft)   { create :ot_ico_foi_noff_draft }
   let(:ot_ico_sar_draft)   { create :ot_ico_sar_noff_draft }
-  let(:kase) { create :case }
+  let(:kase)               { create :case }
+  let(:closed_case)        { create :closed_case }
+
 
   describe 'has a factory' do
     it 'that produces a valid object by default' do
@@ -1640,4 +1646,22 @@ RSpec.describe Case::Base, type: :model do
       expect(trigger_foi.trigger?).to eq true
     end
   end
+
+  describe '#has_responded?' do
+    it 'is true for a closed case' do
+      expect(closed_case.has_responded?).to eq true
+    end
+
+    it 'is true for a responded case' do
+      kase = create :closed_case
+      expect(responded_case.has_responded?).to eq true
+    end
+
+    it 'is false for a case which has not been responded' do
+      expect(assigned_case.has_responded?).to eq false
+      expect(case_being_drafted.has_responded?).to eq false
+      expect(accepted_case.has_responded?).to eq false
+    end
+  end
+
 end

--- a/spec/services/user_deletion_service_spec.rb
+++ b/spec/services/user_deletion_service_spec.rb
@@ -88,28 +88,14 @@ describe UserDeletionService do
                                   responder: responder,
                                   responding_team: team,
                                   received_date: 5.days.ago
-          expect(kase.responder_assignment.state).to eq "accepted"
-          expect(kase.responder).to eq responder
-          expect(kase.current_state).to eq "drafting"
-          expect(kase.responding_team).to eq team
-
-          expect(responded_case.responder_assignment.state).to eq "accepted"
-          expect(responded_case.responder).to eq responder
-          expect(responded_case.current_state).to eq "responded"
-          expect(responded_case.responding_team).to eq team
+          
+          check_key_fields_for_not_responded_case_before_deactivating_responder(kase)
+          check_key_fields_for_responded_case_before_deactivating_responder(responded_case)
 
           service.call
-          kase.reload
-          responded_case.reload
-          expect(kase.responder_assignment.state).to eq "pending"
-          expect(kase.responding_team).to eq team
-          expect(kase.responder).to eq nil
-          expect(kase.current_state).to eq 'awaiting_responder'
 
-          expect(responded_case.responder_assignment.state).to eq "accepted"
-          expect(responded_case.responder).to eq responder
-          expect(responded_case.responding_team).to eq team
-          expect(responded_case.current_state).to eq 'responded'
+          check_key_fields_for_not_responded_case_after_deactivating_responder(kase)
+          check_key_fields_for_responded_case_after_deactivating_responder(responded_case)
         end
 
         it 'sends the team an email' do
@@ -149,6 +135,38 @@ describe UserDeletionService do
         service.call
         expect(responder.reload.team_roles.size).to eq 0
       end
+    end
+
+    private
+
+    def check_key_fields_for_not_responded_case_before_deactivating_responder(kase)
+      expect(kase.responder_assignment.state).to eq "accepted"
+      expect(kase.responder).to eq responder
+      expect(kase.current_state).to eq "drafting"
+      expect(kase.responding_team).to eq team
+    end
+
+    def check_key_fields_for_responded_case_before_deactivating_responder(responded_case)
+      expect(responded_case.responder_assignment.state).to eq "accepted"
+      expect(responded_case.responder).to eq responder
+      expect(responded_case.current_state).to eq "responded"
+      expect(responded_case.responding_team).to eq team
+    end
+
+    def check_key_fields_for_not_responded_case_after_deactivating_responder(kase)
+      kase.reload
+      expect(kase.responder_assignment.state).to eq "pending"
+      expect(kase.responding_team).to eq team
+      expect(kase.responder).to eq nil
+      expect(kase.current_state).to eq 'awaiting_responder'
+    end
+
+    def check_key_fields_for_responded_case_after_deactivating_responder(responded_case)
+      responded_case.reload
+      expect(responded_case.responder_assignment.state).to eq "accepted"
+      expect(responded_case.responder).to eq responder
+      expect(responded_case.responding_team).to eq team
+      expect(responded_case.current_state).to eq 'responded'
     end
   end
 end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to fix the bug when a user having some live cases and some responded cases linked with is deactivated.  The bug was the inconsistency for handing the responded cases.  When user is identified as having live cases linked with by using `has_live_cases_for_team?(@team)` ( the logic for this check is checking whether there is any case whose state is not responded ),  then all those cases linking to this users will be unassigned and be reset back to the "awaiting_responder" state,  even the case is responded which conflict with the checking rule. 

The fix is to filter out those responded cases from the `unassign_from_user` process. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&projectKey=CT&modal=detail&selectedIssue=CT-3805
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
