### PR TITLE
Ct 3934 make cant consistent

### DIFF
--- a/app/assets/javascripts/modules/Dropzone.js
+++ b/app/assets/javascripts/modules/Dropzone.js
@@ -17,7 +17,7 @@ moj.Modules.Dropzone = {
       url : this.$target.data('url'),
       method : 'post',
       addRemoveLinks : true,
-      dictFileTooBig: "File is too big. Max file size is {{maxFilesize}}MB. We can't upload this file.",
+      dictFileTooBig: "File is too big. Max file size is {{maxFilesize}}MB. We cannot upload this file.",
       maxFilesize : this.$target.data('max-filesize-in-mb'),
       previewTemplate : this.$target.data('dz-template'),
       paramName : 'file',

--- a/app/form_models/offender_sar_complaint_case_form.rb
+++ b/app/form_models/offender_sar_complaint_case_form.rb
@@ -29,7 +29,7 @@ module OffenderSARComplaintCaseForm
       original_case = case_link.linked_case
       if not Pundit.policy(object.creator, original_case).show?
         add_errors_for_original_case(
-          I18n.t('activerecord.errors.models.case/sar/offender_complaint.original_case_number.not_authorised'))
+          I18n.t('activerecord.errors.models.case/sar/offender_complaint.attributes.original_case.not_authorised'))
       else
         object.original_case_id = original_case.id
         object.validate_original_case

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -188,7 +188,7 @@ class Case::Base < ApplicationRecord
   validates :current_state, presence: true, on: :update
   validates :email, format: { with: /\A.+@.+\z/ }, if: -> { email.present? }
   validates_presence_of :received_date
-  validates :type, presence: true, exclusion: { in: %w{Case}, message: "Case type can't be blank" }
+  validates :type, presence: true, exclusion: { in: %w{Case}, message: "Case type cannot be blank" }
   validates :workflow, inclusion: { in: %w{ standard trigger full_approval }, message: "invalid" }
 
   validate :validate_related_cases

--- a/app/models/case/ico/base.rb
+++ b/app/models/case/ico/base.rb
@@ -168,7 +168,7 @@ class Case::ICO::Base < Case::Base
   def validate_late_team_recorded
     if prepared_for_recording_late_team? && responded_late?
       if late_team_id.blank?
-        errors.add(:late_team, "can't be blank")
+        errors.add(:late_team, "cannot be blank")
       end
     end
   end

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -99,8 +99,8 @@ class Case::SAR::Offender < Case::Base
   has_many :data_requests, dependent: :destroy, foreign_key: :case_id
   accepts_nested_attributes_for :data_requests
 
-  validates :third_party,          inclusion: { in: [true, false], message: "can't be blank" }
-  validates :flag_as_high_profile, inclusion: { in: [true, false], message: "can't be blank" }
+  validates :third_party,          inclusion: { in: [true, false], message: "cannot be blank" }
+  validates :flag_as_high_profile, inclusion: { in: [true, false], message: "cannot be blank" }
   validates :date_of_birth, presence: true
 
   validates_presence_of :subject_address

--- a/app/models/case/sar/standard.rb
+++ b/app/models/case/sar/standard.rb
@@ -201,13 +201,13 @@ class Case::SAR::Standard < Case::Base
       errors.add(
         :message,
         :blank,
-        message: "can't be blank if no request files attached"
+        message: "cannot be blank if no request files attached"
       )
 
       errors.add(
         :uploaded_request_files,
         :blank,
-        message: "can't be blank if no case details entered"
+        message: "cannot be blank if no case details entered"
       )
     end
   end
@@ -217,7 +217,7 @@ class Case::SAR::Standard < Case::Base
       errors.add(
         :message,
         :blank,
-        message: "can't be blank if no request files attached"
+        message: "cannot be blank if no request files attached"
       )
     end
   end

--- a/app/services/case_extend_for_pit_service.rb
+++ b/app/services/case_extend_for_pit_service.rb
@@ -36,7 +36,7 @@ class CaseExtendForPITService
 
   def validate_params
     unless @reason.present?
-      @case.errors.add(:reason_for_extending, "can't be blank")
+      @case.errors.add(:reason_for_extending, "cannot be blank")
       @result = :validation_error
     end
 
@@ -52,7 +52,7 @@ class CaseExtendForPITService
                         .business_days
                         .after(@case.external_deadline)
     if @extension_deadline.blank?
-      @case.errors.add(:extension_deadline, "Date can't be blank")
+      @case.errors.add(:extension_deadline, "Date cannot be blank")
       false
     elsif @extension_deadline > extension_limit
       @case.errors.add(
@@ -62,7 +62,7 @@ class CaseExtendForPITService
       false
     elsif @extension_deadline < @case.external_deadline
       @case.errors.add(:extension_deadline,
-                       "Date can't be before the final deadline")
+                       "Date cannot be before the final deadline")
       false
     else
       true

--- a/app/services/case_extend_sar_deadline_service.rb
+++ b/app/services/case_extend_sar_deadline_service.rb
@@ -59,17 +59,17 @@ class CaseExtendSARDeadlineService
     if @extension_period.blank?
       @case.errors.add(
         :extension_period,
-        "can't be blank"
+        "cannot be blank"
       )
     elsif @extension_deadline > extension_limit
       @case.errors.add(
         :extension_period,
-        "can't be more than #{@case.time_period_description(@case.extension_time_limit)} beyond the received date"
+        "cannot be more than #{@case.time_period_description(@case.extension_time_limit)} beyond the received date"
       )
     elsif @extension_deadline < @case.external_deadline
       @case.errors.add(
         :extension_period,
-        "can't be before the final deadline"
+        "cannot be before the final deadline"
       )
     end
   end
@@ -78,7 +78,7 @@ class CaseExtendSARDeadlineService
     if @reason.blank?
       @case.errors.add(
         :reason_for_extending,
-        "can't be blank"
+        "cannot be blank"
       )
     end
   end

--- a/app/validators/closed_case_validator.rb
+++ b/app/validators/closed_case_validator.rb
@@ -113,7 +113,7 @@ class ClosedCaseValidator < ActiveModel::Validator
 
   def validate_date_ico_decision_received(rec)
     if rec.date_ico_decision_received.blank?
-      rec.errors.add(:date_ico_decision_received, "can't be blank")
+      rec.errors.add(:date_ico_decision_received, "cannot be blank")
     elsif rec.date_ico_decision_received > Date.today
       rec.errors.add(:date_ico_decision_received, 'future')
     elsif rec.date_ico_decision_received < rec.created_at.to_date
@@ -138,7 +138,7 @@ class ClosedCaseValidator < ActiveModel::Validator
 
   def validate_info_held_status(rec)
     if rec.info_held_status.nil?
-      rec.errors.add(:info_held_status, "can't be blank")
+      rec.errors.add(:info_held_status, "cannot be blank")
     end
   end
 
@@ -150,12 +150,12 @@ class ClosedCaseValidator < ActiveModel::Validator
 
   def validate_date_responded(rec)
     if rec.date_responded.blank?
-      rec.errors.add(:date_responded, "can't be blank")
+      rec.errors.add(:date_responded, "cannot be blank")
     else
       if rec.date_responded < rec.received_date
-        rec.errors.add(:date_responded, "can't be before date received")
+        rec.errors.add(:date_responded, "cannot be before date received")
       elsif rec.date_responded > Date.today
-        rec.errors.add(:date_responded, "can't be in the future")
+        rec.errors.add(:date_responded, "cannot be in the future")
       end
     end
   end
@@ -164,7 +164,7 @@ class ClosedCaseValidator < ActiveModel::Validator
   def validate_outcome(rec)
     if self.class.outcome_required?(info_held_status: rec.info_held_status_abbreviation)
       if rec.outcome.blank?
-        rec.errors.add(:outcome, "can't be blank")
+        rec.errors.add(:outcome, "cannot be blank")
       end
     elsif rec.outcome.present?
       rec.errors.add(:outcome, 'can only be present if information held or part held')

--- a/app/views/cases/foi/_edit_form_details.html.slim
+++ b/app/views/cases/foi/_edit_form_details.html.slim
@@ -4,7 +4,7 @@
   - if @case.attachments.request.present?
     .panel.panel-border-wide
       p
-        = "You can't edit an uploaded request"
+        = "You cannot edit an uploaded request"
   - else
     = f.text_area :message, { rows: 10 }
 

--- a/app/views/cases/pit_extensions/new.html.slim
+++ b/app/views/cases/pit_extensions/new.html.slim
@@ -25,7 +25,7 @@ div.action-copy
       span.visually-hidden
         = "Important"
     strong.normal-weight
-      = "The additional time can't be used to determine whether exemptions apply."
+      = "The additional time cannot be used to determine whether exemptions apply."
       br
       = "It must already be identified that a qualified exemption applies."
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -29,7 +29,7 @@ en:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."
     passwords:
-      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      no_token: "You cannot access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,7 +234,7 @@ en:
               future: cannot be in the future
               not_empty: should be blank if the request is not complete
         linked_case:
-          missing: "doesn't exist"
+          missing: "does not exist"
           references_self: "cannot link to the same case"
           wrong_type: "cannot link a %{case_class} case to a %{linked_case_class} as a %{type} case"
         report:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,7 @@ en:
             date_responded:
               before_received: "cannot be before date received"
               future: "cannot be in the future"
+              blank: cannot be blank
             message:
               optional_blank: "and uploaded request files cannot both be blank"
               blank: test
@@ -131,6 +132,7 @@ en:
             date_responded:
               before_received: "cannot be before date received"
               future: "cannot be in the future"
+              blank: cannot be blank
           related_case_number:
             does_not_match_original: >-
               You've linked an FOI case as the original for this appeal. You
@@ -185,6 +187,20 @@ en:
           attributes:
             third_party:
               inclusion: Please choose yes or no
+        case/sar/standard:
+          attributes:
+            subject_full_name:
+              blank: cannot be blank
+            subject_type:
+              blank: cannot be blank
+            email:
+              blank: cannot be blank
+            postal_address:
+              blank: cannot be blank
+            name:
+              blank: cannot be blank
+            third_party_relationship:
+              blank: cannot be blank
         case/sar/offender:
           attributes:
             date_responded:
@@ -210,7 +226,10 @@ en:
               blank: cannot be blank
             recipient:
               blank: cannot be blank
-
+            date_of_birth:
+              blank: cannot be blank
+            subject_address:
+              blank: cannot be blank
         case/sar/offender_complaint:
           attributes:
             ico_contact_name:
@@ -276,6 +295,18 @@ en:
               <<: *report_dates
               before_start_date: "cannot be after Date to"
             report_type_id:
+              blank: cannot be blank
+        user:
+          attributes:
+            email:
+              blank: cannot be blank
+        case_transition:
+          attributes:
+            message:
+              blank: cannot be blank
+        data_request:
+          attributes:
+            request_type:
               blank: cannot be blank
 
   pundit:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,8 +61,6 @@ en:
               blank: cannot be blank
         case:
           attributes:
-            message:
-              blank: test
             email:
               blank: "and address cannot both be blank"
             external_deadline:
@@ -95,19 +93,34 @@ en:
                 An error has occurred and your case could not be created.
                 Please try again.
             requester_type:
-              blank: Type of requester must be selected
+              blank: must be selected
             flag_for_disclosure_specialists:
               blank: Please choose yes or no
 
         case/foi/standard:
           attributes: &foi_attr
+            received_date:
+              blank: cannot be blank
+            email: 
+              blank: cannot be blank
+            name: 
+              blank: cannot be blank
+            postal_address: 
+              blank: cannot be blank
+            requester_type: 
+              blank: cannot be blank
+            delivery_method: 
+              blank: cannot be blank
+            subject: 
+              blank: cannot be blank
+            flag_for_disclosure_specialists: 
+              blank: cannot be blank
             date_responded:
               before_received: "cannot be before date received"
               future: "cannot be in the future"
               blank: cannot be blank
             message:
               optional_blank: "and uploaded request files cannot both be blank"
-              blank: test
             uploaded_request_files:
               optional_blank: "and message box for saving request detail cannot both be blank"
 
@@ -201,6 +214,14 @@ en:
               blank: cannot be blank
             third_party_relationship:
               blank: cannot be blank
+            received_date:
+              blank: cannot be blank
+            reply_method:
+              blank: cannot be blank
+            subject:
+              blank: cannot be blank
+            third_party_relationship:
+              blank: cannot be blank
         case/sar/offender:
           attributes:
             date_responded:
@@ -208,6 +229,7 @@ en:
               future: "cannot be in the future"
             recipient:
               third_party: cannot be third_party_recipient if third party requester
+              blank: cannot be blank
             third_party_company_name:
               blank: cannot be blank if representative name not given
             third_party_name:
@@ -223,8 +245,6 @@ en:
             subject_type:
               blank: cannot be blank
             received_date:
-              blank: cannot be blank
-            recipient:
               blank: cannot be blank
             date_of_birth:
               blank: cannot be blank
@@ -253,10 +273,17 @@ en:
             external_deadline:
               before_received: "cannot be before date received"
               past: cannot be in the past
