### PR TITLE
Fix typo in rake task

### DIFF
--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -9,7 +9,7 @@ namespace :db do
       x = STDIN.gets.chomp
       exit unless (x == 'y' || x == 'Y')
       begin
-        ActiveRedord::Base.connection.execute 'DROP TABLE conversations'
+        ActiveRecord::Base.connection.execute 'DROP TABLE conversations'
       rescue => err
         puts "#{err.class} trying to drop conversations table"
         puts err.message


### PR DESCRIPTION
## Description
Saw that `ActiveRecord` was mistyped here as `ActiveRedord` - tiny PR to fix.
