### PR TITLE
CT-3054 Clean third part info when option changed

### DIFF
--- a/app/assets/javascripts/modules/ThirdPartyFieldCleanBeforeSubmit.js
+++ b/app/assets/javascripts/modules/ThirdPartyFieldCleanBeforeSubmit.js
@@ -1,0 +1,33 @@
+moj.Modules.ThirdPartyFieldCleanBeforeSubmit = {
+  init: function() {
+    var self = this;
+
+    $('#new_offender_sar').submit(function() {
+      self.clearThirdPartyFields("offender_sar");
+    });
+
+    $('#edit_offender_sar').submit(function() {
+      self.clearThirdPartyFields("offender_sar");
+    });
+
+    $('#new_offender_sar_complaint').submit(function() {
+      self.clearThirdPartyFields("offender_sar_complaint");
+    });
+
+    $('#edit_offender_sar_complaint').submit(function() {
+      self.clearThirdPartyFields("offender_sar_complaint");
+    });
+
+  },
+
+  clearThirdPartyFields: function (case_type){
+    if (($("#" + case_type + "_third_party_false").is(":checked")) ||
+    ($("#" + case_type + "_recipient_subject_recipient").is(":checked"))) {
+      $("#" + case_type + "_third_party_relationship").val('');
+      $("#" + case_type + "_third_party_name").val('');
+      $("#" + case_type + "_third_party_company_name").val('');
+      $("#" + case_type + "_postal_address").val('');
+    }
+  }
+
+};

--- a/spec/features/cases/offender_sar/case_editing_spec.rb
+++ b/spec/features/cases/offender_sar/case_editing_spec.rb
@@ -72,6 +72,18 @@ feature 'Offender SAR Case editing by a manager', :js do
     then_i_should_see_the_pages_for_dispatch_reflected_on_the_show_page
   end
 
+  scenario 'Third party info are cleaned after changing third party to data subject ', js: true do
+    expect(cases_show_page).to be_displayed(id: offender_sar_case.id)
+    cases_show_page.offender_sar_requester_details.change_link.click
+    expect(cases_edit_offender_sar_requester_details_page).to be_displayed
+    cases_edit_offender_sar_requester_details_page.choose_third_party_option(false)
+    click_on "Continue"
+    
+    expect(cases_show_page).to be_displayed(id: offender_sar_case.id)
+    expect(cases_show_page).to have_content "Information requested on someone's behalf? No"
+    check_thiry_party_info_are_cleaned(offender_sar_case)
+  end
+
   def when_i_update_the_exempt_pages_count
     click_on 'Update exempt pages'
     expect(page).to have_content('Update exempt pages')
@@ -128,4 +140,13 @@ feature 'Offender SAR Case editing by a manager', :js do
   def then_i_expect_the_new_date_to_be_reflected_on_the_case_show_page
     expect(cases_show_page).to have_content(I18n.l(offender_sar_case.received_date + 5, format: :default))
   end
+
+  def check_thiry_party_info_are_cleaned(offender_sar_case)
+    offender_sar_case.reload
+    expect(offender_sar_case.third_party).to eq false
+    expect(offender_sar_case.third_party_relationship).to eq "" 
+    expect(offender_sar_case.third_party_company_name).to eq "" 
+    expect(offender_sar_case.third_party_name).to eq "" 
+  end
+
 end

--- a/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
@@ -250,6 +250,18 @@ feature 'offender sar complaint case editing by a manager' do
     then_i_expect_the_result_to_be_reflected_on_the_case_show_page("8901234.55")
   end
 
+  scenario 'Third party info are cleaned after changing third party to data subject ', js: true do
+    expect(cases_show_page).to be_displayed(id: offender_sar_complaint.id)
+    cases_show_page.offender_sar_requester_details.change_link.click
+    expect(cases_edit_offender_sar_complaint_requester_details_page).to be_displayed
+    cases_edit_offender_sar_complaint_requester_details_page.choose_third_party_option(false)
+    click_on "Continue"
+    
+    expect(cases_show_page).to be_displayed(id: offender_sar_complaint.id)
+    expect(cases_show_page).to have_content "Information requested on someone's behalf? No"
+    check_thiry_party_info_are_cleaned(offender_sar_complaint)
+  end
+
   def and_i_expect_the_ico_contact_details_to_be_visible
     expect(cases_show_page).to have_content 'ICO Person'
     expect(cases_show_page).to have_content 'test@email.com'