-          original_case_number:
-            blank: "Enter original case number"
-            not_authorised: cannot be authorised to link this case
-            wrong_type: Original case must be Offender SAR
+            original_case:
+              blank: cannot be blank
+              not_authorised: cannot be authorised to link this case
+              wrong_type: Original case must be Offender SAR
+            complaint_type:
+              blank: cannot be blank
+            complaint_subtype:
+              blank: cannot be blank
+            priority:
+              blank: cannot be blank
+
         assignment:
           attributes:
             state:
@@ -281,6 +308,8 @@ en:
               blank: must be provided if request is complete
               future: cannot be in the future
               not_empty: should be blank if the request is not complete
+            request_type:
+              blank: cannot be blank
         linked_case:
           missing: "does not exist"
           references_self: "cannot link to the same case"
@@ -303,11 +332,7 @@ en:
         case_transition:
           attributes:
             message:
-              blank: cannot be blank
-        data_request:
-          attributes:
-            request_type:
-              blank: cannot be blank
+              blank: cannot be blank            
 
   pundit:
     assignment_policy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,26 +146,41 @@ en:
             received_date:
               future: cannot be in the future
               past: is too far in the past
+              blank: cannot be blank
             external_deadline:
               past: cannot be in the past
               future: is too far in the future
+              blank: cannot be blank
             original_ico_appeal:
               not_ico_sar: is not an ICO appeal for a SAR case
+              blank: cannot be blank
             original_case:
               not_sar: is not a SAR case
+              blank: cannot be blank
+            email:
+              blank: cannot be blank
+            postal_address:
+              blank: cannot be blank
+            ico_officer_name:
+              blank: cannot be blank
+
         case/overturned_ico/foi:
           attributes:
             <<: *foi_attr
             received_date:
               future: cannot be in the future
               past: is too far in the past
+              blank: cannot be blank
             external_deadline:
               past: cannot be in the past
               future: is too far in the future
+              blank: cannot be blank
             original_ico_appeal:
               not_ico_foi: is not an ICO appeal for a FOI case
+              blank: cannot be blank
             original_case:
               not_foi: is not a FOI case
+              blank: cannot be blank
         case/sar:
           attributes:
             third_party:
@@ -185,8 +200,17 @@ en:
               blank: cannot be blank
             third_party_address:
               blank: cannot be blank
-            message_text:
-              blank: atest
+            subject_full_name:
+              blank: cannot be blank
+            subject_address:
+              blank: cannot be blank
+            subject_type:
+              blank: cannot be blank
+            received_date:
+              blank: cannot be blank
+            recipient:
+              blank: cannot be blank
+
         case/sar/offender_complaint:
           attributes:
             ico_contact_name:
@@ -251,6 +275,8 @@ en:
             period_end:
               <<: *report_dates
               before_start_date: "cannot be after Date to"
+            report_type_id:
+              blank: cannot be blank
 
   pundit:
     assignment_policy:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,8 @@ en:
               blank: cannot be blank
         case:
           attributes:
+            message:
+              blank: test
             email:
               blank: "and address cannot both be blank"
             external_deadline:
@@ -104,6 +106,7 @@ en:
               future: "cannot be in the future"
             message:
               optional_blank: "and uploaded request files cannot both be blank"
+              blank: test
             uploaded_request_files:
               optional_blank: "and message box for saving request detail cannot both be blank"
 
@@ -182,6 +185,8 @@ en:
               blank: cannot be blank
             third_party_address:
               blank: cannot be blank
+            message_text:
+              blank: atest
         case/sar/offender_complaint:
           attributes:
             ico_contact_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,7 +62,7 @@ en:
         case:
           attributes:
             email:
-              blank: "and address can't both be blank"
+              blank: "and address cannot both be blank"
             external_deadline:
               too_far_past_received: 'cannot be more than a year past the date received'
               before_received: "cannot be before date received"
@@ -70,14 +70,14 @@ en:
               after_external: "cannot be after final deadline"
               before_received: "cannot be before date received"
             received_date:
-              not_in_future: "can't be in the future."
+              not_in_future: "cannot be in the future."
               past: too far in past.
             date_draft_compliant:
-              before_received: "can't be before date received"
-              not_in_future: "can't be in the future."
-              after_date_responded: "can't be after the date responded"
+              before_received: "cannot be before date received"
+              not_in_future: "cannot be in the future."
+              after_date_responded: "cannot be after the date responded"
             date_of_birth:
-              not_in_future: "can't be in the future."
+              not_in_future: "cannot be in the future."
             related_case_links:
               not_empty: "are not empty. Please remove all linked cases in order to delete this case."
             number_final_pages:
@@ -85,9 +85,9 @@ en:
             number_exempt_pages:
               not_whole_number: 'must be a positive whole number'
             request_dated:
-              not_in_future: "can't be in the future."
+              not_in_future: "cannot be in the future."
             postal_address:
-              blank: "and email can't both be blank"
+              blank: "and email cannot both be blank"
             number:
               duplication: |
                 An error has occurred and your case could not be created.
@@ -100,12 +100,12 @@ en:
         case/foi/standard:
           attributes: &foi_attr
             date_responded:
-              before_received: "can't be before date received"
-              future: "can't be in the future"
+              before_received: "cannot be before date received"
+              future: "cannot be in the future"
             message:
-              optional_blank: "and uploaded request files can't both be blank"
+              optional_blank: "and uploaded request files cannot both be blank"
             uploaded_request_files:
-              optional_blank: "and message box for saving request detail can't both be blank"
+              optional_blank: "and message box for saving request detail cannot both be blank"
 
         case/ico:
           attributes:
@@ -126,8 +126,8 @@ en:
         case/ico/foi:
           attributes:
             date_responded:
-              before_received: "can't be before date received"
-              future: "can't be in the future"
+              before_received: "cannot be before date received"
+              future: "cannot be in the future"
           related_case_number:
             does_not_match_original: >-
               You've linked an FOI case as the original for this appeal. You
@@ -141,10 +141,10 @@ en:
         case/overturned_ico/sar:
           attributes:
             received_date:
-              future: can't be in the future
+              future: cannot be in the future
               past: is too far in the past
             external_deadline:
-              past: can't be in the past
+              past: cannot be in the past
               future: is too far in the future
             original_ico_appeal:
               not_ico_sar: is not an ICO appeal for a SAR case
@@ -154,7 +154,7 @@ en:
           attributes:
             <<: *foi_attr
             received_date:
-              future: can't be in the future
+              future: cannot be in the future
               past: is too far in the past
             external_deadline:
               past: cannot be in the past
@@ -170,36 +170,36 @@ en:
         case/sar/offender:
           attributes:
             date_responded:
-              before_received: "can't be before date received"
-              future: "can't be in the future"
+              before_received: "cannot be before date received"
+              future: "cannot be in the future"
             recipient:
-              third_party: can't be third_party_recipient if third party requester
+              third_party: cannot be third_party_recipient if third party requester
             third_party_company_name:
-              blank: can't be blank if representative name not given
+              blank: cannot be blank if representative name not given
             third_party_name:
-              blank: can't be blank if company name not given
+              blank: cannot be blank if company name not given
             third_party_relationship:
-              blank: can't be blank
+              blank: cannot be blank
             third_party_address:
-              blank: can't be blank
+              blank: cannot be blank
         case/sar/offender_complaint:
           attributes:
             ico_contact_name:
-              blank: can't be blank
+              blank: cannot be blank
             ico_contact_email:
-              blank: can't be blank if ICO contact phone not given
+              blank: cannot be blank if ICO contact phone not given
             ico_contact_phone:
-              blank: can't be blank if ICO contact email not given
+              blank: cannot be blank if ICO contact email not given
             ico_reference:
-              blank: can't be blank
+              blank: cannot be blank
             gld_contact_name:
-              blank: can't be blank
+              blank: cannot be blank
             gld_contact_email:
-              blank: can't be blank if GLD contact phone not given
+              blank: cannot be blank if GLD contact phone not given
             gld_contact_phone:
-              blank: can't be blank if GLD contact email not given
+              blank: cannot be blank if GLD contact email not given
             gld_reference:
-              blank: can't be blank
+              blank: cannot be blank
             linked_cases:
               original_case_already_related: already linked as the original case
             external_deadline:
@@ -207,7 +207,7 @@ en:
               past: cannot be in the past
           original_case_number:
             blank: "Enter original case number"
-            not_authorised: can't be authorised to link this case
+            not_authorised: cannot be authorised to link this case
             wrong_type: Original case must be Offender SAR
         assignment:
           attributes:
@@ -228,24 +228,24 @@ en:
               blank: must be completed
               future: cannot be in the future
             request_type_note:
-              blank: can't be blank
+              blank: cannot be blank
             cached_date_received:
               blank: must be provided if request is complete
               future: cannot be in the future
               not_empty: should be blank if the request is not complete
         linked_case:
           missing: "doesn't exist"
-          references_self: "can't link to the same case"
-          wrong_type: "can't link a %{case_class} case to a %{linked_case_class} as a %{type} case"
+          references_self: "cannot link to the same case"
+          wrong_type: "cannot link a %{case_class} case to a %{linked_case_class} as a %{type} case"
         report:
           attributes:
             correspondence_type:
-              blank: "can't be blank"
+              blank: "cannot be blank"
             period_start: &report_dates
-              in_future: "can't be in the future."
+              in_future: "cannot be in the future."
             period_end:
               <<: *report_dates
-              before_start_date: "can't be after Date to"
+              before_start_date: "cannot be after Date to"
 
   pundit:
     assignment_policy:
@@ -552,7 +552,7 @@ en:
         external_deadline: Final deadline
         ico_officer_name: Name of the ICO information officer who's handling this case
         ico_reference_number: ICO case reference number
-        message: ICO's request details can't be blank
+        message: ICO's request details cannot be blank
         original_case: 
         received_date: Date received at MOJ
       ico:
@@ -749,7 +749,7 @@ en:
         <i class="icon icon-important">
           <span class="visually-hidden">Important</span>
         </i>
-        <strong>You can't update a response after marking it as sent.</strong>
+        <strong>You cannot update a response after marking it as sent.</strong>
       </p>
     offender_sar:
       reason_for_lateness:
@@ -1177,7 +1177,7 @@ en:
       success: The response has been marked as sent.
     foi:
       case_details:
-        cannot_update_closure_html: "This is an old case with closure details that can't be edited. If you need to edit this case <a href=\"#new_feedback\">let us know</a>."
+        cannot_update_closure_html: "This is an old case with closure details that cannot be edited. If you need to edit this case <a href=\"#new_feedback\">let us know</a>."
       close_form:
         date_example: For example, 30 1 2017
         close_date:  Date response sent

--- a/lib/cts/policies.rb
+++ b/lib/cts/policies.rb
@@ -6,7 +6,7 @@ module CTS
     long_desc <<~EOD
       Check the policies for a given user and case. Runs all the policies
       and displays whether it succeeded or not, and if not which checks failed.
-      This is meant as a handy debugging tool to understand why a user can't do
+      This is meant as a handy debugging tool to understand why a user cannot do
       something with a particular case.
 
       Command-Line Args:

--- a/spec/controllers/cases/messages_controller_spec.rb
+++ b/spec/controllers/cases/messages_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Cases::MessagesController, type: :controller do
       end
 
       it "copies the error to the flash" do
-        expect(flash[:case_errors][:message_text]).to eq ["can't be blank"]
+        expect(flash[:case_errors][:message_text]).to eq ["cannot be blank"]
       end
 
       it 'redirects to case detail page and contains a anchor' do

--- a/spec/controllers/cases/messages_controller_spec.rb
+++ b/spec/controllers/cases/messages_controller_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Cases::MessagesController, type: :controller do
       end
 
       it "copies the error to the flash" do
-        expect(flash[:case_errors][:message_text]).to eq ["cannot be blank"]
+        expect(flash[:case_errors][:message_text]).to eq ["can't be blank"]
       end
 
       it 'redirects to case detail page and contains a anchor' do

--- a/spec/controllers/cases/notes_controller_spec.rb
+++ b/spec/controllers/cases/notes_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Cases::NotesController, type: :controller do
       end
 
       it "copies the error to the flash" do
-        expect(flash[:case_errors][:message_text]).to eq ["cannot be blank"]
+        expect(flash[:case_errors][:message_text]).to eq ["can't be blank"]
       end
 
       it 'redirects to case detail page and contains a anchor' do

--- a/spec/controllers/cases/notes_controller_spec.rb
+++ b/spec/controllers/cases/notes_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Cases::NotesController, type: :controller do
       end
 
       it "copies the error to the flash" do
-        expect(flash[:case_errors][:message_text]).to eq ["can't be blank"]
+        expect(flash[:case_errors][:message_text]).to eq ["cannot be blank"]
       end
 
       it 'redirects to case detail page and contains a anchor' do

--- a/spec/controllers/cases/offender_sar_complaint_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_complaint_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'requires original case number to be set' do
             remains_on_step 'link-offender-sar-case'
-            expect(errors[:original_case_number]).to eq ["cannot be blank"]
+            expect(errors[:original_case_number]).to eq ["can't be blank"]
           end
         end
 
@@ -144,7 +144,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
           context 'when complaint-type absent' do
             it 'requires complaint-type to be set' do
               remains_on_step 'complaint-type'
-              expect(errors[:complaint_type]).to eq ["cannot be blank"]
+              expect(errors[:complaint_type]).to eq ["can't be blank"]
             end
           end
           context 'when complaint-type present' do
@@ -198,14 +198,14 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
         context 'when complaint-subtype absent' do
           it 'requires complaint-subtype to be set' do
             remains_on_step 'complaint-type'
