### PR TITLE
Ct 3175 data reference table related

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -44,7 +44,7 @@ class ContactsController < ApplicationController
 
   private
     def set_contact
-      @contact = Contact.find(params[:id])
+      @contact = Contact.includes(:contact_type).find(params[:id])
     end
 
     def set_new_contact_from_params

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -56,8 +56,8 @@ class ContactsController < ApplicationController
     end
 
     def set_contact_type
-      if contact_type_params[:contact_type]
-        @contact_type = CategoryReference.find(contact_type_params[:contact_type])
+      if contact_type_params[:contact_type_id]
+        @contact_type = CategoryReference.find(contact_type_params[:contact_type_id])
         @contact.contact_type = @contact_type
       else
         @contact.contact_type = nil
@@ -78,7 +78,7 @@ class ContactsController < ApplicationController
 
     def contact_type_params
       params.require(:contact).permit(
-        :contact_type
+        :contact_type_id
       )
     end
 end

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,5 +1,8 @@
 class ContactsController < ApplicationController
   before_action :set_contact, only: %i[ edit update destroy ]
+  before_action :set_contact_type_options, only: %i[ create edit new update ]
+  before_action :set_new_contact_from_params, only: :create 
+  before_action :set_contact_type, only: %i[ update create ]
 
   def index
     @contacts = Contact.all
@@ -13,8 +16,6 @@ class ContactsController < ApplicationController
   end
 
   def create
-    @contact = Contact.new(contact_params)
-
     respond_to do |format|
       if @contact.save
         format.html { redirect_to contacts_url, notice: "Contact was successfully created." }
@@ -46,6 +47,23 @@ class ContactsController < ApplicationController
       @contact = Contact.find(params[:id])
     end
 
+    def set_new_contact_from_params
+      @contact = Contact.new(contact_params)
+    end
+
+    def set_contact_type_options
+      @contact_types = CategoryReference.list_by_category(:contact_type)
+    end
+
+    def set_contact_type
+      if contact_type_params[:contact_type]
+        @contact_type = CategoryReference.find(contact_type_params[:contact_type])
+        @contact.contact_type = @contact_type
+      else
+        @contact.contact_type = nil
+      end
+    end
+
     def contact_params
       params.require(:contact).permit(
         :name, 
@@ -54,7 +72,12 @@ class ContactsController < ApplicationController
         :town,
         :county,
         :postcode,
-        :email,
+        :email
+      )
+    end
+
+    def contact_type_params
+      params.require(:contact).permit(
         :contact_type
       )
     end

--- a/app/models/category_reference.rb
+++ b/app/models/category_reference.rb
@@ -1,0 +1,3 @@
+class CategoryReference < ApplicationRecord
+  has_one :contact, foreign_key: :contact_type
+end

--- a/app/models/category_reference.rb
+++ b/app/models/category_reference.rb
@@ -1,3 +1,8 @@
 class CategoryReference < ApplicationRecord
-  has_one :contact, foreign_key: :contact_type
+  has_many :contacts, foreign_key: :contact_type, inverse_of: :contact_type
+
+  def self.list_by_category(category)
+    self.where(category: category).order(:display_order)
+  end
+
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,10 +1,11 @@
 class Contact < ApplicationRecord
-  enum contact_type: %i(prison probation solicitor other)
+  belongs_to :contact_type, class_name: 'CategoryReference'
 
   validates :name, presence: true
   validates :address_line_1, presence: true
   validates :postcode, presence: true
   validates :contact_type, presence: true
+
 
   def address
     format_address("\n")

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,10 +1,11 @@
 class Contact < ApplicationRecord
-  belongs_to :contact_type, class_name: 'CategoryReference'
 
   validates :name, presence: true
   validates :address_line_1, presence: true
   validates :postcode, presence: true
   validates :contact_type, presence: true
+
+  belongs_to :contact_type, class_name: 'CategoryReference', inverse_of: :contacts 
 
 
   def address

--- a/app/views/contacts/_form.html.slim
+++ b/app/views/contacts/_form.html.slim
@@ -6,7 +6,10 @@
     = f.text_field :town
     = f.text_field :county
     = f.text_field :postcode
-    = f.radio_button_fieldset :contact_type, choices: Contact::contact_types.keys
+    = f.radio_button_fieldset :contact_type, 
+      choices: @contact_types, 
+      value_method: :id, 
+      text_method: :value
 
     .button-holder
       = f.submit 'Submit', class: 'button'

--- a/app/views/contacts/_form.html.slim
+++ b/app/views/contacts/_form.html.slim
@@ -1,12 +1,12 @@
 = form_for @contact do |f|
 
-    = f.text_field :name
+    = f.text_field :name, label_options: { value: 'Organisation Name' }
     = f.text_field :address_line_1
     = f.text_field :address_line_2
     = f.text_field :town
     = f.text_field :county
     = f.text_field :postcode