@@ -498,6 +510,14 @@ feature 'offender sar complaint case editing by a manager' do
 
   def when_i_click_costs_change_link
     cases_show_page.offender_sar_complaint_costs.change_link.click
+  end
+
+  def check_thiry_party_info_are_cleaned(complaint)
+    complaint.reload
+    expect(complaint.third_party).to eq false
+    expect(complaint.third_party_relationship).to eq "" 
+    expect(complaint.third_party_company_name).to eq "" 
+    expect(complaint.third_party_name).to eq "" 
   end
 
 end

--- a/spec/site_prism/page_objects/pages/cases/edit/offender_sar_complaint_page_requester_details_edit.rb
+++ b/spec/site_prism/page_objects/pages/cases/edit/offender_sar_complaint_page_requester_details_edit.rb
@@ -21,6 +21,15 @@ module PageObjects
           def edit_third_party_name(value)
             third_party_name.set value
           end
+
+          def choose_third_party_option(third_party_choice)
+            if third_party_choice
+              choose('offender_sar_complaint_third_party_true', visible: false)
+            else
+              choose('offender_sar_complaint_third_party_false', visible: false)
+            end
+          end
+          
         end
       end
     end

--- a/spec/site_prism/page_objects/pages/cases/edit/offender_sar_page_requester_details_edit.rb
+++ b/spec/site_prism/page_objects/pages/cases/edit/offender_sar_page_requester_details_edit.rb
@@ -21,6 +21,15 @@ module PageObjects
           def edit_third_party_name(value)
             third_party_name.set value
           end
+
+          def choose_third_party_option(third_party_choice)
+            if third_party_choice
+              choose('offender_sar_third_party_true', visible: false)
+            else
+              choose('offender_sar_third_party_false', visible: false)
+            end
+          end
+
         end
       end
     end

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_recipient_details.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_complaint_page_recipient_details.rb
@@ -30,7 +30,7 @@ module PageObjects
               if kase.recipient == 'subject_recipient'
                 choose('offender_sar_complaint_recipient_subject_recipient', visible: false)
               elsif kase.recipient == 'requester_recipient'
-                  choose('offender_sar_complaint_recipient_requester_recipient', visible: false)
+                choose('offender_sar_complaint_recipient_requester_recipient', visible: false)
               end
             end
           end

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
@@ -36,7 +36,11 @@ module PageObjects
 
           def fill_in_case_details(params={})
             kase = FactoryBot.build :offender_sar_case, params
-            subject_full_name.set(params[:subject_full_name] || 'Sabrina Adams')
+            if params.present? && params[:subject_full_name].present?
+              subject_full_name.set(params[:subject_full_name])
+            else
+              subject_full_name.set('Sabrina Adams')
+            end
             prison_number.set kase.prison_number
             subject_address.set kase.subject_address
             subject_aliases.set kase.subject_aliases

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
@@ -36,8 +36,7 @@ module PageObjects
 
           def fill_in_case_details(params={})
             kase = FactoryBot.build :offender_sar_case, params
-
-            subject_full_name.set 'Sabrina Adams'
+            subject_full_name.set (params[:subject_full_name] || 'Sabrina Adams')
             prison_number.set kase.prison_number
             subject_address.set kase.subject_address
             subject_aliases.set kase.subject_aliases

--- a/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
+++ b/spec/site_prism/page_objects/pages/cases/new/offender_sar_page_subject_details.rb
@@ -36,7 +36,7 @@ module PageObjects
 
           def fill_in_case_details(params={})
             kase = FactoryBot.build :offender_sar_case, params
-            subject_full_name.set (params[:subject_full_name] || 'Sabrina Adams')
+            subject_full_name.set(params[:subject_full_name] || 'Sabrina Adams')
             prison_number.set kase.prison_number
             subject_address.set kase.subject_address
             subject_aliases.set kase.subject_aliases


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to avoid inconsistent third party information when the option is changed from third part to data subject only during case creation journey or case edit
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [X] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3054
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