-            expect(errors[:complaint_subtype]).to eq ["cannot be blank"]
+            expect(errors[:complaint_subtype]).to eq ["can't be blank"]
           end
         end
 
         context 'when priority absent' do
           it 'requires priority to be set' do
             remains_on_step 'complaint-type'
-            expect(errors[:priority]).to eq ["cannot be blank"]
+            expect(errors[:priority]).to eq ["can't be blank"]
           end
         end
       end

--- a/spec/controllers/cases/offender_sar_complaint_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_complaint_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'requires original case number to be set' do
             remains_on_step 'link-offender-sar-case'
-            expect(errors[:original_case_number]).to eq ["can't be blank"]
+            expect(errors[:original_case_number]).to eq ["cannot be blank"]
           end
         end
 
@@ -113,7 +113,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'The user needs to be allowed to view the original case' do
             remains_on_step 'link-offender-sar-case'
-            expect(errors[:original_case_number]).to eq ["can't be authorised to link this case"]
+            expect(errors[:original_case_number]).to eq ["cannot be authorised to link this case"]
           end
         end
 
@@ -127,7 +127,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'requires the original case is the type allowed for complaint case' do
             remains_on_step 'link-offender-sar-case'
-            expect(errors[:original_case]).to eq ["can't link a Complaint case to a Complaint as a original case"]
+            expect(errors[:original_case]).to eq ["cannot link a Complaint case to a Complaint as a original case"]
           end
         end
       end
@@ -144,7 +144,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
           context 'when complaint-type absent' do
             it 'requires complaint-type to be set' do
               remains_on_step 'complaint-type'
-              expect(errors[:complaint_type]).to eq ["can't be blank"]
+              expect(errors[:complaint_type]).to eq ["cannot be blank"]
             end
           end
           context 'when complaint-type present' do
@@ -157,16 +157,16 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
               end
 
               it 'requires ico contact name' do
-                expect(errors[:ico_contact_name]).to eq ["can't be blank"]
+                expect(errors[:ico_contact_name]).to eq ["cannot be blank"]
               end
 
               it 'requires ico contact phone or email' do
-                expect(errors[:ico_contact_email]).to eq ["can't be blank if ICO contact phone not given"]
-                expect(errors[:ico_contact_phone]).to eq ["can't be blank if ICO contact email not given"]
+                expect(errors[:ico_contact_email]).to eq ["cannot be blank if ICO contact phone not given"]
+                expect(errors[:ico_contact_phone]).to eq ["cannot be blank if ICO contact email not given"]
               end
 
               it 'requires ico reference' do
-                expect(errors[:ico_reference]).to eq ["can't be blank"]
+                expect(errors[:ico_reference]).to eq ["cannot be blank"]
               end
 
             end
@@ -180,16 +180,16 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
               end
 
               it 'requires gld contact name' do
-                expect(errors[:gld_contact_name]).to eq ["can't be blank"]
+                expect(errors[:gld_contact_name]).to eq ["cannot be blank"]
               end
 
               it 'requires gld contact phone or email' do
-                expect(errors[:gld_contact_email]).to eq ["can't be blank if GLD contact phone not given"]
-                expect(errors[:gld_contact_phone]).to eq ["can't be blank if GLD contact email not given"]
+                expect(errors[:gld_contact_email]).to eq ["cannot be blank if GLD contact phone not given"]
+                expect(errors[:gld_contact_phone]).to eq ["cannot be blank if GLD contact email not given"]
               end
 
               it 'requires gld reference' do
-                expect(errors[:gld_reference]).to eq ["can't be blank"]
+                expect(errors[:gld_reference]).to eq ["cannot be blank"]
               end
             end
           end
@@ -198,14 +198,14 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
         context 'when complaint-subtype absent' do
           it 'requires complaint-subtype to be set' do
             remains_on_step 'complaint-type'
-            expect(errors[:complaint_subtype]).to eq ["can't be blank"]
+            expect(errors[:complaint_subtype]).to eq ["cannot be blank"]
           end
         end
 
         context 'when priority absent' do
           it 'requires priority to be set' do
             remains_on_step 'complaint-type'
-            expect(errors[:priority]).to eq ["can't be blank"]
+            expect(errors[:priority]).to eq ["cannot be blank"]
           end
         end
       end
@@ -221,7 +221,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'requires third_party to be set' do
             remains_on_step 'requester-details'
-            expect(errors[:third_party]).to eq ["can't be blank"]
+            expect(errors[:third_party]).to eq ["cannot be blank"]
           end
         end
 
@@ -264,7 +264,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'requires recipient to be set' do
             remains_on_step 'recipient-details'
-            expect(errors[:recipient]).to eq ["can't be blank"]
+            expect(errors[:recipient]).to eq ["cannot be blank"]
           end
         end
 
@@ -303,7 +303,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'fails to be valid' do
             remains_on_step 'request-details'
-            expect(errors[:request_dated]).to eq ["can't be in the future."]
+            expect(errors[:request_dated]).to eq ["cannot be in the future."]
           end
         end
       end
@@ -319,7 +319,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'requires received date to be set' do
             remains_on_step 'date-received'
-            expect(errors[:received_date]).to eq ["can't be blank"]
+            expect(errors[:received_date]).to eq ["cannot be blank"]
           end
         end
 
@@ -338,7 +338,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'fails to be valid' do
             remains_on_step 'date-received'
-            expect(errors[:received_date]).to eq ["can't be in the future."]
+            expect(errors[:received_date]).to eq ["cannot be in the future."]
           end
         end
       end
@@ -461,10 +461,10 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
       it 'check the errors' do
         patch :update, params: invalid_litigation_params
         expect(assigns(:case)).to be_a Case::SAR::OffenderComplaint
-        expect(errors[:gld_contact_name]).to eq ["can't be blank"]
-        expect(errors[:gld_contact_email]).to eq ["can't be blank if GLD contact phone not given"]
-        expect(errors[:gld_contact_phone]).to eq ["can't be blank if GLD contact email not given"]
-        expect(errors[:gld_reference]).to eq ["can't be blank"]
+        expect(errors[:gld_contact_name]).to eq ["cannot be blank"]
+        expect(errors[:gld_contact_email]).to eq ["cannot be blank if GLD contact phone not given"]
+        expect(errors[:gld_contact_phone]).to eq ["cannot be blank if GLD contact email not given"]
+        expect(errors[:gld_reference]).to eq ["cannot be blank"]
         expect(litigation_complaint.object.transitions.where(event: "edit_case").count).to eq 0
       end
     end
@@ -473,10 +473,10 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
       it 'check the errors' do
         patch :update, params: invalid_ico_params
         expect(assigns(:case)).to be_a Case::SAR::OffenderComplaint
-        expect(errors[:ico_contact_name]).to eq ["can't be blank"]
-        expect(errors[:ico_contact_email]).to eq ["can't be blank if ICO contact phone not given"]
-        expect(errors[:ico_contact_phone]).to eq ["can't be blank if ICO contact email not given"]
-        expect(errors[:ico_reference]).to eq ["can't be blank"]
+        expect(errors[:ico_contact_name]).to eq ["cannot be blank"]
+        expect(errors[:ico_contact_email]).to eq ["cannot be blank if ICO contact phone not given"]
+        expect(errors[:ico_contact_phone]).to eq ["cannot be blank if ICO contact email not given"]
+        expect(errors[:ico_reference]).to eq ["cannot be blank"]
         expect(ico_complaint.object.transitions.where(event: "edit_case").count).to eq 0
       end
     end
@@ -503,10 +503,10 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
   # Utility methods
 
   def third_party_validations_found(errors)
