### PR TITLE
CT-3885 Fixed the 2 cases_closing_specs

### DIFF
--- a/spec/features/cases/foi/case_closing_spec.rb
+++ b/spec/features/cases/foi/case_closing_spec.rb
@@ -304,21 +304,6 @@ feature 'Closing a case' do
 
   private
 
-  def select_random_exemption
-    excemption_options = cases_close_page.exemptions.exemption_options
-    #select a random exemption
-    total_number_exemptions = excemption_options.count
-
-    # choose a random exemption, but not exemption[0] because that is not valid for NCND
-    random_exemption =  Random.new
-                          .rand(1..(total_number_exemptions - 1))
-
-    expect(excemption_options.size > 1).to eq true
-    excemption_options[random_exemption].click
-
-    excemption_options[random_exemption].text
-  end
-
   def close_case(kase)
     expect(cases_page.case_list.last.status.text).to eq 'Ready to close'
     click_link kase.number

--- a/spec/features/cases/overturned_foi/case_closing_spec.rb
+++ b/spec/features/cases/overturned_foi/case_closing_spec.rb
@@ -266,21 +266,6 @@ feature 'Closing a case' do
 
   private
 
-  def select_random_exemption
-    excemption_options = cases_close_page.exemptions.exemption_options
-    #select a random exemption
-    total_number_exemptions = excemption_options.count
-
-    # choose a random exemption, but not exemption[0] because that is not valid for NCND
-    random_exemption =  Random.new
-                          .rand(1..(total_number_exemptions - 1))
-
-    expect(excemption_options.size > 1).to eq true
-    excemption_options[random_exemption].click
-
-    excemption_options[random_exemption].text
-  end
-
   def close_case(kase)
     expect(cases_page.case_list.first.status.text).to eq 'Ready to close'
     click_link kase.number

--- a/spec/support/features/steps/cases/close_steps.rb
+++ b/spec/support/features/steps/cases/close_steps.rb
@@ -1,0 +1,14 @@
+def select_random_exemption
+  excemption_options = cases_close_page.exemptions.exemption_options
+  #select a random exemption
+  total_number_exemptions = excemption_options.count
+
+  # choose a random exemption, but not exemption[0] because that is not valid for NCND
+  random_exemption =  Random.new
+                        .rand(1..(total_number_exemptions - 1))
+  expect(excemption_options.size > 1).to eq true
+  scroll_to excemption_options[random_exemption]
+  excemption_options[random_exemption].click(wait: 10)
+
+  excemption_options[random_exemption].text
+end


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
Recently, The 2 cases_closing_spec for FOI and Overturned FOI failed quite often recently,  after checking the error : 
`Selenium::WebDriver::Error::ElementNotInteractableError: element not interactable, element has zero size  (Session info: headless chrome=94.0.4606.61)`
The possible reason can be 
- The elements are not visible from UI due to the exemption randomly chosen at the bottom of list 
- The time of loading the page takes a little long
The first reason may explain why the test specs  don't fail all the time,  but failed at random time.  Although it still doesn't quite explain why this failure situation happens relevant often recently 

The solution is to address by 
- scrolling to the chosen time 
- giving more time
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [X] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=25&modal=detail&selectedIssue=CT-3885
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