-    = f.radio_button_fieldset :contact_type, 
+    = f.radio_button_fieldset :contact_type_id, 
       choices: @contact_types, 
       value_method: :id, 
       text_method: :value

--- a/app/views/contacts/index.html.slim
+++ b/app/views/contacts/index.html.slim
@@ -21,7 +21,7 @@ table.report
       tr
         td = contact.name
         td = contact.inline_address
-        td = contact.contact_type
+        td = contact.contact_type.value
         td = link_to 'Edit', edit_contact_path(contact)
         td = link_to 'Delete', contact, data: { confirm: 'Are you sure?' }, method: :delete
 

--- a/app/views/contacts/index.html.slim
+++ b/app/views/contacts/index.html.slim
@@ -10,7 +10,7 @@
 table.report
   thead
     tr
-      th Name
+      th Organisation name
       th Address
       th Contact type
       th

--- a/db/data_migrations/20210914112717_add_address_types.rb
+++ b/db/data_migrations/20210914112717_add_address_types.rb
@@ -1,0 +1,58 @@
+class AddAddressTypes < ActiveRecord::DataMigration
+  # rubocop:disable Metrics/MethodLength
+  def up
+    category_references = [
+      { 
+        category: 'contact_type',
+        code: 'prison',
+        value: 'Prison',
+        display_order: 10
+      },
+      { 
+        category: 'contact_type',
+        code: 'probation',
+        value: 'Probation centre',
+        display_order: 20
+      },
+      { 
+        category: 'contact_type',
+        code: 'solicitor',
+        value: 'Solicitor',
+        display_order: 30
+      },
+      { 
+        category: 'contact_type',
+        code: 'branston',
+        value: 'Branson',
+        display_order: 40
+      },
+      { 
+        category: 'contact_type',
+        code: 'hmpps_hq',
+        value: 'HMPPS HQ',
+        display_order: 50
+      },
+      { 
+        category: 'contact_type',
+        code: 'hmcts',
+        value: 'HMCTS',
+        display_order: 60
+      },
+      { 
+        category: 'contact_type',
+        code: 'other',
+        value: 'Other',
+        display_order: 70
+      }
+    ]
+
+    category_references.each do |category_reference|
+      CategoryReference.create(category_reference)
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def down
+    CategoryReference.where(category: 'contact_type').delete_all
+  end
+end

--- a/db/migrate/20210914110858_create_category_references.rb
+++ b/db/migrate/20210914110858_create_category_references.rb
@@ -1,0 +1,13 @@
+class CreateCategoryReferences < ActiveRecord::Migration[5.2]
+  def change
+    create_table :category_references do |t|
+      t.string :category
+      t.string :code
+      t.string :value
+      t.integer :display_order
+      t.boolean :deactivated
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210914111215_add_category_reference_to_contacts.rb
+++ b/db/migrate/20210914111215_add_category_reference_to_contacts.rb
@@ -1,0 +1,6 @@
+class AddCategoryReferenceToContacts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :contacts, :contact_type
+    add_reference :contacts, :contact_type, foreign_key: { to_table: :category_references }, index: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -447,6 +447,41 @@ ALTER SEQUENCE public.cases_users_transitions_trackers_id_seq OWNED BY public.ca
 
 
 --