-    expect(errors[:third_party_name]).to eq ["can't be blank if company name not given"]
-    expect(errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
-    expect(errors[:third_party_relationship]).to eq ["can't be blank"]
-    expect(errors[:postal_address]).to eq ["can't be blank"]
+    expect(errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
+    expect(errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
+    expect(errors[:third_party_relationship]).to eq ["cannot be blank"]
+    expect(errors[:postal_address]).to eq ["cannot be blank"]
   end
 
   def remains_on_step(step)

--- a/spec/controllers/cases/offender_sar_complaint_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_complaint_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
 
           it 'requires the original case is the type allowed for complaint case' do
             remains_on_step 'link-offender-sar-case'
-            expect(errors[:original_case]).to eq ["cannot link a Complaint case to a Complaint as a original case"]
+            expect(errors[:original_case]).to eq ["Original case must be Offender SAR"]
           end
         end
       end
@@ -144,7 +144,7 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
           context 'when complaint-type absent' do
             it 'requires complaint-type to be set' do
               remains_on_step 'complaint-type'
-              expect(errors[:complaint_type]).to eq ["can't be blank"]
+              expect(errors[:complaint_type]).to eq ["cannot be blank"]
             end
           end
           context 'when complaint-type present' do
@@ -198,14 +198,14 @@ RSpec.describe Cases::OffenderSarComplaintController, type: :controller do
         context 'when complaint-subtype absent' do
           it 'requires complaint-subtype to be set' do
             remains_on_step 'complaint-type'
-            expect(errors[:complaint_subtype]).to eq ["can't be blank"]
+            expect(errors[:complaint_subtype]).to eq ["cannot be blank"]
           end
         end
 
         context 'when priority absent' do
           it 'requires priority to be set' do
             remains_on_step 'complaint-type'
-            expect(errors[:priority]).to eq ["can't be blank"]
+            expect(errors[:priority]).to eq ["cannot be blank"]
           end
         end
       end

--- a/spec/controllers/cases/offender_sar_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_controller_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
         # contains logic to set required ones if missing
         it 'sets empty values and validates other fields' do
           remains_on_step 'subject-details'
-          expect(errors[:date_of_birth]).to eq ["can't be blank"]
+          expect(errors[:date_of_birth]).to eq ["cannot be blank"]
           expect(errors[:subject_type]).to eq ["cannot be blank"]
           expect(errors[:flag_as_high_profile]).to eq ["cannot be blank"]
         end

--- a/spec/controllers/cases/offender_sar_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_controller_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
         # contains logic to set required ones if missing
         it 'sets empty values and validates other fields' do
           remains_on_step 'subject-details'
-          expect(errors[:date_of_birth]).to eq ["cannot be blank"]
+          expect(errors[:date_of_birth]).to eq ["can't be blank"]
           expect(errors[:subject_type]).to eq ["cannot be blank"]
           expect(errors[:flag_as_high_profile]).to eq ["cannot be blank"]
         end

--- a/spec/controllers/cases/offender_sar_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_controller_spec.rb
@@ -102,8 +102,8 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
 
         it 'validates subject name and address' do
           remains_on_step 'subject-details'
-          expect(errors[:subject_full_name]).to eq ["can't be blank"]
-          expect(errors[:subject_address]).to eq ["can't be blank"]
+          expect(errors[:subject_full_name]).to eq ["cannot be blank"]
+          expect(errors[:subject_address]).to eq ["cannot be blank"]
         end
 
         # unset radio options and date fields are hard to validate
@@ -111,9 +111,9 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
         # contains logic to set required ones if missing
         it 'sets empty values and validates other fields' do
           remains_on_step 'subject-details'
-          expect(errors[:date_of_birth]).to eq ["can't be blank"]
-          expect(errors[:subject_type]).to eq ["can't be blank"]
-          expect(errors[:flag_as_high_profile]).to eq ["can't be blank"]
+          expect(errors[:date_of_birth]).to eq ["cannot be blank"]
+          expect(errors[:subject_type]).to eq ["cannot be blank"]
+          expect(errors[:flag_as_high_profile]).to eq ["cannot be blank"]
         end
       end
 
@@ -128,7 +128,7 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
 
           it 'requires third_party to be set' do
             remains_on_step 'requester-details'
-            expect(errors[:third_party]).to eq ["can't be blank"]
+            expect(errors[:third_party]).to eq ["cannot be blank"]
           end
         end
 
@@ -171,7 +171,7 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
 
           it 'requires recipient to be set' do
             remains_on_step 'recipient-details'
-            expect(errors[:recipient]).to eq ["can't be blank"]
+            expect(errors[:recipient]).to eq ["cannot be blank"]
           end
         end
 
@@ -210,7 +210,7 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
 
           it 'fails to be valid' do
             remains_on_step 'request-details'
-            expect(errors[:request_dated]).to eq ["can't be in the future."]
+            expect(errors[:request_dated]).to eq ["cannot be in the future."]
           end
         end
       end
@@ -226,7 +226,7 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
 
           it 'requires received date to be set' do
             remains_on_step 'date-received'
-            expect(errors[:received_date]).to eq ["can't be blank"]
+            expect(errors[:received_date]).to eq ["cannot be blank"]
           end
         end
 
@@ -245,7 +245,7 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
 
           it 'fails to be valid' do
             remains_on_step 'date-received'
-            expect(errors[:received_date]).to eq ["can't be in the future."]
+            expect(errors[:received_date]).to eq ["cannot be in the future."]
           end
         end
       end
@@ -354,10 +354,10 @@ RSpec.describe Cases::OffenderSarController, type: :controller do
   # Utility methods
 
   def third_party_validations_found(errors)
-    expect(errors[:third_party_name]).to eq ["can't be blank if company name not given"]
-    expect(errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
-    expect(errors[:third_party_relationship]).to eq ["can't be blank"]
-    expect(errors[:postal_address]).to eq ["can't be blank"]
+    expect(errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
+    expect(errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
+    expect(errors[:third_party_relationship]).to eq ["cannot be blank"]
+    expect(errors[:postal_address]).to eq ["cannot be blank"]
   end
 
   def remains_on_step(step)

--- a/spec/controllers/cases_controller/show_spec.rb
+++ b/spec/controllers/cases_controller/show_spec.rb
@@ -30,10 +30,10 @@ describe CasesController, type: :controller do
       sign_in responder
 
       get :show, params: { id: accepted_case.id },
-          flash:{"case_errors"=>{:message_text => ["can't be blank"]}}
+          flash:{"case_errors"=>{:message_text => ["cannot be blank"]}}
 
       expect(assigns(:case).errors.messages[:message_text].first)
-        .to eq("can't be blank")
+        .to eq("cannot be blank")
 
     end
 

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -111,10 +111,10 @@ RSpec.describe CasesController, type: :controller do
       sign_in responder
 
       get :show, params: { id: accepted_case.id },
-          flash:{"case_errors"=>{:message_text => ["can't be blank"]}}
+          flash:{"case_errors"=>{:message_text => ["cannot be blank"]}}
 
       expect(assigns(:case).errors.messages[:message_text].first)
-        .to eq("can't be blank")
+        .to eq("cannot be blank")
     end
 
     it 'syncs case transitions tracker for user' do

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe StatsController, type: :controller do
 
         it 'marks an error for missing correspondence type but  not report type' do
           post :create, params: params
-          expect(assigns(:report).errors[:correspondence_type]).to eq ["can't be blank"]
+          expect(assigns(:report).errors[:correspondence_type]).to eq ["cannot be blank"]
           expect(assigns(:report).errors[:report_type]).not_to be_present
         end
       end
@@ -218,7 +218,7 @@ RSpec.describe StatsController, type: :controller do
 
         it 'marks the report type as being in error' do
           post :create, params: params
-          expect(assigns(:report).errors[:report_type_id]).to eq ["can't be blank"]
+          expect(assigns(:report).errors[:report_type_id]).to eq ["cannot be blank"]
         end
       end
 

--- a/spec/features/admin/joining_teams_spec.rb
+++ b/spec/features/admin/joining_teams_spec.rb
@@ -39,7 +39,7 @@ feature 'joining business units' do
     teams_show_page.join_team_link.click
     expect(teams_join_page).to be_displayed(id: bu.id)
 
-    # Verify that teams with a special role can't be joined
+    # Verify that teams with a special role cannot be joined
     select("Operations")
     select("Press Office Directorate")
     expect(teams_join_page.find_row("Press Office")).not_to have_text "Join with this team"

--- a/spec/features/cases/foi/case_assignment_responding_spec.rb
+++ b/spec/features/cases/foi/case_assignment_responding_spec.rb
@@ -70,7 +70,7 @@ feature 'respond to responder assignment' do
     expect(page).
       to have_content('1 error prevented this form from being submitted')
     expect(page).
-      to have_content("Why are you rejecting this case? can't be blank")
+      to have_content("Why are you rejecting this case? cannot be blank")
   end
 
   scenario 'kilo tries to submit the form without selecting accept / reject' do

--- a/spec/features/cases/foi/case_assignment_responding_spec.rb
+++ b/spec/features/cases/foi/case_assignment_responding_spec.rb
@@ -70,7 +70,7 @@ feature 'respond to responder assignment' do
     expect(page).
       to have_content('1 error prevented this form from being submitted')
     expect(page).
-      to have_content("Why are you rejecting this case? cannot be blank")
+      to have_content("Why are you rejecting this case? can't be blank")
   end
 
   scenario 'kilo tries to submit the form without selecting accept / reject' do

--- a/spec/features/cases/foi/editing_case_closure_spec.rb
+++ b/spec/features/cases/foi/editing_case_closure_spec.rb
@@ -57,7 +57,7 @@ feature 'editing case closure information' do
     cases_show_page.load(id: kase.id)
     expect(cases_show_page.case_details).not_to have_edit_closure
     expect(cases_show_page.case_details)
-      .to have_text("This is an old case with closure details that can't be edited. If you need to edit this case let us know.")
+      .to have_text("This is an old case with closure details that cannot be edited. If you need to edit this case let us know.")
   end
 
   scenario 'responder views case details for FOI with old closure info', js: true do
@@ -69,6 +69,6 @@ feature 'editing case closure information' do
     cases_show_page.load(id: kase.id)
     expect(cases_show_page.case_details).not_to have_edit_closure
     expect(cases_show_page.case_details)
-        .not_to have_text("This is an old case with closure details that can't be edited. If you need to edit this case let us know.")
+        .not_to have_text("This is an old case with closure details that cannot be edited. If you need to edit this case let us know.")
   end
 end

--- a/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_editing_spec.rb
@@ -32,7 +32,7 @@ feature 'offender sar complaint case editing by a manager' do
     expect(cases_edit_offender_sar_complaint_page).to be_displayed
     expect(cases_edit_offender_sar_complaint_subject_details_page).to have_content("Full name of data subject")
     expect(cases_edit_offender_sar_complaint_subject_details_page).to have_content("What is the location of the data subject?")
-    expect(cases_edit_offender_sar_complaint_subject_details_page).to have_content("Subject full name can't be blank")
+    expect(cases_edit_offender_sar_complaint_subject_details_page).to have_content("Subject full name cannot be blank")
 
     cases_edit_offender_sar_complaint_subject_details_page.edit_name 'Bob Hope'
     click_on "Continue"

--- a/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
+++ b/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
@@ -77,7 +77,7 @@ feature 'respond to responder assignment' do
     expect(page).
       to have_content('1 error prevented this form from being submitted')
     expect(page).
-      to have_content("Why are you rejecting this case? can't be blank")
+      to have_content("Why are you rejecting this case? cannot be blank")
   end
 
   scenario 'kilo tries to submit the form without selecting accept / reject' do

--- a/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
+++ b/spec/features/cases/overturned_foi/accept_and_reject_spec.rb
@@ -77,7 +77,7 @@ feature 'respond to responder assignment' do
     expect(page).
       to have_content('1 error prevented this form from being submitted')
     expect(page).
-      to have_content("Why are you rejecting this case? cannot be blank")
+      to have_content("Why are you rejecting this case? can't be blank")
   end
 
   scenario 'kilo tries to submit the form without selecting accept / reject' do

--- a/spec/javascripts/modules/DropzoneSpec.js
+++ b/spec/javascripts/modules/DropzoneSpec.js
@@ -21,7 +21,7 @@ describe('Modules.Dropzone.js', function() {
 
     it('should change the default error messages',function() {
       expect(dropzone.dropzone.options.dictFileTooBig)
-        .toEqual('File is too big. Max file size is {{maxFilesize}}MB. We can\'t upload this file.')
+        .toEqual('File is too big. Max file size is {{maxFilesize}}MB. We cannot upload this file.')
     })
   })
 });

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Case::Base, type: :model do
         it 'is not valid' do
           closed_case.info_held_status = nil
           expect(closed_case).not_to be_valid
-          expect(closed_case.errors[:info_held_status]).to eq ["can't be blank"]
+          expect(closed_case.errors[:info_held_status]).to eq ["cannot be blank"]
         end
       end
     end
@@ -235,7 +235,7 @@ RSpec.describe Case::Base, type: :model do
 
   describe '#type' do
     it { should validate_exclusion_of(:type).in_array(['Case'])
-                    .with_message("Case type can't be blank")}
+                    .with_message("Case type cannot be blank")}
   end
 
   describe '#received_date' do
@@ -522,7 +522,7 @@ RSpec.describe Case::Base, type: :model do
       kase = build(:case, related_cases: [linked_case])
       expect(kase).not_to be_valid
       expect(kase.errors[:related_cases])
-        .to eq ["can't link a FOI case to a FOI as a related case"]
+        .to eq ["cannot link a FOI case to a FOI as a related case"]
     end
   end
 

--- a/spec/models/case/ico/base_spec.rb
+++ b/spec/models/case/ico/base_spec.rb
@@ -155,7 +155,7 @@ describe Case::ICO::Base do
       ico = build(:ico_foi_case, original_case: linked_case)
       expect(ico).not_to be_valid
       expect(ico.errors[:original_case])
-        .to eq ["can't link a ICO Appeal - FOI case to a ICO Appeal - FOI as a original case"]
+        .to eq ["cannot link a ICO Appeal - FOI case to a ICO Appeal - FOI as a original case"]
     end
 
     it "validates that a case isn't both original and related" do
@@ -170,7 +170,7 @@ describe Case::ICO::Base do
       ico = create(:ico_foi_case)
       ico.original_case = nil
       ico.valid?
-      expect(ico.errors[:original_case]).to eq ["can't be blank"]
+      expect(ico.errors[:original_case]).to eq ["cannot be blank"]
     end
   end
 
@@ -238,7 +238,7 @@ describe Case::ICO::Base do
       kase.received_date = Date.today + 1.day
       expect(kase).not_to be_valid
       expect(kase.errors[:received_date])
-        .to eq ["can't be in the future."]
+        .to eq ["cannot be in the future."]
     end
   end
 

--- a/spec/models/case/ico/base_spec.rb
+++ b/spec/models/case/ico/base_spec.rb
@@ -170,7 +170,7 @@ describe Case::ICO::Base do
       ico = create(:ico_foi_case)
       ico.original_case = nil
       ico.valid?
-      expect(ico.errors[:original_case]).to eq ["cannot be blank"]
+      expect(ico.errors[:original_case]).to eq ["can't be blank"]
     end
   end
 

--- a/spec/models/case/overturned_ico/base_spec.rb
+++ b/spec/models/case/overturned_ico/base_spec.rb
@@ -47,7 +47,7 @@ describe Case::OverturnedICO::Base do
       it 'is invalid if no email address specified' do
         overturned_ico.email = nil
         expect(overturned_ico).not_to be_valid
-        expect(overturned_ico.errors[:email]).to eq ["can't be blank"]
+        expect(overturned_ico.errors[:email]).to eq ["cannot be blank"]
       end
     end
 
@@ -55,7 +55,7 @@ describe Case::OverturnedICO::Base do
       it 'is invalid if no postal address specified' do
         overturned_ico.reply_method = 'send_by_post'
         expect(overturned_ico).not_to be_valid
-        expect(overturned_ico.errors[:postal_address]).to eq ["can't be blank"]
+        expect(overturned_ico.errors[:postal_address]).to eq ["cannot be blank"]
       end
     end
   end
@@ -158,7 +158,7 @@ describe Case::OverturnedICO::Base do
     it 'is not valid if not set' do
       overturned_ico.ico_officer_name = ''
       expect(overturned_ico).not_to be_valid
-      expect(overturned_ico.errors[:ico_officer_name]).to include("can't be blank")
+      expect(overturned_ico.errors[:ico_officer_name]).to include("cannot be blank")
     end
 
   end

--- a/spec/models/case/overturned_ico/foi_spec.rb
+++ b/spec/models/case/overturned_ico/foi_spec.rb
@@ -94,13 +94,13 @@ describe Case::OverturnedICO::FOI do
     context 'received_date' do
       it 'errors if blank' do
         expect(new_case).not_to be_valid
-        expect(new_case.errors[:received_date]).to eq ["can't be blank"]
+        expect(new_case.errors[:received_date]).to eq ["cannot be blank"]
       end
 
       it 'errors if in the future' do
         new_case.received_date = 1.day.from_now
         expect(new_case).not_to be_valid
-        expect(new_case.errors[:received_date]).to eq ["can't be in the future"]
+        expect(new_case.errors[:received_date]).to eq ["cannot be in the future"]
       end
 
       context 'too far in the past' do
@@ -139,7 +139,7 @@ describe Case::OverturnedICO::FOI do
     context 'external_deadline' do
       it 'errors if blank' do
         expect(new_case).not_to be_valid
-        expect(new_case.errors[:external_deadline]).to eq ["can't be blank"]
+        expect(new_case.errors[:external_deadline]).to eq ["cannot be blank"]
       end
 
       context 'in the past' do
@@ -184,7 +184,7 @@ describe Case::OverturnedICO::FOI do
       context 'blank' do
         it 'errors' do
           expect(new_case).not_to be_valid
-          expect(new_case.errors[:original_ico_appeal]).to eq ["can't be blank"]
+          expect(new_case.errors[:original_ico_appeal]).to eq ["cannot be blank"]
         end
       end
 
@@ -226,7 +226,7 @@ describe Case::OverturnedICO::FOI do
 
         it 'errors' do
           expect(new_case).not_to be_valid
-          expect(new_case.errors[:original_case]).to eq ["can't be blank"]
+          expect(new_case.errors[:original_case]).to eq ["cannot be blank"]
         end
       end
 
@@ -245,7 +245,7 @@ describe Case::OverturnedICO::FOI do
             ico_foi = create :ico_foi_case
             new_case.original_case = ico_foi
             new_case.valid?
-            expect(new_case.errors[:original_case]).to eq ["can't link a Overturned ICO appeal for FOI case to a ICO Appeal - FOI as a original case"]
+            expect(new_case.errors[:original_case]).to eq ["cannot link a Overturned ICO appeal for FOI case to a ICO Appeal - FOI as a original case"]
           end
         end
 
@@ -254,7 +254,7 @@ describe Case::OverturnedICO::FOI do
             sar = create :sar_case
             new_case.original_case = sar
             new_case.valid?
-            expect(new_case.errors[:original_case]).to eq ["can't link a Overturned ICO appeal for FOI case to a Non-offender SAR as a original case"]
+            expect(new_case.errors[:original_case]).to eq ["cannot link a Overturned ICO appeal for FOI case to a Non-offender SAR as a original case"]
           end
         end
       end

--- a/spec/models/case/overturned_ico/sar_spec.rb
+++ b/spec/models/case/overturned_ico/sar_spec.rb
@@ -83,13 +83,13 @@ describe Case::OverturnedICO::SAR do
     context 'received_date' do
       it 'errors if blank' do
         expect(new_case).not_to be_valid
-        expect(new_case.errors[:received_date]).to eq ["can't be blank"]
+        expect(new_case.errors[:received_date]).to eq ["cannot be blank"]
       end
 
       it 'errors if in the future' do
         new_case.received_date = 1.day.from_now
         expect(new_case).not_to be_valid
-        expect(new_case.errors[:received_date]).to eq ["can't be in the future"]
+        expect(new_case.errors[:received_date]).to eq ["cannot be in the future"]
       end
 
       context 'too far in the past' do
@@ -128,7 +128,7 @@ describe Case::OverturnedICO::SAR do
     context 'external_deadline' do
       it 'errors if blank' do
         expect(new_case).not_to be_valid
-        expect(new_case.errors[:external_deadline]).to eq ["can't be blank"]
+        expect(new_case.errors[:external_deadline]).to eq ["cannot be blank"]
       end
 
       context 'in the past' do
@@ -136,7 +136,7 @@ describe Case::OverturnedICO::SAR do
           it 'errors' do
             new_case.external_deadline = 1.day.ago
             expect(new_case).not_to be_valid
-            expect(new_case.errors[:external_deadline]).to eq ["can't be in the past"]
+            expect(new_case.errors[:external_deadline]).to eq ["cannot be in the past"]
           end
         end
 
@@ -173,7 +173,7 @@ describe Case::OverturnedICO::SAR do
       context 'blank' do
         it 'errors' do
           expect(new_case).not_to be_valid
-          expect(new_case.errors[:original_ico_appeal]).to eq ["can't be blank"]
+          expect(new_case.errors[:original_ico_appeal]).to eq ["cannot be blank"]
         end
       end
 
@@ -215,7 +215,7 @@ describe Case::OverturnedICO::SAR do
 
         it 'errors' do
           expect(new_case).not_to be_valid
-          expect(new_case.errors[:original_case]).to eq ["can't be blank"]
+          expect(new_case.errors[:original_case]).to eq ["cannot be blank"]
         end
       end
 
@@ -234,7 +234,7 @@ describe Case::OverturnedICO::SAR do
             ico_sar = create :ico_sar_case
             new_case.original_case = ico_sar
             new_case.valid?
-            expect(new_case.errors[:original_case]).to eq ["can't link a Overturned ICO appeal for non-offender SAR case to a ICO Appeal - SAR as a original case"]
+            expect(new_case.errors[:original_case]).to eq ["cannot link a Overturned ICO appeal for non-offender SAR case to a ICO Appeal - SAR as a original case"]
           end
         end
 
@@ -243,7 +243,7 @@ describe Case::OverturnedICO::SAR do
             foi = create :case
             new_case.original_case = foi
             new_case.valid?
-            expect(new_case.errors[:original_case]).to eq ["can't link a Overturned ICO appeal for non-offender SAR case to a FOI as a original case"]
+            expect(new_case.errors[:original_case]).to eq ["cannot link a Overturned ICO appeal for non-offender SAR case to a FOI as a original case"]
           end
         end
       end

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -38,7 +38,7 @@ describe Case::SAR::InternalReview do
       kase = build :sar_internal_review, subject_full_name: nil, subject_type: nil, third_party: nil
 
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_full_name]).to eq(["can't be blank"])
+      expect(kase.errors[:subject_full_name]).to eq(["cannot be blank"])
       expect(kase.errors[:third_party]).to eq(["Please choose yes or no"])
     end
   end
@@ -69,7 +69,7 @@ describe Case::SAR::InternalReview do
       it 'errors' do
         kase = build(:sar_internal_review, subject_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:subject_type]).to eq ["can't be blank"]
