### PR TITLE
Fix cross cutting test failure

### DIFF
--- a/spec/features/cases/ico/editing_case_closure_spec.rb
+++ b/spec/features/cases/ico/editing_case_closure_spec.rb
@@ -4,7 +4,7 @@ feature 'editing case closure information' do
   given(:manager) { find_or_create :disclosure_bmt_user }
 
   scenario 'bmt changes ico decision to overturned', js: true do
-    Timecop.freeze(11.days.ago) do
+    Timecop.freeze(11.business_days.ago) do
       kase = create :closed_ico_foi_case
       Timecop.return
       login_as manager
@@ -16,8 +16,8 @@ feature 'editing case closure information' do
   end
 
   scenario 'bmt changes ico decision to upheld', js: true do
-    Timecop.freeze(11.days.ago) do
-      kase = create :closed_ico_foi_case, :overturned_by_ico, created_at: 11.days.ago
+    Timecop.freeze(11.business_days.ago) do
+      kase = create :closed_ico_foi_case, :overturned_by_ico, created_at: 11.business_days.ago
       Timecop.return
       login_as manager
       cases_show_page.load(id: kase.id)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,7 +52,8 @@ Capybara.register_driver :headless_chrome do |app|
     options.add_argument('--enable-features=NetworkService,NetworkServiceInProcess')
   end
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: options)
+
 end
 
 Capybara.javascript_driver = :headless_chrome

--- a/spec/support/features/steps/cases/edit_steps.rb
+++ b/spec/support/features/steps/cases/edit_steps.rb
@@ -194,6 +194,7 @@ def edit_ico_case_closure_step(kase:, decision_received_date: Date.today, ico_de
     cases_edit_closure_page.ico_decision.overturned.click
   end
   upload_ico_decision_file
+  binding.pry
   cases_edit_closure_page.click_on 'Save changes'
   expect(cases_show_page).to be_displayed(id: kase.id)
   expect(cases_show_page.notice.text)

--- a/spec/support/features/steps/cases/edit_steps.rb
+++ b/spec/support/features/steps/cases/edit_steps.rb
@@ -194,7 +194,6 @@ def edit_ico_case_closure_step(kase:, decision_received_date: Date.today, ico_de
     cases_edit_closure_page.ico_decision.overturned.click
   end
   upload_ico_decision_file
-  binding.pry
   cases_edit_closure_page.click_on 'Save changes'
   expect(cases_show_page).to be_displayed(id: kase.id)
   expect(cases_show_page.notice.text)


### PR DESCRIPTION
## Description

This bug was caused by mismatch between duration types. Timecop was going back 11 days, and creating a case.

Then the test goes back to the present and tries to edit the case with a decision recieved 10 business days ago.

During breaks like christmas 11 days ago is more recent than 10 business days ago hence we get an error due to the decision being before the case was created.

Move everything to use "business days" to prevent future flakiness