+-- Name: category_references; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.category_references (
+    id bigint NOT NULL,
+    category character varying,
+    code character varying,
+    value character varying,
+    display_order integer,
+    deactivated boolean,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: category_references_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.category_references_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: category_references_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.category_references_id_seq OWNED BY public.category_references.id;
+
+
+--
 -- Name: contacts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -459,9 +494,9 @@ CREATE TABLE public.contacts (
     county character varying,
     postcode character varying,
     email character varying,
-    contact_type integer DEFAULT 0,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    contact_type_id bigint
 );
 
 
@@ -1205,6 +1240,13 @@ ALTER TABLE ONLY public.cases_users_transitions_trackers ALTER COLUMN id SET DEF
 
 
 --
+-- Name: category_references id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.category_references ALTER COLUMN id SET DEFAULT nextval('public.category_references_id_seq'::regclass);
+
+
+--
 -- Name: contacts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1393,6 +1435,14 @@ ALTER TABLE ONLY public.cases
 
 ALTER TABLE ONLY public.cases_users_transitions_trackers
     ADD CONSTRAINT cases_users_transitions_trackers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: category_references category_references_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.category_references
+    ADD CONSTRAINT category_references_pkey PRIMARY KEY (id);
 
 
 --
@@ -1682,6 +1732,13 @@ CREATE INDEX index_cases_users_transitions_trackers_on_user_id ON public.cases_u
 
 
 --
+-- Name: index_contacts_on_contact_type_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_contacts_on_contact_type_id ON public.contacts USING btree (contact_type_id);
+
+
+--
 -- Name: index_data_request_logs_on_data_request_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1931,6 +1988,14 @@ ALTER TABLE ONLY public.data_requests
 
 
 --
+-- Name: contacts fk_rails_b8815787ee; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.contacts
+    ADD CONSTRAINT fk_rails_b8815787ee FOREIGN KEY (contact_type_id) REFERENCES public.category_references(id);
+
+
+--
 -- Name: data_request_logs fk_rails_fc711a84cc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2087,6 +2152,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210518085422'),
 ('20210625113911'),
 ('20210723160533'),
-('20210727143427');
+('20210727143427'),
+('20210914110858'),
+('20210914111215');
 
 

--- a/spec/factories/category_references.rb
+++ b/spec/factories/category_references.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :category_reference do
+    category { "MyString" }
+    code { "MyString" }
+    value { "MyString" }
+    display_order { 1 }
+    deactivated { false }
+  end
+end

--- a/spec/factories/category_references.rb
+++ b/spec/factories/category_references.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :category_reference do
-    category { "MyString" }
-    code { "MyString" }
-    value { "MyString" }
+    category { "contact_type" }
+    code { "probation" }
+    value { "Probation Office" }
     display_order { 1 }
     deactivated { false }
   end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
     county {}
     postcode { 'FE2 9JK' }
     email { "fake.email@test098.gov.uk" }
-    contact_type { "prison" }
+    contact_type { build(:category_reference) }
   end
 end

--- a/spec/models/category_reference_spec.rb
+++ b/spec/models/category_reference_spec.rb
@@ -1,5 +1,51 @@
 require 'rails_helper'
 
 RSpec.describe CategoryReference, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  before do
+    category_references = [
+      { 
+        category: 'food_types',
+        code: 'apple',
+        value: 'Bramley apple',
+        display_order: 1,
+      },
+      { 
+        category: 'food_types',
+        code: 'bread',
+        value: 'sliced bread',
+        display_order: 2,
+      },
+      { 
+        category: 'food_types',
+        code: 'rice',
+        value: 'sticky rice',
+        display_order: 3,
+      },
+      { 
+        category: 'food_types',
+        code: 'potatoes',
+        value: 'triple cooked chips',
+        display_order: 4,
+      },
+      { 
+        category: 'food_types',
+        code: 'other',
+        value: 'Some other food type',
+        display_order: 5,
+      }
+    ]
+
+    category_references.each do |category_reference|
+      CategoryReference.create(category_reference)
+    end
+  end
+
+  describe '#list_by_category' do
+    it 'will return a hash of values for a category' do
+      expected =  ['apple', 'bread', 'rice', 'potatoes', 'other']
+      expect(CategoryReference.list_by_category(:food_types).size).to eq(5)
+      expect(CategoryReference.list_by_category(:food_types).pluck(:code)).to eq(expected)
+    end
+  end
 end

--- a/spec/models/category_reference_spec.rb
+++ b/spec/models/category_reference_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CategoryReference, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Contact, type: :model do
 
     it 'must have a valid contact_type' do
       expect(contact_2).to be_valid
-      expect{ contact_3 }.to raise_exception 
+      expect{ contact_3 }.to raise_exception(ActiveRecord::AssociationTypeMismatch)
     end
   end
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe Contact, type: :model do
                              address_line_2: 'little heath',
                              town: 'bakersville',
                              county: 'Mercia',
-                             postcode: 'FE2 9JK',
-                             contact_type: ['prison', 'probation', 'solicitor', 'other'].sample) }
+                             postcode: 'FE2 9JK')}
 
     let(:contact_3) { build(:contact,
                              name: 'HMP halifax',
@@ -56,7 +55,8 @@ RSpec.describe Contact, type: :model do
       expect(contact_2.county).to match("Mercia")
       expect(contact_2.postcode).to match("FE2 9JK")
       expect(contact_2.email).to match("fake.email@test098.gov.uk")
-      expect(['prison', 'probation', 'solicitor', 'other']).to include(contact_2.contact_type)
+      expect(contact_2.contact_type).to be_a(CategoryReference)
+      expect(contact_2.contact_type.value).to eq("Probation Office")
     end
   end
 end


### PR DESCRIPTION
## Description
Adds CategoryReference table to replace the use of enums and adds an implementation for it to be used with the Cotacts / address book.

PR created off the back of comments on [this PR](https://github.com/ministryofjustice/correspondence_tool_staff/pull/1717)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-3783](https://dsdmoj.atlassian.net/browse/CT-3783)

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Run the data migrations
Run a regular db migration

go to `/contacts` 
click 'Add new address'
Fill in form
Submit

Also test that validations are correct especially for the Contact_types