+        expect(kase.errors[:subject_type]).to eq ["cannot be blank"]
       end
     end
   end
@@ -83,7 +83,7 @@ describe Case::SAR::InternalReview do
     it 'validates presence of email when reply is to be sent by email' do
       kase = build :sar_internal_review, reply_method: :send_by_email, email: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:email]).to eq ["can't be blank"]
+      expect(kase.errors[:email]).to eq ["cannot be blank"]
     end
   end
 
@@ -91,7 +91,7 @@ describe Case::SAR::InternalReview do
     it 'validates presence of postal address when reply is to be sent by post' do
       kase = build :sar_internal_review, reply_method: :send_by_post, postal_address: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:postal_address]).to eq ["can't be blank"]
+      expect(kase.errors[:postal_address]).to eq ["cannot be blank"]
     end
   end
 
@@ -100,7 +100,7 @@ describe Case::SAR::InternalReview do
       it 'validates presence of name when third party is true' do
         kase = build :sar_internal_review, third_party: true, name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:name]).to eq ["can't be blank"]
+        expect(kase.errors[:name]).to eq ["cannot be blank"]
       end
 
       it 'does not validates presence of name when third party is false' do
@@ -113,7 +113,7 @@ describe Case::SAR::InternalReview do
       it 'must be persent when thrid party is true' do
         kase = build :sar_internal_review, third_party: true, third_party_relationship: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
       end
 
       it 'does not validates presence of third party relationship when third party is false' do
@@ -128,7 +128,7 @@ describe Case::SAR::InternalReview do
       kase = build :sar_internal_review, uploaded_request_files: [], message: ''
       expect(kase).not_to be_valid
       expect(kase.errors[:message])
-        .to eq ["can't be blank if no request files attached"]
+        .to eq ["cannot be blank if no request files attached"]
     end
 
     it 'validates presence if attached request files is missing on update' do
@@ -137,7 +137,7 @@ describe Case::SAR::InternalReview do
       kase.update_attributes(message: '')
       expect(kase).not_to be_valid
       expect(kase.errors[:message])
-        .to eq ["can't be blank if no request files attached"]
+        .to eq ["cannot be blank if no request files attached"]
     end
 
     it 'can be empty on create if uploaded_request_files is present' do
@@ -170,7 +170,7 @@ describe Case::SAR::InternalReview do
       kase = build :sar_internal_review, uploaded_request_files: [], message: ''
       expect(kase).not_to be_valid
       expect(kase.errors[:uploaded_request_files])
-        .to eq ["can't be blank if no case details entered"]
+        .to eq ["cannot be blank if no case details entered"]
     end
 
     it 'does validates presence if message is present' do

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -38,7 +38,7 @@ describe Case::SAR::InternalReview do
       kase = build :sar_internal_review, subject_full_name: nil, subject_type: nil, third_party: nil
 
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_full_name]).to eq(["can't be blank"])
+      expect(kase.errors[:subject_full_name]).to eq(["cannot be blank"])
       expect(kase.errors[:third_party]).to eq(["Please choose yes or no"])
     end
   end
@@ -69,7 +69,7 @@ describe Case::SAR::InternalReview do
       it 'errors' do
         kase = build(:sar_internal_review, subject_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:subject_type]).to eq ["can't be blank"]
+        expect(kase.errors[:subject_type]).to eq ["cannot be blank"]
       end
     end
   end
@@ -83,7 +83,7 @@ describe Case::SAR::InternalReview do
     it 'validates presence of email when reply is to be sent by email' do
       kase = build :sar_internal_review, reply_method: :send_by_email, email: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:email]).to eq ["can't be blank"]
+      expect(kase.errors[:email]).to eq ["cannot be blank"]
     end
   end
 
@@ -91,7 +91,7 @@ describe Case::SAR::InternalReview do
     it 'validates presence of postal address when reply is to be sent by post' do
       kase = build :sar_internal_review, reply_method: :send_by_post, postal_address: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:postal_address]).to eq ["can't be blank"]
+      expect(kase.errors[:postal_address]).to eq ["cannot be blank"]
     end
   end
 
@@ -100,7 +100,7 @@ describe Case::SAR::InternalReview do
       it 'validates presence of name when third party is true' do
         kase = build :sar_internal_review, third_party: true, name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:name]).to eq ["can't be blank"]
+        expect(kase.errors[:name]).to eq ["cannot be blank"]
       end
 
       it 'does not validates presence of name when third party is false' do
@@ -113,7 +113,7 @@ describe Case::SAR::InternalReview do
       it 'must be persent when thrid party is true' do
         kase = build :sar_internal_review, third_party: true, third_party_relationship: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
       end
 
       it 'does not validates presence of third party relationship when third party is false' do

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -38,7 +38,7 @@ describe Case::SAR::InternalReview do
       kase = build :sar_internal_review, subject_full_name: nil, subject_type: nil, third_party: nil
 
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_full_name]).to eq(["cannot be blank"])
+      expect(kase.errors[:subject_full_name]).to eq(["can't be blank"])
       expect(kase.errors[:third_party]).to eq(["Please choose yes or no"])
     end
   end
@@ -69,7 +69,7 @@ describe Case::SAR::InternalReview do
       it 'errors' do
         kase = build(:sar_internal_review, subject_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:subject_type]).to eq ["cannot be blank"]
+        expect(kase.errors[:subject_type]).to eq ["can't be blank"]
       end
     end
   end
@@ -83,7 +83,7 @@ describe Case::SAR::InternalReview do
     it 'validates presence of email when reply is to be sent by email' do
       kase = build :sar_internal_review, reply_method: :send_by_email, email: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:email]).to eq ["cannot be blank"]
+      expect(kase.errors[:email]).to eq ["can't be blank"]
     end
   end
 
@@ -91,7 +91,7 @@ describe Case::SAR::InternalReview do
     it 'validates presence of postal address when reply is to be sent by post' do
       kase = build :sar_internal_review, reply_method: :send_by_post, postal_address: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:postal_address]).to eq ["cannot be blank"]
+      expect(kase.errors[:postal_address]).to eq ["can't be blank"]
     end
   end
 
@@ -100,7 +100,7 @@ describe Case::SAR::InternalReview do
       it 'validates presence of name when third party is true' do
         kase = build :sar_internal_review, third_party: true, name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:name]).to eq ["cannot be blank"]
+        expect(kase.errors[:name]).to eq ["can't be blank"]
       end
 
       it 'does not validates presence of name when third party is false' do
@@ -113,7 +113,7 @@ describe Case::SAR::InternalReview do
       it 'must be persent when thrid party is true' do
         kase = build :sar_internal_review, third_party: true, third_party_relationship: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
       end
 
       it 'does not validates presence of third party relationship when third party is false' do

--- a/spec/models/case/sar/offender_complaint_spec.rb
+++ b/spec/models/case/sar/offender_complaint_spec.rb
@@ -39,7 +39,7 @@ describe Case::SAR::OffenderComplaint do
       kase = build :offender_sar_complaint, subject_full_name: nil, subject_type: nil, third_party: nil, flag_as_high_profile: nil
 
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_full_name]).to eq(["can't be blank"])
+      expect(kase.errors[:subject_full_name]).to eq(["cannot be blank"])
       expect(kase.errors[:third_party]).to eq(["cannot be blank"])
     end
   end
@@ -49,7 +49,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, complaint_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:complaint_type]).to eq ["can't be blank"]
+        expect(kase.errors[:complaint_type]).to eq ["cannot be blank"]
       end
     end
 
@@ -75,7 +75,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, priority: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:priority]).to eq ["can't be blank"]
+        expect(kase.errors[:priority]).to eq ["cannot be blank"]
       end
     end
 
@@ -118,7 +118,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, complaint_subtype: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:complaint_subtype]).to eq ["can't be blank"]
+        expect(kase.errors[:complaint_subtype]).to eq ["cannot be blank"]
       end
     end
 
@@ -164,7 +164,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, subject_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:subject_type]).to eq ["can't be blank"]
+        expect(kase.errors[:subject_type]).to eq ["cannot be blank"]
       end
     end
   end
@@ -195,7 +195,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, recipient: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:recipient]).to eq ["can't be blank"]
+        expect(kase.errors[:recipient]).to eq ["cannot be blank"]
       end
     end
   end
@@ -212,7 +212,7 @@ describe Case::SAR::OffenderComplaint do
       it 'validates presence of postal address when recipient is third party' do
         kase = build :offender_sar_complaint, :third_party, postal_address: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:postal_address]).to eq ["can't be blank"]
+        expect(kase.errors[:postal_address]).to eq ["cannot be blank"]
       end
     end
   end
@@ -239,7 +239,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, date_of_birth: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_of_birth]).to eq ["can't be in the future."]
+        expect(kase.errors[:date_of_birth]).to eq ["cannot be in the future."]
       end
     end
 
@@ -247,7 +247,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, date_of_birth: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_of_birth]).to eq ["can't be blank"]
+        expect(kase.errors[:date_of_birth]).to eq ["cannot be blank"]
       end
     end
   end
@@ -275,7 +275,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, received_date: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:received_date]).to eq ["can't be in the future."]
+        expect(kase.errors[:received_date]).to eq ["cannot be in the future."]
       end
     end
   end
@@ -293,7 +293,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, request_dated: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:request_dated]).to eq ["can't be in the future."]
+        expect(kase.errors[:request_dated]).to eq ["cannot be in the future."]
       end
     end
   end
@@ -337,16 +337,16 @@ describe Case::SAR::OffenderComplaint do
       it 'validates third party names when third party is true' do
         kase = build :offender_sar_complaint, :third_party, third_party_name: '', third_party_company_name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_name]).to eq ["can't be blank if company name not given"]
-        expect(kase.errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
+        expect(kase.errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
+        expect(kase.errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
       end
 
       it 'validates third party names when recipient is third party' do
         kase = build :offender_sar_complaint, third_party: false, third_party_name: '',
                       third_party_company_name: '', recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_name]).to eq ["can't be blank if company name not given"]
-        expect(kase.errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
+        expect(kase.errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
+        expect(kase.errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
       end
 
       it 'does not validate third_party names when ecipient is not third party too' do
@@ -361,14 +361,14 @@ describe Case::SAR::OffenderComplaint do
       it 'must be present when thrid party is true' do
         kase = build :offender_sar_complaint, third_party: true, third_party_relationship: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
       end
 
       it 'must be present when third party is false but recipient is third party' do
         kase = build :offender_sar_complaint, third_party: false, third_party_relationship: '',
                       recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
       end
 
       it 'does not validates presence of third party relationship when recipient is not third party' do
@@ -592,7 +592,7 @@ describe Case::SAR::OffenderComplaint do
     it 'validates presence of subject address' do
       kase = build :offender_sar_complaint, subject_address: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_address]).to eq ["can't be blank"]
+      expect(kase.errors[:subject_address]).to eq ["cannot be blank"]
     end
   end
 
@@ -601,7 +601,7 @@ describe Case::SAR::OffenderComplaint do
       it 'must be present when ico is true' do
         kase = build :offender_sar_complaint, complaint_type: 'ico_complaint', ico_contact_name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:ico_contact_name]).to eq ["can't be blank"]
+        expect(kase.errors[:ico_contact_name]).to eq ["cannot be blank"]
       end
 
       it 'is not required when litigation or standard complaint' do
@@ -739,7 +739,7 @@ describe Case::SAR::OffenderComplaint do
       complaint = build(:offender_sar_complaint, original_case: linked_case)
       expect(complaint).not_to be_valid
       expect(complaint.errors[:original_case])
-        .to eq ["can't link a Complaint case to a Complaint as a original case"]
+        .to eq ["Original case must be Offender SAR"]
     end
 
     it "validates that a case isn't both original and related" do
@@ -754,7 +754,7 @@ describe Case::SAR::OffenderComplaint do
       complaint = create(:offender_sar_complaint)
       complaint.original_case = nil
       complaint.valid?
-      expect(complaint.errors[:original_case]).to eq ["can't be blank"]
+      expect(complaint.errors[:original_case]).to eq ["cannot be blank"]
     end
   end
 
@@ -781,7 +781,7 @@ describe Case::SAR::OffenderComplaint do
       complaint.valid?
       expect(complaint).not_to be_valid
       expect(complaint.errors[:related_cases])
-      .to eq ["can't link a Complaint case to a Offender SAR as a related case"]
+      .to eq ["cannot link a Complaint case to a Offender SAR as a related case"]
     end
   end
 

--- a/spec/models/case/sar/offender_complaint_spec.rb
+++ b/spec/models/case/sar/offender_complaint_spec.rb
@@ -39,8 +39,8 @@ describe Case::SAR::OffenderComplaint do
       kase = build :offender_sar_complaint, subject_full_name: nil, subject_type: nil, third_party: nil, flag_as_high_profile: nil
 
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_full_name]).to eq(["can't be blank"])
-      expect(kase.errors[:third_party]).to eq(["can't be blank"])
+      expect(kase.errors[:subject_full_name]).to eq(["cannot be blank"])
+      expect(kase.errors[:third_party]).to eq(["cannot be blank"])
     end
   end
 
@@ -49,7 +49,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, complaint_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:complaint_type]).to eq ["can't be blank"]
+        expect(kase.errors[:complaint_type]).to eq ["cannot be blank"]
       end
     end
 
@@ -75,7 +75,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, priority: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:priority]).to eq ["can't be blank"]
+        expect(kase.errors[:priority]).to eq ["cannot be blank"]
       end
     end
 
@@ -118,7 +118,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, complaint_subtype: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:complaint_subtype]).to eq ["can't be blank"]
+        expect(kase.errors[:complaint_subtype]).to eq ["cannot be blank"]
       end
     end
 
@@ -164,7 +164,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, subject_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:subject_type]).to eq ["can't be blank"]
+        expect(kase.errors[:subject_type]).to eq ["cannot be blank"]
       end
     end
   end
@@ -195,7 +195,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, recipient: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:recipient]).to eq ["can't be blank"]
+        expect(kase.errors[:recipient]).to eq ["cannot be blank"]
       end
     end
   end
@@ -212,7 +212,7 @@ describe Case::SAR::OffenderComplaint do
       it 'validates presence of postal address when recipient is third party' do
         kase = build :offender_sar_complaint, :third_party, postal_address: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:postal_address]).to eq ["can't be blank"]
+        expect(kase.errors[:postal_address]).to eq ["cannot be blank"]
       end
     end
   end
@@ -239,7 +239,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, date_of_birth: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_of_birth]).to eq ["can't be in the future."]
+        expect(kase.errors[:date_of_birth]).to eq ["cannot be in the future."]
       end
     end
 
@@ -247,7 +247,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, date_of_birth: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_of_birth]).to eq ["can't be blank"]
+        expect(kase.errors[:date_of_birth]).to eq ["cannot be blank"]
       end
     end
   end
@@ -275,7 +275,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, received_date: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:received_date]).to eq ["can't be in the future."]
+        expect(kase.errors[:received_date]).to eq ["cannot be in the future."]
       end
     end
   end
@@ -293,7 +293,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, request_dated: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:request_dated]).to eq ["can't be in the future."]
+        expect(kase.errors[:request_dated]).to eq ["cannot be in the future."]
       end
     end
   end
@@ -337,16 +337,16 @@ describe Case::SAR::OffenderComplaint do
       it 'validates third party names when third party is true' do
         kase = build :offender_sar_complaint, :third_party, third_party_name: '', third_party_company_name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_name]).to eq ["can't be blank if company name not given"]
-        expect(kase.errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
+        expect(kase.errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
+        expect(kase.errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
       end
 
       it 'validates third party names when recipient is third party' do
         kase = build :offender_sar_complaint, third_party: false, third_party_name: '',
                       third_party_company_name: '', recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_name]).to eq ["can't be blank if company name not given"]
-        expect(kase.errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
+        expect(kase.errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
+        expect(kase.errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
       end
 
       it 'does not validate third_party names when ecipient is not third party too' do
@@ -361,14 +361,14 @@ describe Case::SAR::OffenderComplaint do
       it 'must be present when thrid party is true' do
         kase = build :offender_sar_complaint, third_party: true, third_party_relationship: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
       end
 
       it 'must be present when third party is false but recipient is third party' do
         kase = build :offender_sar_complaint, third_party: false, third_party_relationship: '',
                       recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
       end
 
       it 'does not validates presence of third party relationship when recipient is not third party' do
@@ -592,7 +592,7 @@ describe Case::SAR::OffenderComplaint do
     it 'validates presence of subject address' do
       kase = build :offender_sar_complaint, subject_address: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_address]).to eq ["can't be blank"]
+      expect(kase.errors[:subject_address]).to eq ["cannot be blank"]
     end
   end
 
@@ -601,7 +601,7 @@ describe Case::SAR::OffenderComplaint do
       it 'must be present when ico is true' do
         kase = build :offender_sar_complaint, complaint_type: 'ico_complaint', ico_contact_name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:ico_contact_name]).to eq ["can't be blank"]
+        expect(kase.errors[:ico_contact_name]).to eq ["cannot be blank"]
       end
 
       it 'is not required when litigation or standard complaint' do
@@ -739,7 +739,7 @@ describe Case::SAR::OffenderComplaint do
       complaint = build(:offender_sar_complaint, original_case: linked_case)
       expect(complaint).not_to be_valid
       expect(complaint.errors[:original_case])
-        .to eq ["can't link a Complaint case to a Complaint as a original case"]
+        .to eq ["cannot link a Complaint case to a Complaint as a original case"]
     end
 
     it "validates that a case isn't both original and related" do
@@ -754,7 +754,7 @@ describe Case::SAR::OffenderComplaint do
       complaint = create(:offender_sar_complaint)
       complaint.original_case = nil
       complaint.valid?
-      expect(complaint.errors[:original_case]).to eq ["can't be blank"]
+      expect(complaint.errors[:original_case]).to eq ["cannot be blank"]
     end
   end
 
@@ -781,7 +781,7 @@ describe Case::SAR::OffenderComplaint do
       complaint.valid?
       expect(complaint).not_to be_valid
       expect(complaint.errors[:related_cases])
-      .to eq ["can't link a Complaint case to a Offender SAR as a related case"]
+      .to eq ["cannot link a Complaint case to a Offender SAR as a related case"]
     end
   end
 

--- a/spec/models/case/sar/offender_complaint_spec.rb
+++ b/spec/models/case/sar/offender_complaint_spec.rb
@@ -39,7 +39,7 @@ describe Case::SAR::OffenderComplaint do
       kase = build :offender_sar_complaint, subject_full_name: nil, subject_type: nil, third_party: nil, flag_as_high_profile: nil
 
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_full_name]).to eq(["cannot be blank"])
+      expect(kase.errors[:subject_full_name]).to eq(["can't be blank"])
       expect(kase.errors[:third_party]).to eq(["cannot be blank"])
     end
   end
@@ -49,7 +49,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, complaint_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:complaint_type]).to eq ["cannot be blank"]
+        expect(kase.errors[:complaint_type]).to eq ["can't be blank"]
       end
     end
 
@@ -75,7 +75,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, priority: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:priority]).to eq ["cannot be blank"]
+        expect(kase.errors[:priority]).to eq ["can't be blank"]
       end
     end
 
@@ -118,7 +118,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, complaint_subtype: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:complaint_subtype]).to eq ["cannot be blank"]
+        expect(kase.errors[:complaint_subtype]).to eq ["can't be blank"]
       end
     end
 
@@ -164,7 +164,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, subject_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:subject_type]).to eq ["cannot be blank"]
+        expect(kase.errors[:subject_type]).to eq ["can't be blank"]
       end
     end
   end
@@ -195,7 +195,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, recipient: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:recipient]).to eq ["cannot be blank"]
+        expect(kase.errors[:recipient]).to eq ["can't be blank"]
       end
     end
   end
@@ -212,7 +212,7 @@ describe Case::SAR::OffenderComplaint do
       it 'validates presence of postal address when recipient is third party' do
         kase = build :offender_sar_complaint, :third_party, postal_address: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:postal_address]).to eq ["cannot be blank"]
+        expect(kase.errors[:postal_address]).to eq ["can't be blank"]
       end
     end
   end
@@ -239,7 +239,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, date_of_birth: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_of_birth]).to eq ["cannot be in the future."]
+        expect(kase.errors[:date_of_birth]).to eq ["can't be in the future."]
       end
     end
 
@@ -247,7 +247,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, date_of_birth: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_of_birth]).to eq ["cannot be blank"]
+        expect(kase.errors[:date_of_birth]).to eq ["can't be blank"]
       end
     end
   end
@@ -275,7 +275,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, received_date: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:received_date]).to eq ["cannot be in the future."]
+        expect(kase.errors[:received_date]).to eq ["can't be in the future."]
       end
     end
   end
@@ -293,7 +293,7 @@ describe Case::SAR::OffenderComplaint do
       it 'errors' do
         kase = build(:offender_sar_complaint, request_dated: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:request_dated]).to eq ["cannot be in the future."]
+        expect(kase.errors[:request_dated]).to eq ["can't be in the future."]
       end
     end
   end
@@ -337,16 +337,16 @@ describe Case::SAR::OffenderComplaint do
       it 'validates third party names when third party is true' do
         kase = build :offender_sar_complaint, :third_party, third_party_name: '', third_party_company_name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
-        expect(kase.errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
+        expect(kase.errors[:third_party_name]).to eq ["can't be blank if company name not given"]
+        expect(kase.errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
       end
 
       it 'validates third party names when recipient is third party' do
         kase = build :offender_sar_complaint, third_party: false, third_party_name: '',
                       third_party_company_name: '', recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
-        expect(kase.errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
+        expect(kase.errors[:third_party_name]).to eq ["can't be blank if company name not given"]
+        expect(kase.errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
       end
 
       it 'does not validate third_party names when ecipient is not third party too' do
@@ -361,14 +361,14 @@ describe Case::SAR::OffenderComplaint do
       it 'must be present when thrid party is true' do
         kase = build :offender_sar_complaint, third_party: true, third_party_relationship: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
       end
 
       it 'must be present when third party is false but recipient is third party' do
         kase = build :offender_sar_complaint, third_party: false, third_party_relationship: '',
                       recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
       end
 
       it 'does not validates presence of third party relationship when recipient is not third party' do
@@ -592,7 +592,7 @@ describe Case::SAR::OffenderComplaint do
     it 'validates presence of subject address' do
       kase = build :offender_sar_complaint, subject_address: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_address]).to eq ["cannot be blank"]
+      expect(kase.errors[:subject_address]).to eq ["can't be blank"]
     end
   end
 
@@ -601,7 +601,7 @@ describe Case::SAR::OffenderComplaint do
       it 'must be present when ico is true' do
         kase = build :offender_sar_complaint, complaint_type: 'ico_complaint', ico_contact_name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:ico_contact_name]).to eq ["cannot be blank"]
+        expect(kase.errors[:ico_contact_name]).to eq ["can't be blank"]
       end
 
       it 'is not required when litigation or standard complaint' do
@@ -739,7 +739,7 @@ describe Case::SAR::OffenderComplaint do
       complaint = build(:offender_sar_complaint, original_case: linked_case)
       expect(complaint).not_to be_valid
       expect(complaint.errors[:original_case])
-        .to eq ["cannot link a Complaint case to a Complaint as a original case"]
+        .to eq ["can't link a Complaint case to a Complaint as a original case"]
     end
 
     it "validates that a case isn't both original and related" do
@@ -754,7 +754,7 @@ describe Case::SAR::OffenderComplaint do
       complaint = create(:offender_sar_complaint)
       complaint.original_case = nil
       complaint.valid?
-      expect(complaint.errors[:original_case]).to eq ["cannot be blank"]
+      expect(complaint.errors[:original_case]).to eq ["can't be blank"]
     end
   end
 
@@ -781,7 +781,7 @@ describe Case::SAR::OffenderComplaint do
       complaint.valid?
       expect(complaint).not_to be_valid
       expect(complaint.errors[:related_cases])
-      .to eq ["cannot link a Complaint case to a Offender SAR as a related case"]
+      .to eq ["can't link a Complaint case to a Offender SAR as a related case"]
     end
   end
 

--- a/spec/models/case/sar/offender_spec.rb
+++ b/spec/models/case/sar/offender_spec.rb
@@ -46,8 +46,8 @@ describe Case::SAR::Offender do
       kase = build :offender_sar_case, subject_full_name: nil, subject_type: nil, third_party: nil, flag_as_high_profile: nil
 
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_full_name]).to eq(["can't be blank"])
-      expect(kase.errors[:third_party]).to eq(["can't be blank"])
+      expect(kase.errors[:subject_full_name]).to eq(["cannot be blank"])
+      expect(kase.errors[:third_party]).to eq(["cannot be blank"])
     end
   end
 
@@ -98,7 +98,7 @@ describe Case::SAR::Offender do
       it 'errors' do
         kase = build(:offender_sar_case, subject_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:subject_type]).to eq ["can't be blank"]
+        expect(kase.errors[:subject_type]).to eq ["cannot be blank"]
       end
     end
   end
@@ -129,7 +129,7 @@ describe Case::SAR::Offender do
       it 'errors' do
         kase = build(:offender_sar_case, recipient: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:recipient]).to eq ["can't be blank"]
+        expect(kase.errors[:recipient]).to eq ["cannot be blank"]
       end
     end
   end
@@ -146,7 +146,7 @@ describe Case::SAR::Offender do
       it 'validates presence of postal address when recipient is third party' do
         kase = build :offender_sar_case, :third_party, postal_address: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:postal_address]).to eq ["can't be blank"]
+        expect(kase.errors[:postal_address]).to eq ["cannot be blank"]
       end
     end
   end
@@ -173,7 +173,7 @@ describe Case::SAR::Offender do
       it 'errors' do
         kase = build(:offender_sar_case, date_of_birth: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_of_birth]).to eq ["can't be in the future."]
+        expect(kase.errors[:date_of_birth]).to eq ["cannot be in the future."]
       end
     end
 
@@ -181,7 +181,7 @@ describe Case::SAR::Offender do
       it 'errors' do
         kase = build(:offender_sar_case, date_of_birth: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_of_birth]).to eq ["can't be blank"]
+        expect(kase.errors[:date_of_birth]).to eq ["cannot be blank"]
       end
     end
   end
@@ -209,7 +209,7 @@ describe Case::SAR::Offender do
       it 'errors' do
         kase = build(:offender_sar_case, received_date: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:received_date]).to eq ["can't be in the future."]
+        expect(kase.errors[:received_date]).to eq ["cannot be in the future."]
       end
     end
   end
@@ -227,7 +227,7 @@ describe Case::SAR::Offender do
       it 'errors' do
         kase = build(:offender_sar_case, request_dated: 1.day.from_now)
         expect(kase).not_to be_valid
-        expect(kase.errors[:request_dated]).to eq ["can't be in the future."]
+        expect(kase.errors[:request_dated]).to eq ["cannot be in the future."]
       end
     end
   end
@@ -271,16 +271,16 @@ describe Case::SAR::Offender do
       it 'validates third party names when third party is true' do
         kase = build :offender_sar_case, :third_party, third_party_name: '', third_party_company_name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_name]).to eq ["can't be blank if company name not given"]
-        expect(kase.errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
+        expect(kase.errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
+        expect(kase.errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
       end
 
       it 'validates third party names when recipient is third party' do
         kase = build :offender_sar_case, third_party: false, third_party_name: '',
                       third_party_company_name: '', recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_name]).to eq ["can't be blank if company name not given"]
-        expect(kase.errors[:third_party_company_name]).to eq ["can't be blank if representative name not given"]
+        expect(kase.errors[:third_party_name]).to eq ["cannot be blank if company name not given"]
+        expect(kase.errors[:third_party_company_name]).to eq ["cannot be blank if representative name not given"]
       end
 
       it 'does not validate third_party names when ecipient is not third party too' do
@@ -295,14 +295,14 @@ describe Case::SAR::Offender do
       it 'must be present when thrid party is true' do
         kase = build :offender_sar_case, third_party: true, third_party_relationship: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
       end
 
       it 'must be present when third party is false but recipient is third party' do
         kase = build :offender_sar_case, third_party: false, third_party_relationship: '',
                       recipient: 'third_party_recipient'
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
       end
 
       it 'does not validates presence of third party relationship when recipient is not third party' do
@@ -416,7 +416,7 @@ describe Case::SAR::Offender do
   #     kase = build :sar_case, uploaded_request_files: [], message: ''
   #     expect(kase).not_to be_valid
   #     expect(kase.errors[:uploaded_request_files])
-  #       .to eq ["can't be blank if no case details entered"]
+  #       .to eq ["cannot be blank if no case details entered"]
   #   end
 
   #   it 'does validates presence if message is present' do
@@ -643,7 +643,7 @@ describe Case::SAR::Offender do
     it 'validates presence of subject address' do
       kase = build :offender_sar_case, subject_address: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_address]).to eq ["can't be blank"]
+      expect(kase.errors[:subject_address]).to eq ["cannot be blank"]
     end
   end
 

--- a/spec/models/case/sar_spec.rb
+++ b/spec/models/case/sar_spec.rb
@@ -38,7 +38,7 @@ describe Case::SAR::Standard do
       kase = build :sar_case, subject_full_name: nil, subject_type: nil, third_party: nil
 
       expect(kase).not_to be_valid
-      expect(kase.errors[:subject_full_name]).to eq(["can't be blank"])
+      expect(kase.errors[:subject_full_name]).to eq(["cannot be blank"])
       expect(kase.errors[:third_party]).to eq(["Please choose yes or no"])
     end
   end
@@ -69,7 +69,7 @@ describe Case::SAR::Standard do
       it 'errors' do
         kase = build(:sar_case, subject_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:subject_type]).to eq ["can't be blank"]
+        expect(kase.errors[:subject_type]).to eq ["cannot be blank"]
       end
     end
   end
@@ -83,7 +83,7 @@ describe Case::SAR::Standard do
     it 'validates presence of email when reply is to be sent by email' do
       kase = build :sar_case, reply_method: :send_by_email, email: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:email]).to eq ["can't be blank"]
+      expect(kase.errors[:email]).to eq ["cannot be blank"]
     end
   end
 
@@ -91,7 +91,7 @@ describe Case::SAR::Standard do
     it 'validates presence of postal address when reply is to be sent by post' do
       kase = build :sar_case, reply_method: :send_by_post, postal_address: ''
       expect(kase).not_to be_valid
-      expect(kase.errors[:postal_address]).to eq ["can't be blank"]
+      expect(kase.errors[:postal_address]).to eq ["cannot be blank"]
     end
   end
 
@@ -100,7 +100,7 @@ describe Case::SAR::Standard do
       it 'validates presence of name when third party is true' do
         kase = build :sar_case, third_party: true, name: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:name]).to eq ["can't be blank"]
+        expect(kase.errors[:name]).to eq ["cannot be blank"]
       end
 
       it 'does not validates presence of name when third party is false' do
@@ -113,7 +113,7 @@ describe Case::SAR::Standard do
       it 'must be persent when thrid party is true' do
         kase = build :sar_case, third_party: true, third_party_relationship: ''
         expect(kase).not_to be_valid
-        expect(kase.errors[:third_party_relationship]).to eq ["can't be blank"]
+        expect(kase.errors[:third_party_relationship]).to eq ["cannot be blank"]
       end
 
       it 'does not validates presence of third party relationship when third party is false' do
@@ -128,7 +128,7 @@ describe Case::SAR::Standard do
       kase = build :sar_case, uploaded_request_files: [], message: ''
       expect(kase).not_to be_valid
       expect(kase.errors[:message])
-        .to eq ["can't be blank if no request files attached"]
+        .to eq ["cannot be blank if no request files attached"]
     end
 
     it 'validates presence if attached request files is missing on update' do
@@ -137,7 +137,7 @@ describe Case::SAR::Standard do
       kase.update_attributes(message: '')
       expect(kase).not_to be_valid
       expect(kase.errors[:message])
-        .to eq ["can't be blank if no request files attached"]
+        .to eq ["cannot be blank if no request files attached"]
     end
 
     it 'can be empty on create if uploaded_request_files is present' do
@@ -170,7 +170,7 @@ describe Case::SAR::Standard do
       kase = build :sar_case, uploaded_request_files: [], message: ''
       expect(kase).not_to be_valid
       expect(kase.errors[:uploaded_request_files])
-        .to eq ["can't be blank if no case details entered"]
+        .to eq ["cannot be blank if no case details entered"]
     end
 
     it 'does validates presence if message is present' do

--- a/spec/models/case_transition_spec.rb
+++ b/spec/models/case_transition_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe CaseTransition, type: :model do
                                    acting_team_id: kase.responding_team.id
       )
       expect(transition).not_to be_valid
-      expect(transition.errors[:message]).to eq ["can't be blank"]
+      expect(transition.errors[:message]).to eq ["cannot be blank"]
 
     end
   end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Searchable do
       # use the Searchable concern.
 
       class << self
-        # can't create doubles otherwise
+        # cannot create doubles otherwise
         include RSpec::Mocks::ExampleMethods
 
         def table_name

--- a/spec/models/data_request_spec.rb
+++ b/spec/models/data_request_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe DataRequest, type: :model do
 
       it 'ensures the note is present' do
         expect(subject).not_to be_valid
-        expect(subject.errors[:request_type_note]).to eq ["can't be blank"]
+        expect(subject.errors[:request_type_note]).to eq ["cannot be blank"]
       end
     end
 
@@ -195,7 +195,7 @@ RSpec.describe DataRequest, type: :model do
       it 'errors' do
         kase = build(:data_request, request_type: nil)
         expect(kase).not_to be_valid
-        expect(kase.errors[:request_type]).to eq ["can't be blank"]
+        expect(kase.errors[:request_type]).to eq ["cannot be blank"]
       end
     end
   end

--- a/spec/models/linked_case_spec.rb
+++ b/spec/models/linked_case_spec.rb
@@ -50,14 +50,14 @@ describe LinkedCase do
         case_link = LinkedCase.create(case: foi, linked_case: foi)
         expect(case_link).not_to be_valid
         expect(case_link.errors[:linked_case])
-          .to eq ["can't link to the same case"]
+          .to eq ["cannot link to the same case"]
       end
 
       it 'cannot link to a SAR case' do
         case_link = LinkedCase.create(case: foi, linked_case: sar)
         expect(case_link).not_to be_valid
         expect(case_link.errors[:linked_case])
-          .to eq ["can't link a FOI case to a Non-offender SAR as a related case"]
+          .to eq ["cannot link a FOI case to a Non-offender SAR as a related case"]
       end
     end
   end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Report, type: :model do
       )
     }
 
-    it "can't be in the future" do
+    it "cannot be in the future" do
       expect(tomorrow).to_not be_valid
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -171,7 +171,7 @@ RSpec.configure do |config|
   # Replace stubbing out CASE_UPLOADS_S3_BUCKET with a test harness of our own
   # making. The problem with stubbing out is that it doesn't work in 'before
   # :all' blocks, which are sometimes needed e.g. ICO appeals which always
-  # require an uploaded document. so can't be instantiate in a 'before :all'
+  # require an uploaded document. so cannot be instantiate in a 'before :all'
   self.class.__send__(:remove_const, :CASE_UPLOADS_S3_BUCKET)
   self.class.const_set(:CASE_UPLOADS_S3_BUCKET,
                        TestAWSS3.new.bucket(Settings.case_uploads_s3_bucket))

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -171,7 +171,7 @@ RSpec.configure do |config|
   # Replace stubbing out CASE_UPLOADS_S3_BUCKET with a test harness of our own
   # making. The problem with stubbing out is that it doesn't work in 'before
   # :all' blocks, which are sometimes needed e.g. ICO appeals which always
-  # require an uploaded document. so cannot be instantiate in a 'before :all'
+  # require an uploaded document. so cannot be instantiated in a 'before :all'
   self.class.__send__(:remove_const, :CASE_UPLOADS_S3_BUCKET)
   self.class.const_set(:CASE_UPLOADS_S3_BUCKET,
                        TestAWSS3.new.bucket(Settings.case_uploads_s3_bucket))

--- a/spec/services/case_extend_for_pit_service_spec.rb
+++ b/spec/services/case_extend_for_pit_service_spec.rb
@@ -60,7 +60,7 @@ describe CaseExtendForPITService do
       it 'adds an error to the case' do
         service.call
         expect(case_being_drafted.errors[:reason_for_extending])
-          .to eq ["can't be blank"]
+          .to eq ["cannot be blank"]
       end
     end
 
@@ -80,7 +80,7 @@ describe CaseExtendForPITService do
       it 'adds an error to the case' do
         service.call
         expect(case_being_drafted.errors[:extension_deadline])
-          .to eq ["Date can't be blank"]
+          .to eq ["Date cannot be blank"]
       end
     end
 
@@ -110,7 +110,7 @@ describe CaseExtendForPITService do
       it 'adds an error to the case' do
         service.call
         expect(case_being_drafted.errors[:extension_deadline])
-          .to eq ["Date can't be before the final deadline"]
+          .to eq ["Date cannot be before the final deadline"]
       end
     end
 

--- a/spec/services/case_extend_sar_deadline_service_spec.rb
+++ b/spec/services/case_extend_sar_deadline_service_spec.rb
@@ -78,7 +78,7 @@ describe CaseExtendSARDeadlineService do
 
           it {
             expect(sar_case.errors[:extension_period])
-              .to eq ["can't be blank"]
+              .to eq ["cannot be blank"]
           }
         end
 
@@ -99,7 +99,7 @@ describe CaseExtendSARDeadlineService do
 
           it {
             expect(sar_case.errors[:extension_period])
-              .to eq ["can't be more than two calendar months beyond the received date"]
+              .to eq ["cannot be more than two calendar months beyond the received date"]
           }
         end
 
@@ -119,7 +119,7 @@ describe CaseExtendSARDeadlineService do
 
           it {
             expect(sar_case.errors[:extension_period])
-              .to eq ["can't be before the final deadline"]
+              .to eq ["cannot be before the final deadline"]
           }
         end
 
@@ -156,7 +156,7 @@ describe CaseExtendSARDeadlineService do
 
         it {
           expect(sar_case.errors[:reason_for_extending])
-            .to eq ["can't be blank"]
+            .to eq ["cannot be blank"]
         }
       end
 

--- a/spec/services/case_linking_service_spec.rb
+++ b/spec/services/case_linking_service_spec.rb
@@ -92,7 +92,7 @@ describe CaseLinkingService do
             service.create
             expect(service.result).to eq :validation_error
             expect(sar_case_1.errors[:linked_case_number])
-              .to eq ["can't link a Non-offender SAR case to a FOI as a related case"]
+              .to eq ["cannot link a Non-offender SAR case to a FOI as a related case"]
           end
         end
 
@@ -102,7 +102,7 @@ describe CaseLinkingService do
             service.create
             expect(service.result).to eq :validation_error
             expect(foi_case.errors[:linked_case_number])
-              .to eq ["can't link a FOI case to a Non-offender SAR as a related case"]
+              .to eq ["cannot link a FOI case to a Non-offender SAR as a related case"]
           end
         end
 
@@ -255,7 +255,7 @@ describe CaseLinkingService do
       it 'adds an error to the case' do
         service.create
         expect(kase.errors[:linked_case_number])
-          .to eq ["can't be blank"]
+          .to eq ["cannot be blank"]
       end
     end
 
@@ -273,7 +273,7 @@ describe CaseLinkingService do
       it 'adds an error to the case' do
         service.create
         expect(kase.errors[:linked_case_number])
-          .to eq ["can't link to the same case"]
+          .to eq ["cannot link to the same case"]
       end
     end
 

--- a/spec/services/case_linking_service_spec.rb
+++ b/spec/services/case_linking_service_spec.rb
@@ -255,7 +255,7 @@ describe CaseLinkingService do
       it 'adds an error to the case' do
         service.create
         expect(kase.errors[:linked_case_number])
-          .to eq ["cannot be blank"]
+          .to eq ["can't be blank"]
       end
     end
 
@@ -291,7 +291,7 @@ describe CaseLinkingService do
       it 'adds an error to the case' do
         service.create
         expect(kase.errors[:linked_case_number])
-          .to eq ["doesn't exist"]
+          .to eq ["does not exist"]
       end
     end
   end

--- a/spec/services/mark_response_as_sent_service_spec.rb
+++ b/spec/services/mark_response_as_sent_service_spec.rb
@@ -32,7 +32,7 @@ describe MarkResponseAsSentService do
 
         it 'sets the error' do
           service.call
-          expect(foi_kase.errors[:date_responded]).to eq ["can't be blank"]
+          expect(foi_kase.errors[:date_responded]).to eq ["cannot be blank"]
         end
       end
 
@@ -52,7 +52,7 @@ describe MarkResponseAsSentService do
 
         it 'sets the error' do
           service.call
-          expect(foi_kase.errors[:date_responded]).to eq ["can't be blank"]
+          expect(foi_kase.errors[:date_responded]).to eq ["cannot be blank"]
         end
 
       end
@@ -74,7 +74,7 @@ describe MarkResponseAsSentService do
 
         it 'sets the error' do
           service.call
-          expect(foi_kase.errors[:date_responded]).to eq ["can't be in the future"]
+          expect(foi_kase.errors[:date_responded]).to eq ["cannot be in the future"]
         end
       end
     end
@@ -126,7 +126,7 @@ describe MarkResponseAsSentService do
 
         it 'sets the error' do
           service.call
-          expect(ico_kase.errors[:date_responded]).to eq ["can't be blank"]
+          expect(ico_kase.errors[:date_responded]).to eq ["cannot be blank"]
         end
       end
 
@@ -167,7 +167,7 @@ describe MarkResponseAsSentService do
 
         it 'sets the error' do
           service.call
-          expect(ico_kase.errors[:date_responded]).to eq ["can't be in the future"]
+          expect(ico_kase.errors[:date_responded]).to eq ["cannot be in the future"]
         end
       end
     end

--- a/spec/services/user_creation_service_spec.rb
+++ b/spec/services/user_creation_service_spec.rb
@@ -44,7 +44,7 @@ describe UserCreationService do
           params[:email] = ''
           service.call
           expect(service.result).to eq :error
-          expect(service.user.errors[:email]).to eq ["can't be blank"]
+          expect(service.user.errors[:email]).to eq ["cannot be blank"]
         end
       end
     end

--- a/spec/site_prism/page_objects/sections/shared/gov_uk_date_section.rb
+++ b/spec/site_prism/page_objects/sections/shared/gov_uk_date_section.rb
@@ -5,7 +5,7 @@ module PageObjects
         # NB: The fields here are set as 'visible: false' to allow them to be
         #     used for hidden date fields (like the received_date on ICO
         #     Overturned cases). However, if they field really is not visible
-        #     then while you can test for it's presence using these, you can't
+        #     then while you can test for it's presence using these, you cannot
         #     set the value of the fields.
         element :day, :xpath, ".//input[contains(@name,'_dd')]", visible: false
         element :month, :xpath, ".//input[contains(@name,'_mm')]", visible: false

--- a/spec/support/shared_examples/cases/update_examples.rb
+++ b/spec/support/shared_examples/cases/update_examples.rb
@@ -90,7 +90,7 @@ RSpec.shared_examples 'update case spec' do
           Timecop.freeze(now) do
             params[correspondence_type_abbr]['date_draft_compliant_yyyy'] = '2020'
             patch :update, params: params
-            expect(assigns(:case).errors.full_messages).to eq ['Date compliant draft uploaded can\'t be in the future.']
+            expect(assigns(:case).errors.full_messages).to eq ['Date compliant draft uploaded cannot be in the future.']
           end
         end
       end

--- a/spec/support/shared_examples/cases/update_examples.rb
+++ b/spec/support/shared_examples/cases/update_examples.rb
@@ -80,7 +80,7 @@ RSpec.shared_examples 'update case spec' do
             kase.date_responded = 3.business_days.after(kase.received_date)
             params[correspondence_type_abbr]['date_draft_compliant_yyyy'] = '2016'
             patch :update, params: params
-            expect(assigns(:case).errors.full_messages).to eq ["Date compliant draft uploaded can't be before date received"]
+            expect(assigns(:case).errors.full_messages).to eq ["Date compliant draft uploaded cannot be before date received"]
           end
         end
       end
@@ -100,7 +100,7 @@ RSpec.shared_examples 'update case spec' do
           Timecop.freeze(now) do
             params[correspondence_type_abbr]['date_draft_compliant_yyyy'] = '2016'
             patch :update, params: params
-            expect(assigns(:case).errors.full_messages).to eq ["Date compliant draft uploaded can't be before date received"]
+            expect(assigns(:case).errors.full_messages).to eq ["Date compliant draft uploaded cannot be before date received"]
           end
         end
       end

--- a/spec/validators/case_link_type_validator_spec.rb
+++ b/spec/validators/case_link_type_validator_spec.rb
@@ -163,7 +163,7 @@ describe CaseLinkTypeValidator do
       validator = CaseLinkTypeValidator.new
       validator.validate(case_link)
       expect(case_link.errors[:linked_case])
-        .to eq ["can't link a FOI case to a FOI as a related case"]
+        .to eq ["cannot link a FOI case to a FOI as a related case"]
       expect(CaseLinkTypeValidator)
         .to have_received(:classes_can_be_linked_with_type?)
               .with(type: 'related',

--- a/spec/validators/closed_case_validator_spec.rb
+++ b/spec/validators/closed_case_validator_spec.rb
@@ -57,19 +57,19 @@ describe 'ClosedCaseValidator' do
       it 'errors if date_responded blank' do
         kase.date_responded = nil
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_responded]).to eq(["can't be blank"])
+        expect(kase.errors[:date_responded]).to eq(["cannot be blank"])
       end
 
       it 'errors if date_responded in the future' do
         kase.date_responded = 3.days.from_now
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_responded]).to eq(["can't be in the future"])
+        expect(kase.errors[:date_responded]).to eq(["cannot be in the future"])
       end
 
       it 'errors if date before received date' do
         kase.date_responded = kase.received_date - 1.day
         expect(kase).not_to be_valid
-        expect(kase.errors[:date_responded]).to eq(["can't be before date received"])
+        expect(kase.errors[:date_responded]).to eq(["cannot be before date received"])
       end
 
       it 'does not error if between received date and today' do
@@ -477,7 +477,7 @@ describe 'ClosedCaseValidator' do
         it 'is invalid' do
           responded_ico.date_ico_decision_received = nil
           expect(responded_ico).not_to be_valid
-          expect(responded_ico.errors[:date_ico_decision_received]).to eq ["can't be blank"]
+          expect(responded_ico.errors[:date_ico_decision_received]).to eq ["cannot be blank"]
         end
       end
       context 'future' do

--- a/spec/validators/responded_case_validator_spec.rb
+++ b/spec/validators/responded_case_validator_spec.rb
@@ -18,7 +18,7 @@ describe RespondedCaseValidator do
       it 'is not valid' do
         ico.date_responded = nil
         expect(ico).not_to be_valid
-        expect(ico.errors[:date_responded]).to eq ["can't be blank"]
+        expect(ico.errors[:date_responded]).to eq ["cannot be blank"]
       end
     end
 
@@ -34,7 +34,7 @@ describe RespondedCaseValidator do
       it 'is not valid' do
         ico.date_responded = ico.received_date - 1.day
         expect(ico).not_to be_valid
-        expect(ico.errors[:date_responded]).to eq ["can't be before date received"]
+        expect(ico.errors[:date_responded]).to eq ["cannot be before date received"]
       end
     end
 
@@ -42,7 +42,7 @@ describe RespondedCaseValidator do
       it 'is not valid' do
         ico.date_responded = 1.day.from_now.to_date
         expect(ico).not_to be_valid
-        expect(ico.errors[:date_responded]).to eq ["can't be in the future"]
+        expect(ico.errors[:date_responded]).to eq ["cannot be in the future"]
       end
     end
   end


### PR DESCRIPTION
## Description
Change "can't" to "cannot" and "doesn't" to "does not" where ever possible and quick

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
e.g.
![image](https://user-images.githubusercontent.com/22935203/140956580-fe111f27-8b09-48f0-8dbd-f2eb5b98071b.png)
![image](https://user-images.githubusercontent.com/22935203/140956637-acac188f-d3f7-4a1d-9fc7-5fd1f62412a9.png)


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-3934

### Deployment
n/a

### Manual testing instructions
Most places it should say in validation errors "cannot be" instead of "can't be" 
