### PR TITLE
Add SAR IR Closure outcomes

### DIFF
--- a/app/assets/javascripts/modules/CaseClosure.js
+++ b/app/assets/javascripts/modules/CaseClosure.js
@@ -18,12 +18,25 @@ moj.Modules.CaseClosure = {
 
   $refusalExemptions : $('.js-refusal-exemptions'),
 
+
+  // SAR IR specific variables
+  $sarIrOutcomeGroup : $('.appeal-outcome-group'),
+  $sarIrOutcomeUpheldInPart : $('#sar_internal_review_sar_ir_outcome_id_upheld_in_part'),
+  $sarIrOutcomeOverturned : $('#sar_internal_review_sar_ir_outcome_id_overturned'),
+  $outcomeExplanationGroups : $('.responsible-for-outcome-group, .outcome-reasons-group'),
+
   init: function() {
     var self = this;
 
     self.showHideOtherGroup();
 
     self.showHideExemption();
+
+    self.showHideOutcomeExplantionGroups();
+
+    self.$sarIrOutcomeGroup.on('change', ':radio', function() {
+      self.showHideOutcomeExplantionGroups();
+    });
 
     //Bind events
     self.$infoHeldGroup.on('change', ':radio', function(){
@@ -37,6 +50,17 @@ moj.Modules.CaseClosure = {
     self.$otherReasons.on('change', ':radio', function() {
       self.showHideExemption();
     });
+  },
+
+  showHideOutcomeExplantionGroups: function() {
+    var upheldInPart = this.$sarIrOutcomeUpheldInPart.is(':checked');
+    var overturned = this.$sarIrOutcomeOverturned.is(':checked');
+
+    if (upheldInPart || overturned) {
+      this.$outcomeExplanationGroups.show();
+    } else {
+      this.$outcomeExplanationGroups.hide();
+    }
   },
 
   showHideOtherGroup: function() {

--- a/app/assets/javascripts/modules/CaseClosure.js
+++ b/app/assets/javascripts/modules/CaseClosure.js
@@ -21,8 +21,8 @@ moj.Modules.CaseClosure = {
 
   // SAR IR specific variables
   $sarIrOutcomeGroup : $('.appeal-outcome-group'),
-  $sarIrOutcomeUpheldInPart : $('#sar_internal_review_sar_ir_outcome_id_upheld_in_part'),
-  $sarIrOutcomeOverturned : $('#sar_internal_review_sar_ir_outcome_id_overturned'),
+  $sarIrOutcomeUpheldInPart : $('#sar_internal_review_sar_ir_outcome_upheld_in_part'),
+  $sarIrOutcomeOverturned : $('#sar_internal_review_sar_ir_outcome_overturned'),
   $outcomeExplanationGroups : $('.responsible-for-outcome-group, .outcome-reasons-group'),
 
   init: function() {

--- a/app/controllers/concerns/sar_internal_review_cases_params.rb
+++ b/app/controllers/concerns/sar_internal_review_cases_params.rb
@@ -50,7 +50,10 @@ module SARInternalReviewCasesParams
       :date_responded_dd,
       :date_responded_mm,
       :date_responded_yyyy,
+      :sar_ir_outcome,
       :late_team_id,
+      :team_responsible_for_outcome_id,
+      outcome_reason_ids: []
     ).merge(refusal_reason_abbreviation: missing_info_to_tmm)
   end
 

--- a/app/decorators/case/sar/internal_review_decorator.rb
+++ b/app/decorators/case/sar/internal_review_decorator.rb
@@ -28,4 +28,11 @@ class Case::SAR::InternalReviewDecorator < Case::SAR::StandardDecorator
     end
   end
 
+  def pretty_outcome_reasons
+    object.outcome_reasons
+      .map { |reason| reason.name }
+      .join(",<br>")
+      .html_safe
+  end
+
 end

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -334,6 +334,16 @@ class Case::Base < ApplicationRecord
             through: 'cases_exemptions',
             foreign_key: :case_id
 
+  has_many :cases_outcome_reasons,
+           class_name: 'CaseOutcomeReason',
+           table_name: :cases_outcome_reasons,
+           foreign_key: :case_id
+
+  has_many :outcome_reasons,
+            class_name: 'CaseClosure::OutcomeReason',
+            through: 'cases_outcome_reasons',
+            foreign_key: :case_id
+
   has_many :case_links,
            -> { readonly },
            class_name: 'LinkedCase',

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -336,7 +336,6 @@ class Case::Base < ApplicationRecord
 
   has_many :cases_outcome_reasons,
            class_name: 'CaseOutcomeReason',
-           table_name: :cases_outcome_reasons,
            foreign_key: :case_id
 
   has_many :outcome_reasons,

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -313,6 +313,8 @@ class Case::Base < ApplicationRecord
 
   belongs_to :late_team, class_name: 'BusinessUnit'
 
+  belongs_to :team_responsible_for_outcome, class_name: 'BusinessUnit'
+
   belongs_to :outcome, class_name: 'CaseClosure::Outcome'
 
   belongs_to :appeal_outcome, class_name: 'CaseClosure::AppealOutcome'

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -2,6 +2,8 @@ class Case::SAR::InternalReview < Case::SAR::Standard
 
   include LinkableOriginalCase
 
+  belongs_to :sar_ir_outcome, class_name: 'CaseClosure::AppealOutcome'
+
   validates_presence_of :original_case
 
   attr_accessor :original_case_number
@@ -9,7 +11,6 @@ class Case::SAR::InternalReview < Case::SAR::Standard
   validates_presence_of :sar_ir_subtype
 
   jsonb_accessor :properties,
-                 sar_ir_outcome_id: :integer,
                  sar_ir_subtype: :string,
                  team_responsible_for_outcome_id: :integer
 
@@ -54,4 +55,11 @@ class Case::SAR::InternalReview < Case::SAR::Standard
     compliance: 'compliance'
   }
 
+  def sar_ir_outcome
+    appeal_outcome&.name
+  end
+
+  def sar_ir_outcome=(name)
+    self.appeal_outcome = CaseClosure::AppealOutcome.by_name(name)
+  end
 end

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -3,12 +3,14 @@ class Case::SAR::InternalReview < Case::SAR::Standard
   include LinkableOriginalCase
 
   belongs_to :sar_ir_outcome, class_name: 'CaseClosure::AppealOutcome'
+  belongs_to :team_responsible_for_outcome, class_name: 'BusinessUnit'
 
   validates_presence_of :original_case
+  validates_presence_of :sar_ir_subtype
 
   attr_accessor :original_case_number
 
-  validates_presence_of :sar_ir_subtype
+
 
   jsonb_accessor :properties,
                  sar_ir_subtype: :string,

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -3,7 +3,6 @@ class Case::SAR::InternalReview < Case::SAR::Standard
   include LinkableOriginalCase
 
   belongs_to :sar_ir_outcome, class_name: 'CaseClosure::AppealOutcome'
-  belongs_to :team_responsible_for_outcome, class_name: 'BusinessUnit'
 
   validates_presence_of :original_case
   validates_presence_of :sar_ir_subtype

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -60,6 +60,10 @@ class Case::SAR::InternalReview < Case::SAR::Standard
     appeal_outcome&.name
   end
 
+  def sar_ir_outcome_abbr
+    appeal_outcome&.abbreviation
+  end
+
   def sar_ir_outcome=(name)
     self.appeal_outcome = CaseClosure::AppealOutcome.by_name(name)
   end

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -9,7 +9,9 @@ class Case::SAR::InternalReview < Case::SAR::Standard
   validates_presence_of :sar_ir_subtype
 
   jsonb_accessor :properties,
-                 sar_ir_subtype: :string
+                 sar_ir_outcome_id: :integer,
+                 sar_ir_subtype: :string,
+                 team_responsible_for_outcome_id: :integer
 
   HUMANIZED_ATTRIBUTES = {
     sar_ir_subtype: 'Case type',

--- a/app/models/case_closure/outcome_reason.rb
+++ b/app/models/case_closure/outcome_reason.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: case_closure_metadata
+#
+#  id                      :integer          not null, primary key
+#  type                    :string
+#  subtype                 :string
+#  name                    :string
+#  abbreviation            :string
+#  sequence_id             :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  requires_refusal_reason :boolean          default(FALSE)
+#  requires_exemption      :boolean          default(FALSE)
+#  active                  :boolean          default(TRUE)
+#  omit_for_part_refused   :boolean          default(FALSE)
+#
+
+module CaseClosure
+  class OutcomeReason < Metadatum
+  end
+end

--- a/app/models/case_outcome_reason.rb
+++ b/app/models/case_outcome_reason.rb
@@ -1,0 +1,13 @@
+class CaseOutcomeReason < ApplicationRecord
+
+  self.table_name = :cases_outcome_reasons
+
+  belongs_to :case,
+             foreign_key: :case_id,
+             class_name: 'Case::Base'
+
+  belongs_to :outcome_reason,
+             class_name: 'CaseClosure::OutcomeReason',
+             foreign_key: :outcome_reason_id
+
+end

--- a/app/validators/closed_case_validator.rb
+++ b/app/validators/closed_case_validator.rb
@@ -252,6 +252,6 @@ class ClosedCaseValidator < ActiveModel::Validator
   private
 
   def not_upheld(rec)
-    rec.sar_ir_outcome == 'Overturned' || rec.sar_ir_outcome == 'Upheld in part'
+    rec.appeal_outcome.abbreviation == 'overturned' || rec.sar_ir_outcome == 'part_upheld'
   end
 end

--- a/app/validators/closed_case_validator.rb
+++ b/app/validators/closed_case_validator.rb
@@ -103,8 +103,6 @@ class ClosedCaseValidator < ActiveModel::Validator
     end
   end
 
-  private
-
   def run_validations(validations:, kase:)
     validations.each do |validation|
       self.__send__(validation, kase)
@@ -190,7 +188,7 @@ class ClosedCaseValidator < ActiveModel::Validator
 
   def validate_outcome_reasons(rec) 
     if not_upheld(rec) && rec.outcome_reason_ids == []
-      rec.errors.add(:outcome_reason_ids, 'must be selected')
+      rec.errors.add(:outcome_reasons, 'must be selected')
     end
   end
 

--- a/app/validators/closed_case_validator.rb
+++ b/app/validators/closed_case_validator.rb
@@ -252,6 +252,6 @@ class ClosedCaseValidator < ActiveModel::Validator
   private
 
   def not_upheld(rec)
-    rec.appeal_outcome.abbreviation == 'overturned' || rec.sar_ir_outcome == 'part_upheld'
+    rec.sar_ir_outcome_abbr == 'overturned' || rec.sar_ir_outcome_abbr == 'part_upheld'
   end
 end

--- a/app/validators/closed_case_validator.rb
+++ b/app/validators/closed_case_validator.rb
@@ -32,7 +32,9 @@ class ClosedCaseValidator < ActiveModel::Validator
   # the form to close a case, and is only required at that time.
   PROCESSING_CLOSURE_VALIDATIONS = {
     'SAR'=>                 [:validate_tmm],
-    'SAR_INTERNAL_REVIEW'=> [:validate_tmm],
+    'SAR_INTERNAL_REVIEW'=> [:validate_tmm, 
+                             :validate_sar_ir_outcome,
+                             :validate_team_responsible],
     'FOI'=>                 [],
     'ICO'=>                 [],
     'OVERTURNED_SAR' =>     [:validate_tmm,
@@ -151,6 +153,12 @@ class ClosedCaseValidator < ActiveModel::Validator
     end
   end
 
+  def validate_sar_ir_outcome(rec)
+    if rec.sar_ir_outcome.blank?
+      rec.errors.add(:sar_ir_outcome, 'must be selected')
+    end
+  end
+
   def validate_date_responded(rec)
     if rec.date_responded.blank?
       rec.errors.add(:date_responded, "cannot be blank")
@@ -163,7 +171,6 @@ class ClosedCaseValidator < ActiveModel::Validator
     end
   end
 
-
   def validate_outcome(rec)
     if self.class.outcome_required?(info_held_status: rec.info_held_status_abbreviation)
       if rec.outcome.blank?
@@ -171,6 +178,20 @@ class ClosedCaseValidator < ActiveModel::Validator
       end
     elsif rec.outcome.present?
       rec.errors.add(:outcome, 'can only be present if information held or part held')
+    end
+  end
+
+  def validate_team_responsible(rec)
+    not_upheld = rec.sar_ir_outcome == 'Upheld' || rec.sar_ir_outcome == 'Upheld in part'
+    if not_upheld && rec.team_responsible_for_outcome_id.blank? 
+      rec.errors.add(:team_responsible_for_outcome, 'must be selected')
+    end
+  end
+
+  def validate_outcome_reasons(rec) 
+    not_upheld = rec.sar_ir_outcome == 'Upheld' || rec.sar_ir_outcome == 'Upheld in part'
+    if not_upheld && rec.outcome_reason_ids == []
+      rec.errors.add(:outcome_reasons, 'must be selected')
     end
   end
 

--- a/app/views/cases/sar_internal_review/_close_form.html.slim
+++ b/app/views/cases/sar_internal_review/_close_form.html.slim
@@ -6,9 +6,6 @@
             form_hint_text: t('cases.sar.close_form.date_example'),
             today_button: {class: ''} }
 
-  .missing-info
-    = f.radio_button_fieldset :missing_info
-
   .grid-row
     .column-two-thirds
       .button-holder

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -13,6 +13,13 @@
       text_method: :name, 
       value_method: :id
 
+  .appeal-outcome-group
+    = render partial: 'cases/sar_internal_review/outcome_reason_checkbox_section', 
+      locals: { outcome_reasons: CaseClosure::OutcomeReason.all, 
+        heading: 'Reason(s) for outcome being partially upheld out overturned?', 
+        hint: 'Select all that apply', 
+        kase: @case, f: f }
+
   .missing-info
     = f.radio_button_fieldset :missing_info
 

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -4,6 +4,14 @@
   - if @case.responded_late?
     = render partial: 'cases/shared/team_caused_late_response', locals: {kase: @case, f: f}
 
+  .appeal-outcome-group
+    = f.radio_button_fieldset :sar_ir_outcome_id, choices: CaseClosure::AppealOutcome.active.map(&:name)
+
+  .appeal-outcome-group
+    = f.radio_button_fieldset :team_responsible_for_outcome_id, 
+      choices: @team_collection.teams, 
+      text_method: :name, 
+      value_method: :id
 
   .missing-info
     = f.radio_button_fieldset :missing_info

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -19,8 +19,8 @@
   .outcome-reasons-group
     = render partial: 'cases/sar_internal_review/outcome_reason_checkbox_section', 
       locals: { outcome_reasons: CaseClosure::OutcomeReason.all, 
-        heading: 'Reason(s) for outcome being partially upheld out overturned?', 
-        hint: 'Select all that apply', 
+        heading: t('cases.sar_internal_review.outcome_reasons.heading'),
+        hint: t('cases.sar_internal_review.outcome_reasons.hint'),
         kase: @case, f: f }
 
   .missing-info

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -8,7 +8,7 @@
       = render partial: 'cases/shared/team_caused_late_response', locals: {kase: @case, f: f}
 
   .appeal-outcome-group
-    = f.radio_button_fieldset :sar_ir_outcome_id, choices: CaseClosure::AppealOutcome.active.map(&:name)
+    = f.radio_button_fieldset :sar_ir_outcome, choices: CaseClosure::AppealOutcome.active.map(&:name)
 
   .responsible-for-outcome-group
     = f.radio_button_fieldset :team_responsible_for_outcome_id, 

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -2,18 +2,20 @@
 = form_for kase, as: :sar_internal_review, url: url do |f|
 
   - if @case.responded_late?
-    = render partial: 'cases/shared/team_caused_late_response', locals: {kase: @case, f: f}
+    .responsible-for-lateness-group
+      = render partial: 'cases/shared/team_caused_late_response', locals: {kase: @case, f: f}
 
   .appeal-outcome-group
     = f.radio_button_fieldset :sar_ir_outcome_id, choices: CaseClosure::AppealOutcome.active.map(&:name)
 
-  .appeal-outcome-group
+  / .js-outcome-group
+  .form-group
     = f.radio_button_fieldset :team_responsible_for_outcome_id, 
       choices: @team_collection.teams, 
       text_method: :name, 
       value_method: :id
 
-  .appeal-outcome-group
+  .outcome-reasons-group
     = render partial: 'cases/sar_internal_review/outcome_reason_checkbox_section', 
       locals: { outcome_reasons: CaseClosure::OutcomeReason.all, 
         heading: 'Reason(s) for outcome being partially upheld out overturned?', 

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -1,6 +1,8 @@
 - url = defined?(form_url) ? form_url : polymorphic_path(@case, action: :process_respond_and_close)
 = form_for kase, as: :sar_internal_review, url: url do |f|
 
+  .js-sar-internal-review
+
   - if @case.responded_late?
     .responsible-for-lateness-group
       = render partial: 'cases/shared/team_caused_late_response', locals: {kase: @case, f: f}
@@ -8,8 +10,7 @@
   .appeal-outcome-group
     = f.radio_button_fieldset :sar_ir_outcome_id, choices: CaseClosure::AppealOutcome.active.map(&:name)
 
-  / .js-outcome-group
-  .form-group
+  .responsible-for-outcome-group
     = f.radio_button_fieldset :team_responsible_for_outcome_id, 
       choices: @team_collection.teams, 
       text_method: :name, 

--- a/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
+++ b/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
@@ -1,0 +1,10 @@
+.form-group
+  fieldset
+    legend
+      span.form-label-bold
+        = heading
+
+    = collection_check_boxes(:sar_internal_review, :outcome_reason_ids, outcome_reasons, :id, :name) do |b|
+      - content_tag :div, class: "multiple-choice" do
+        - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids)) \
+            + b.label(for: "sar_internal_review_outcome_reason_ids_#{b.object.id}")

--- a/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
+++ b/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
@@ -3,6 +3,8 @@
     legend
       span.form-label-bold
         = heading
+      span.form-hint
+        = hint
 
     = collection_check_boxes(:sar_internal_review, :outcome_reason_ids, outcome_reasons, :id, :name) do |b|
       - content_tag :div, class: "multiple-choice" do

--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -34,6 +34,11 @@ tbody.response-details
       th = t('common.case.outcome')
       td = case_details.outcome.name
 
+  - if case_details.outcome_reasons.present?
+    tr.refusal-reason
+      th = t('common.case.outcome_reason')
+      td = case_details.pretty_outcome_reasons
+
   - if case_details.refusal_reason.present?
     tr.refusal-reason
       th = t('common.case.reason_for_refusal')

--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -34,8 +34,13 @@ tbody.response-details
       th = t('common.case.outcome')
       td = case_details.outcome.name
 
+  - if case_details.team_responsible_for_outcome.present?
+    tr.team-responsible
+      th = t('common.case.team_responsible_for_outcome')
+      td = case_details.team_responsible_for_outcome.name
+
   - if case_details.outcome_reasons.present?
-    tr.refusal-reason
+    tr.outcome-reasons
       th = t('common.case.outcome_reason')
       td = case_details.pretty_outcome_reasons
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -958,6 +958,7 @@ en:
       progress_for_clearance: "Ready for Disclosure clearance"
       reason_for_refusal: Outcome
       outcome_reason: Reason for appeal outcome
+      team_responsible_for_outcome: Business unit responsible for appeal outcome
       reassign_case: "Change team member"
       received_date: Date request received at MOJ
       remove_link_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,7 +510,7 @@ en:
         sar_ir_subtype: Case type
         name:  Full name of the requestor
         late_team_id: Who was responsible for lateness?
-        sar_ir_outcome_id: SAR IR Outcome?
+        sar_ir_outcome: SAR IR Outcome?
         team_responsible_for_outcome_id: Who was responsible for outcome being partially upheld or overturned?
         missing_info:  Was the response asking for missing information (e.g. proof of ID), or clarification, i.e. a TTM?
       offender_sar_complaint:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -957,6 +957,7 @@ en:
       prison_number: "Prison number"
       progress_for_clearance: "Ready for Disclosure clearance"
       reason_for_refusal: Outcome
+      outcome_reason: Reason for appeal outcome
       reassign_case: "Change team member"
       received_date: Date request received at MOJ
       remove_link_html: |

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -509,6 +509,10 @@ en:
         third_party: Is this information being requested on someone else's behalf?
         sar_ir_subtype: Case type
         name:  Full name of the requestor
+        late_team_id: Who was responsible for lateness?
+        sar_ir_outcome_id: SAR IR Outcome?
+        team_responsible_for_outcome_id: Who was responsible for outcome being partially upheld or overturned?
+        missing_info:  Was the response asking for missing information (e.g. proof of ID), or clarification, i.e. a TTM?
       offender_sar_complaint:
         original_case_number: Is this the correct case?
         complaint_type: What sort of complaint is this?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1336,6 +1336,9 @@ en:
       edit_case_details: Edit case details
       new_form_common:
         dropzone: Requestor's proof of ID and other documents
+      outcome_reasons: 
+        heading: Reason(s) for outcome being partially upheld out overturned?
+        hint: Select all that apply
     search_bar:
       heading: Case number, requester name or keyword
       hint: For example, 170113001, John Smith or prison meals

--- a/db/data_migrations/20220125145612_add_sar_ir_outcome_reasons.rb
+++ b/db/data_migrations/20220125145612_add_sar_ir_outcome_reasons.rb
@@ -1,0 +1,30 @@
+class AddSarIrOutcomeReasons < ActiveRecord::DataMigration
+  def up
+    CaseClosure::OutcomeReason.find_or_create_by!(
+      name: 'Proper searches not carried out/missing information',
+      abbreviation: 'missing_info',
+      sequence_id: 900
+    )
+
+    CaseClosure::OutcomeReason.find_or_create_by!(
+      name: 'Incorrect exemption engaged',
+      abbreviation: 'wrong_exemp',
+      sequence_id: 905
+    )
+
+    CaseClosure::OutcomeReason.find_or_create_by!(
+      name: 'Excessive redaction(s)',
+      abbreviation: 'excess_redacts',
+      sequence_id: 910
+    )
+  end
+
+  def down
+    ['missing_info', 'wrong_exemp','excess_redacts'].each do |abbreviation|
+       outcome_reason = CaseClosure::OutcomeReason.find_by(
+         abbreviation: abbreviation
+       )
+       outcome_reason.delete if outcome_reason.nil?
+    end
+  end
+end

--- a/db/migrate/20220117091139_create_join_table_cases_outcome_reason.rb
+++ b/db/migrate/20220117091139_create_join_table_cases_outcome_reason.rb
@@ -1,0 +1,9 @@
+class CreateJoinTableCasesOutcomeReason < ActiveRecord::Migration[5.2]
+  def change
+    create_table :cases_outcome_reasons do |t|
+      t.belongs_to :case, index: true
+      t.belongs_to :outcome_reason, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/seeders/case_closure_metadata_seeder.rb
+++ b/db/seeders/case_closure_metadata_seeder.rb
@@ -7,6 +7,7 @@ module CaseClosure
       seed_appeal_outcomes(verbose)
       seed_refusal_reasons(verbose)
       seed_exemptions(verbose)
+      seed_outcome_reasons(verbose)
       implement_oct_2017_changes(verbose)
       implement_jan_2021_changes(verbose)
       implement_feb_2021_changes(verbose)
@@ -243,6 +244,25 @@ module CaseClosure
         name: '(s43) - Commercial interests',
         abbreviation: 'comm',
         sequence_id: 685)
+    end
+
+    def self.seed_outcome_reasons(verbose)
+      puts "----Seeding CaseClosure::OutcomeReasons----" if verbose
+
+      OutcomeReason.find_or_create_by!(
+        name: 'Proper searches not carried out/missing information',
+        abbreviation: 'missing_info',
+        sequence_id: 900)
+
+      OutcomeReason.find_or_create_by!(
+        name: 'Incorrect exemption engaged',
+        abbreviation: 'wrong_exemp',
+        sequence_id: 905)
+
+      OutcomeReason.find_or_create_by!(
+        name: 'Excessive redaction(s)',
+        abbreviation: 'excess_redacts',
+        sequence_id: 910)
     end
     #rubocop:enable Metrics/MethodLength
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -416,6 +416,38 @@ ALTER SEQUENCE public.cases_id_seq OWNED BY public.cases.id;
 
 
 --
+-- Name: cases_outcome_reasons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.cases_outcome_reasons (
+    id bigint NOT NULL,
+    case_id bigint,
+    outcome_reason_id bigint,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: cases_outcome_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.cases_outcome_reasons_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: cases_outcome_reasons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.cases_outcome_reasons_id_seq OWNED BY public.cases_outcome_reasons.id;
+
+
+--
 -- Name: cases_users_transitions_trackers; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1235,6 +1267,13 @@ ALTER TABLE ONLY public.cases_exemptions ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: cases_outcome_reasons id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cases_outcome_reasons ALTER COLUMN id SET DEFAULT nextval('public.cases_outcome_reasons_id_seq'::regclass);
+
+
+--
 -- Name: cases_users_transitions_trackers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1421,6 +1460,14 @@ ALTER TABLE ONLY public.case_transitions
 
 ALTER TABLE ONLY public.cases_exemptions
     ADD CONSTRAINT cases_exemptions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: cases_outcome_reasons cases_outcome_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.cases_outcome_reasons
+    ADD CONSTRAINT cases_outcome_reasons_pkey PRIMARY KEY (id);
 
 
 --
@@ -1717,6 +1764,20 @@ CREATE INDEX index_cases_on_requester_type ON public.cases USING btree (requeste
 --
 
 CREATE INDEX index_cases_on_user_id ON public.cases USING btree (user_id);
+
+
+--
+-- Name: index_cases_outcome_reasons_on_case_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_cases_outcome_reasons_on_case_id ON public.cases_outcome_reasons USING btree (case_id);
+
+
+--
+-- Name: index_cases_outcome_reasons_on_outcome_reason_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_cases_outcome_reasons_on_outcome_reason_id ON public.cases_outcome_reasons USING btree (outcome_reason_id);
 
 
 --
@@ -2157,7 +2218,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210727143427'),
 ('20210914110858'),
 ('20210914111215'),
-('20210917113753');
-
+('20210917113753'),
+('20220117091139');
 
 

--- a/spec/decorators/case/sar/sar_internal_review_decorator_spec.rb
+++ b/spec/decorators/case/sar/sar_internal_review_decorator_spec.rb
@@ -23,6 +23,26 @@ describe Case::SAR::InternalReviewDecorator do
     end
   end
 
+  describe '#pretty_outcome_reasons' do
+    it 'pretty prints outcome_reasons' do
+      stub_reasons = [
+        double(CaseClosure::OutcomeReason),
+        double(CaseClosure::OutcomeReason),
+        double(CaseClosure::OutcomeReason)
+      ]
+
+      stub_reasons.each_with_index do |reason, i|
+        allow(reason).to receive(:name).and_return("Outcome Reason #{i + 1}")
+      end
+
+      kase = sar_ir_case.decorate
+      allow(kase.object).to receive(:outcome_reasons).and_return(stub_reasons)
+
+      expected_string = 'Outcome Reason 1,<br>Outcome Reason 2,<br>Outcome Reason 3'
+      expect(kase.pretty_outcome_reasons).to eq expected_string 
+    end
+  end
+
   describe '#subject_type_display' do
     it 'humanizes the subject_type for display' do
       kase = sar_ir_case.decorate

--- a/spec/factories/case/sar_internal_reviews.rb
+++ b/spec/factories/case/sar_internal_reviews.rb
@@ -310,4 +310,38 @@ FactoryBot.define do
       kase.reload
     end
   end
+
+  factory :ready_to_close_sar_internal_review, parent: :accepted_sar_internal_review do
+    missing_info { false }
+
+    transient do
+      identifier { "responded sar ir" }
+    end
+
+    received_date  { 22.business_days.ago }
+    date_responded { 4.business_days.ago }
+
+    after(:create) do |kase, evaluator|
+      if evaluator.flag_for_disclosure
+        create :case_transition_progress_for_clearance,
+               case: kase,
+               acting_team: evaluator.responding_team,
+               acting_user: evaluator.responder,
+               target_team: evaluator.approving_team
+
+        create :case_transition_approve,
+               case: kase,
+               acting_team: evaluator.approving_team,
+               acting_user: evaluator.approver
+      end
+
+      create :case_transition_respond,
+             case: kase,
+             acting_user: evaluator.responder,
+             acting_team: evaluator.responding_team,
+             target_user: evaluator.responder,
+             target_team: evaluator.responding_team
+      kase.reload
+    end
+  end
 end

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -50,10 +50,13 @@ feature 'SAR Internal Review Case can be closed', js:true do
 
         cases_closure_outcomes_page.sar_ir_responsible_for_outcome.disclosure.click
         cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
+        cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Incorrect exemption engaged", visible: false
         cases_closure_outcomes_page.missing_info.sar_ir_yes.click
         cases_closure_outcomes_page.submit_button.click
 
         expect(cases_show_page).to have_content("You've closed this case.")
+        expect(cases_show_page).to have_content("Excessive redaction(s)")
+        expect(cases_show_page).to have_content("Incorrect exemption engaged")
       end
     end
 

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -27,19 +27,27 @@ feature 'SAR Internal Review Case can be closed', js:true do
   end
 
   describe 'as a manager closing a SAR IR' do
-    fcontext 'for late case' do
+    context 'for late case' do
       it 'page loads with correct fields asking who is responsible for lateness' do
         login_as manager
         cases_page.load
         click_link "#{late_sar_ir.number}"
         cases_show_page.actions.close_case.click
+
         cases_close_page.submit_button.click
 
-        cases_closure_outcomes_page.sar_ir_responsible_for_lateness.disclosure_radio.click
-        cases_closure_outcomes_page.sar_ir_outcome.upheld_in_part.click
-        cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
-        cases_closure_outcomes_page.missing_info.sar_ir_yes.click
+        cases_closure_outcomes_page.sar_ir_responsible_for_lateness.disclosure.click
+
         on_load_field_expectations(lateness: true)
+
+        cases_closure_outcomes_page.sar_ir_outcome.upheld_in_part.click
+
+        hidden_fields_are_shown_expectations
+
+        cases_closure_outcomes_page.sar_ir_responsible_for_outcome.disclosure.click
+        cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
+
+        cases_closure_outcomes_page.missing_info.sar_ir_yes.click
 
         cases_closure_outcomes_page.submit_button.click
 
@@ -54,8 +62,16 @@ feature 'SAR Internal Review Case can be closed', js:true do
         click_link "#{sar_ir.number}"
         cases_show_page.actions.close_case.click
         cases_close_page.submit_button.click
-        cases_closure_outcomes_page.sar_ir_outcome.upheld.click
+
         on_load_field_expectations
+
+        cases_closure_outcomes_page.sar_ir_outcome.upheld.click
+        cases_closure_outcomes_page.missing_info.sar_ir_yes.click
+        hidden_fields_are_not_shown_expectations
+
+        cases_closure_outcomes_page.submit_button.click
+
+        expect(cases_show_page).to have_content("You've closed this case.")
       end
     end
   end
@@ -66,9 +82,21 @@ feature 'SAR Internal Review Case can be closed', js:true do
     else
       expect(page).to_not have_content("Who was responsible for lateness?")
     end
+
+    expect(page).to_not have_content("Who was responsible for outcome being partially upheld or overturned?")
+    expect(page).to_not have_content("Reason(s) for outcome being partially upheld out overturned?")
+
     expect(page).to have_content("SAR IR Outcome?")
-    # expect(page).to_not have_content("Who was responsible for outcome being partially upheld or overturned?")
-    # expect(page).to_not have_content("Reason(s) for outcome being partly upheld or overturned?")
     expect(page).to have_content("Was the response asking for missing information (e.g. proof of ID), or clarification, i.e. a TTM?")
+  end
+
+  def hidden_fields_are_shown_expectations
+    expect(page).to have_content("Who was responsible for outcome being partially upheld or overturned?")
+    expect(page).to have_content("Reason(s) for outcome being partially upheld out overturned?")
+  end
+
+  def hidden_fields_are_not_shown_expectations
+    expect(page).to_not have_content("Who was responsible for outcome being partially upheld or overturned?")
+    expect(page).to_not have_content("Reason(s) for outcome being partially upheld out overturned?")
   end
 end

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -21,14 +21,18 @@ feature 'SAR Internal Review Case can be closed', js:true do
     find_or_create :team_dacu_disclosure
   end
 
-  before do
+  before(:all) do
     require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
     CaseClosure::MetadataSeeder.seed!
   end
 
+  after(:all) do
+    CaseClosure::MetadataSeeder.unseed!
+  end
+
   describe 'as a manager closing a SAR IR' do
     context 'for late case' do
-      it 'page loads with correct fields asking who is responsible for lateness' do
+      scenario 'page loads with correct fields asking who is responsible for lateness' do
         login_as manager
         cases_page.load
         click_link "#{late_sar_ir.number}"
@@ -42,13 +46,11 @@ feature 'SAR Internal Review Case can be closed', js:true do
 
         cases_closure_outcomes_page.sar_ir_outcome.upheld_in_part.click
 
-        hidden_fields_are_shown_expectations
+        hidden_fields_expectations
 
         cases_closure_outcomes_page.sar_ir_responsible_for_outcome.disclosure.click
         cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
-
         cases_closure_outcomes_page.missing_info.sar_ir_yes.click
-
         cases_closure_outcomes_page.submit_button.click
 
         expect(cases_show_page).to have_content("You've closed this case.")
@@ -56,7 +58,7 @@ feature 'SAR Internal Review Case can be closed', js:true do
     end
 
     context 'for in-time case' do
-      it 'page loads with correct fields asking' do
+      scenario 'page loads with correct fields asking' do
         login_as manager
         cases_page.load
         click_link "#{sar_ir.number}"
@@ -67,7 +69,8 @@ feature 'SAR Internal Review Case can be closed', js:true do
 
         cases_closure_outcomes_page.sar_ir_outcome.upheld.click
         cases_closure_outcomes_page.missing_info.sar_ir_yes.click
-        hidden_fields_are_not_shown_expectations
+
+        hidden_fields_expectations(should_be_shown: false)
 
         cases_closure_outcomes_page.submit_button.click
 
@@ -76,6 +79,8 @@ feature 'SAR Internal Review Case can be closed', js:true do
     end
   end
 
+  private
+
   def on_load_field_expectations(lateness: false) 
     if lateness
       expect(page).to have_content("Who was responsible for lateness?")
@@ -83,20 +88,17 @@ feature 'SAR Internal Review Case can be closed', js:true do
       expect(page).to_not have_content("Who was responsible for lateness?")
     end
 
-    expect(page).to_not have_content("Who was responsible for outcome being partially upheld or overturned?")
-    expect(page).to_not have_content("Reason(s) for outcome being partially upheld out overturned?")
-
     expect(page).to have_content("SAR IR Outcome?")
     expect(page).to have_content("Was the response asking for missing information (e.g. proof of ID), or clarification, i.e. a TTM?")
   end
 
-  def hidden_fields_are_shown_expectations
-    expect(page).to have_content("Who was responsible for outcome being partially upheld or overturned?")
-    expect(page).to have_content("Reason(s) for outcome being partially upheld out overturned?")
-  end
-
-  def hidden_fields_are_not_shown_expectations
-    expect(page).to_not have_content("Who was responsible for outcome being partially upheld or overturned?")
-    expect(page).to_not have_content("Reason(s) for outcome being partially upheld out overturned?")
+  def hidden_fields_expectations(should_be_shown: true)
+    if should_be_shown
+      expect(page).to have_content("Who was responsible for outcome being partially upheld or overturned?")
+      expect(page).to have_content("Reason(s) for outcome being partially upheld out overturned?")
+    else
+      expect(page).to_not have_content("Who was responsible for outcome being partially upheld or overturned?")
+      expect(page).to_not have_content("Reason(s) for outcome being partially upheld out overturned?")
+    end
   end
 end

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+feature 'SAR Internal Review Case can be closed', js:true do
+
+  given(:responder)       { find_or_create(:sar_responder) }
+  given(:responding_team) { create :responding_team, responders: [responder] }
+  given(:manager)         { find_or_create :disclosure_bmt_user }
+  given(:managing_team)   { create :managing_team, managers: [manager] }
+  given(:approver)        { (find_or_create :team_dacu_disclosure).users.first }
+
+  let!(:sar_ir) { create(:ready_to_close_sar_internal_review) }
+
+  let!(:late_sar_ir) { 
+    create(:ready_to_close_sar_internal_review, 
+            date_responded: Date.today,
+            external_deadline: Date.today - 5) 
+  }
+
+  background do
+    responding_team
+    find_or_create :team_dacu_disclosure
+  end
+
+  before do
+    require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
+    CaseClosure::MetadataSeeder.seed!
+  end
+
+  context 'as a manager closing a SAR IR' do
+    context 'for late case' do
+      it 'page loads with correct fields asking who is responsible for lateness' do
+        login_as manager
+        cases_page.load
+        click_link "#{late_sar_ir.number}"
+        cases_show_page.actions.close_case.click
+        cases_close_page.submit_button.click
+        on_load_field_expectations(lateness: true)
+      end
+    end
+
+    context 'for in-time case' do
+      it 'page loads with correct fields asking' do
+        login_as manager
+        cases_page.load
+        click_link "#{sar_ir.number}"
+        cases_show_page.actions.close_case.click
+        cases_close_page.submit_button.click
+        on_load_field_expectations
+      end
+    end
+  end
+
+  def on_load_field_expectations(lateness: false) 
+    if lateness
+      expect(page).to have_content("Who was responsible for lateness?")
+    else
+      expect(page).to_not have_content("Who was responsible for lateness?")
+    end
+    expect(page).to have_content("SAR IR Outcome?")
+    expect(page).to have_content("Who was responsible for outcome being partially upheld or overturned?")
+    expect(page).to have_content("Was the response asking for missing information (e.g. proof of ID), or clarification, i.e. a TTM?")
+  end
+end

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -26,7 +26,7 @@ feature 'SAR Internal Review Case can be closed', js:true do
     CaseClosure::MetadataSeeder.seed!
   end
 
-  context 'as a manager closing a SAR IR' do
+  describe 'as a manager closing a SAR IR' do
     context 'for late case' do
       it 'page loads with correct fields asking who is responsible for lateness' do
         login_as manager

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -36,8 +36,6 @@ feature 'SAR Internal Review Case can be closed', js:true do
 
         cases_close_page.submit_button.click
 
-        binding.pry
-
         cases_closure_outcomes_page.sar_ir_responsible_for_lateness.disclosure.click
 
         on_load_field_expectations(lateness: true)

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -36,6 +36,8 @@ feature 'SAR Internal Review Case can be closed', js:true do
 
         cases_close_page.submit_button.click
 
+        binding.pry
+
         cases_closure_outcomes_page.sar_ir_responsible_for_lateness.disclosure.click
 
         on_load_field_expectations(lateness: true)

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -21,12 +21,12 @@ feature 'SAR Internal Review Case can be closed', js:true do
     find_or_create :team_dacu_disclosure
   end
 
-  before(:all) do
+  before :all do
     require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
     CaseClosure::MetadataSeeder.seed!
   end
 
-  after(:all) do
+  after :all do
     CaseClosure::MetadataSeeder.unseed!
   end
 
@@ -38,7 +38,6 @@ feature 'SAR Internal Review Case can be closed', js:true do
         click_link "#{late_sar_ir.number}"
         cases_show_page.actions.close_case.click
         cases_close_page.submit_button.click
-
 
         on_load_field_expectations(lateness: true)
 

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -13,7 +13,7 @@ feature 'SAR Internal Review Case can be closed', js:true do
   let!(:late_sar_ir) { 
     create(:ready_to_close_sar_internal_review, 
             date_responded: Date.today,
-            external_deadline: Date.today - 10) 
+            external_deadline: 30.business_days.ago) 
   }
 
   background do
@@ -37,12 +37,12 @@ feature 'SAR Internal Review Case can be closed', js:true do
         cases_page.load
         click_link "#{late_sar_ir.number}"
         cases_show_page.actions.close_case.click
-
         cases_close_page.submit_button.click
 
-        cases_closure_outcomes_page.sar_ir_responsible_for_lateness.disclosure.click
 
         on_load_field_expectations(lateness: true)
+
+        cases_closure_outcomes_page.sar_ir_responsible_for_lateness.disclosure.click
 
         cases_closure_outcomes_page.sar_ir_outcome.upheld_in_part.click
 
@@ -57,6 +57,8 @@ feature 'SAR Internal Review Case can be closed', js:true do
         expect(cases_show_page).to have_content("You've closed this case.")
         expect(cases_show_page).to have_content("Excessive redaction(s)")
         expect(cases_show_page).to have_content("Incorrect exemption engaged")
+        expect(cases_show_page).to have_content("Business unit responsible for appeal outcome")
+        expect(cases_show_page).to have_content("Disclosure BMT")
       end
     end
 

--- a/spec/features/cases/sar_internal_review/case_creating_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_creating_spec.rb
@@ -22,6 +22,11 @@ feature 'SAR Internal Review Case creation by a manager' do
     cases_page.load
   end
 
+  before do
+    require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
+    CaseClosure::MetadataSeeder.seed!
+  end
+
   scenario 'creating a SAR internal review case', js: true do
     when_i_start_sar_ir_case_journey
     and_i_try_to_link_an_foi_case

--- a/spec/features/cases/sar_internal_review/case_creating_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_creating_spec.rb
@@ -22,9 +22,13 @@ feature 'SAR Internal Review Case creation by a manager' do
     cases_page.load
   end
 
-  before do
+  before :all do
     require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
     CaseClosure::MetadataSeeder.seed!
+  end
+
+  after :all do
+    CaseClosure::MetadataSeeder.unseed!
   end
 
   scenario 'creating a SAR internal review case', js: true do
@@ -59,20 +63,12 @@ feature 'SAR Internal Review Case creation by a manager' do
     then_they_can_mark_the_case_as_sent
 
     when_a_manager_logs_in
-    and_they_can_close_the_case
-    then_they_are_alerted_that_the_case_is_closed
+    they_see_the_option_to_close_the_case
   end
 
-  def then_they_are_alerted_that_the_case_is_closed
-    expect(page).to have_content("You've closed this case.")
-  end
-
-  def and_they_can_close_the_case
+  def they_see_the_option_to_close_the_case
     click_link latest_sar_ir_number
-    cases_show_page.actions.close_case.click
-    cases_close_page.submit_button.click
-    cases_closure_outcomes_page.missing_info.sar_ir_no.click
-    cases_closure_outcomes_page.submit_button.click
+    expect(cases_show_page.actions.close_case).to be_a(Capybara::Node::Element)
   end
 
   def when_a_manager_logs_in

--- a/spec/features/cases/sar_internal_review/case_editing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_editing_spec.rb
@@ -72,8 +72,8 @@ feature 'SAR Internal Review Case can be edited', js:true do
     expect(page).to_not have_content('Edit case details')
   end
 
-  def and_they_edit_the_case_details(sar_ir)
-    cases_show_page.load(id: sar_ir.id)
+  def and_they_edit_the_case_details(sar_internal_review)
+    cases_show_page.load(id: sar_internal_review.id)
     cases_show_page.case_details.edit_case.click
 
     page = case_new_sar_ir_case_details_page

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -32,9 +32,13 @@ require 'rails_helper'
 
 describe Case::SAR::InternalReview do
 
-  before do
+  before :all do
     require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
     CaseClosure::MetadataSeeder.seed!
+  end
+
+  after :all do
+    CaseClosure::MetadataSeeder.unseed!
   end
 
   context 'validates that SAR-specific fields are not blank' do

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -32,6 +32,11 @@ require 'rails_helper'
 
 describe Case::SAR::InternalReview do
 
+  before do
+    require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
+    CaseClosure::MetadataSeeder.seed!
+  end
+
   context 'validates that SAR-specific fields are not blank' do
     it 'is not valid' do
 
@@ -435,5 +440,16 @@ describe Case::SAR::InternalReview do
     it { should validate_presence_of(:sar_ir_subtype) }
 
     it { should have_enum(:sar_ir_subtype).with_values(['timeliness', 'compliance' ]) }
+  end
+
+  describe '#sar_ir_outcome' do
+    let(:sar_internal_review) { build(:sar_internal_review) }
+    it 'can set a sar_ir_outcome by name' do
+      sar_internal_review.sar_ir_outcome = "Upheld"
+
+      expect(sar_internal_review.sar_ir_outcome).to match("Upheld")
+      expect(sar_internal_review.appeal_outcome).to be_an_instance_of(CaseClosure::AppealOutcome)
+      expect(sar_internal_review.appeal_outcome.abbreviation).to match("upheld")
+    end
   end
 end

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -456,4 +456,16 @@ describe Case::SAR::InternalReview do
       expect(sar_internal_review.appeal_outcome.abbreviation).to match("upheld")
     end
   end
+
+  describe '#sar_ir_outcome_abbr' do
+    let(:sar_internal_review) { build(:sar_internal_review) }
+    it 'can return a sar ir outcome abbreviation' do
+      sar_internal_review.sar_ir_outcome = "Upheld"
+
+      expect(sar_internal_review.sar_ir_outcome_abbr).to match("upheld")
+      expect(sar_internal_review.sar_ir_outcome_abbr).to be_an_instance_of(String)
+      expect(sar_internal_review.sar_ir_outcome_abbr).to match("upheld")
+    end
+  end
+
 end

--- a/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
@@ -12,11 +12,25 @@ module PageObjects
                  PageObjects::Sections::Cases::CaseAttachmentSection,
                  '.case-attachments-group'
 
+        section :sar_ir_outcome, '.appeal-outcome-group' do
+          element :upheld, 'label[for="sar_internal_review_sar_ir_outcome_id_upheld"]'
+          element :upheld_in_part, 'label[for="sar_internal_review_sar_ir_outcome_id_upheld_in_part"]'
+          element :overturned, 'label[for="sar_internal_review_sar_ir_outcome_id_overturned"]'
+        end
+
+        section :sar_ir_outcome_reasons, '.outcome-reasons-group' do
+        end
+
+        section :sar_ir_responsible_for_lateness, '.responsible-for-lateness-group' do
+          element :disclosure_radio, 'input[id^="sar_internal_review_late_team_id_"]', match: :first, visible: false
+        end
+
         section :appeal_outcome, '.appeal-outcome-group' do
           element :upheld, 'label[for="foi_appeal_outcome_name_upheld"]'
           element :upheld_in_part, 'label[for="foi_appeal_outcome_name_upheld_in_part"]'
           element :overturned, 'label[for="foi_appeal_outcome_name_overturned"]'
         end
+
 
         section :ico_decision, '.ico-decision' do
           element :upheld, 'input#case_ico_ico_decision_upheld', visible: false

--- a/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
@@ -17,9 +17,9 @@ module PageObjects
         end
 
         section :sar_ir_outcome, '.appeal-outcome-group' do
-          element :upheld, 'label[for="sar_internal_review_sar_ir_outcome_id_upheld"]'
-          element :upheld_in_part, 'label[for="sar_internal_review_sar_ir_outcome_id_upheld_in_part"]'
-          element :overturned, 'label[for="sar_internal_review_sar_ir_outcome_id_overturned"]'
+          element :upheld, 'label[for="sar_internal_review_sar_ir_outcome_upheld"]'
+          element :upheld_in_part, 'label[for="sar_internal_review_sar_ir_outcome_upheld_in_part"]'
+          element :overturned, 'label[for="sar_internal_review_sar_ir_outcome_overturned"]'
         end
 
         section :sar_ir_responsible_for_outcome, '.responsible-for-outcome-group' do

--- a/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
@@ -12,18 +12,23 @@ module PageObjects
                  PageObjects::Sections::Cases::CaseAttachmentSection,
                  '.case-attachments-group'
 
+        section :sar_ir_responsible_for_lateness, '.responsible-for-lateness-group' do
+          element :disclosure, 'input[id^="sar_internal_review_late_team_id_"]', match: :first, visible: false
+        end
+
         section :sar_ir_outcome, '.appeal-outcome-group' do
           element :upheld, 'label[for="sar_internal_review_sar_ir_outcome_id_upheld"]'
           element :upheld_in_part, 'label[for="sar_internal_review_sar_ir_outcome_id_upheld_in_part"]'
           element :overturned, 'label[for="sar_internal_review_sar_ir_outcome_id_overturned"]'
         end
 
+        section :sar_ir_responsible_for_outcome, '.responsible-for-outcome-group' do
+          element :disclosure, 'input[id^="sar_internal_review_team_responsible_for_outcome_id_"]', match: :first, visible: false
+        end
+
         section :sar_ir_outcome_reasons, '.outcome-reasons-group' do
         end
 
-        section :sar_ir_responsible_for_lateness, '.responsible-for-lateness-group' do
-          element :disclosure_radio, 'input[id^="sar_internal_review_late_team_id_"]', match: :first, visible: false
-        end
 
         section :appeal_outcome, '.appeal-outcome-group' do
           element :upheld, 'label[for="foi_appeal_outcome_name_upheld"]'

--- a/spec/validators/closed_case_validator_spec.rb
+++ b/spec/validators/closed_case_validator_spec.rb
@@ -562,5 +562,69 @@ describe 'ClosedCaseValidator' do
     end
   end
 
+  fcontext 'SAR IR cases' do
+
+    let!(:sar_ir) { create(:ready_to_close_sar_internal_review) }
+    let(:outcome_reason_ids) { CaseClosure::OutcomeReason.all.map(&:id) }
+
+    before(:each) do
+      sar_ir.prepare_for_close
+    end
+
+    context '#validate_sar_ir_outcome' do
+      context 'sar_ir_outcome blank' do
+        it 'has correct error' do
+          sar_ir.save
+          expect(sar_ir.errors[:sar_ir_outcome]).to eq ['must be selected']
+        end
+      end
+
+      context 'sar_ir_outcome present' do
+        it 'has no errors' do
+          sar_ir.sar_ir_outcome = 'Upheld'
+          sar_ir.save
+          expect(sar_ir.errors[:sar_ir_outcome]).to eq [] 
+        end
+      end
+    end
+
+    context '#validate_outcome_reasons' do
+      context 'outcome reasons blank' do
+        it 'has correct error' do
+          sar_ir.sar_ir_outcome = 'Upheld in part'
+          sar_ir.save
+          expect(sar_ir.errors[:outcome_reasons]).to eq ['must be selected']
+        end
+      end
+
+      context 'ourcome reasonss present' do
+        it 'has no errors' do
+          sar_ir.sar_ir_outcome = 'Upheld in part'
+          sar_ir.outcome_reason_ids = outcome_reason_ids
+          sar_ir.save
+          expect(sar_ir.errors[:outcome_reasons]).to eq [] 
+        end
+      end
+    end
+
+    context '#validate_team_responsible' do
+      context 'team responsible blank' do
+        it 'has correct error' do
+          sar_ir.sar_ir_outcome = 'Upheld in part'
+          sar_ir.save
+          expect(sar_ir.errors[:team_responsible_for_outcome]).to eq ['must be selected']
+        end
+      end
+
+      context 'team responsible present' do
+        it 'has no errors' do
+          sar_ir.sar_ir_outcome = 'Upheld in part'
+          sar_ir.team_responsible_for_outcome_id = 1
+          sar_ir.save
+          expect(sar_ir.errors[:team_responsible_for_outcome]).to eq [] 
+        end
+      end
+    end
+  end
 end
 

--- a/spec/validators/closed_case_validator_spec.rb
+++ b/spec/validators/closed_case_validator_spec.rb
@@ -574,7 +574,7 @@ describe 'ClosedCaseValidator' do
     context '#validate_sar_ir_outcome' do
       context 'sar_ir_outcome blank' do
         it 'has correct error' do
-          sar_ir.save
+          sar_ir.valid?
           expect(sar_ir.errors[:sar_ir_outcome]).to eq ['must be selected']
         end
       end
@@ -582,7 +582,7 @@ describe 'ClosedCaseValidator' do
       context 'sar_ir_outcome present' do
         it 'has no errors' do
           sar_ir.sar_ir_outcome = 'Upheld'
-          sar_ir.save
+          sar_ir.valid?
           expect(sar_ir.errors[:sar_ir_outcome]).to eq [] 
         end
       end
@@ -592,7 +592,7 @@ describe 'ClosedCaseValidator' do
       context 'outcome reasons blank' do
         it 'has correct error' do
           sar_ir.sar_ir_outcome = 'Upheld in part'
-          sar_ir.save
+          sar_ir.valid?
           expect(sar_ir.errors[:outcome_reasons]).to eq ['must be selected']
         end
       end
@@ -601,7 +601,7 @@ describe 'ClosedCaseValidator' do
         it 'has no errors' do
           sar_ir.sar_ir_outcome = 'Upheld in part'
           sar_ir.outcome_reason_ids = outcome_reason_ids
-          sar_ir.save
+          sar_ir.valid?
           expect(sar_ir.errors[:outcome_reasons]).to eq [] 
         end
       end
@@ -611,7 +611,7 @@ describe 'ClosedCaseValidator' do
       context 'team responsible blank' do
         it 'has correct error' do
           sar_ir.sar_ir_outcome = 'Upheld in part'
-          sar_ir.save
+          sar_ir.valid?
           expect(sar_ir.errors[:team_responsible_for_outcome_id]).to eq ['must be selected']
         end
       end
@@ -620,7 +620,7 @@ describe 'ClosedCaseValidator' do
         it 'has no errors' do
           sar_ir.sar_ir_outcome = 'Upheld in part'
           sar_ir.team_responsible_for_outcome_id = 1
-          sar_ir.save
+          sar_ir.valid?
           expect(sar_ir.errors[:team_responsible_for_outcome_id]).to eq [] 
         end
       end

--- a/spec/validators/closed_case_validator_spec.rb
+++ b/spec/validators/closed_case_validator_spec.rb
@@ -612,7 +612,7 @@ describe 'ClosedCaseValidator' do
         it 'has correct error' do
           sar_ir.sar_ir_outcome = 'Upheld in part'
           sar_ir.save
-          expect(sar_ir.errors[:team_responsible_for_outcome]).to eq ['must be selected']
+          expect(sar_ir.errors[:team_responsible_for_outcome_id]).to eq ['must be selected']
         end
       end
 
@@ -621,7 +621,7 @@ describe 'ClosedCaseValidator' do
           sar_ir.sar_ir_outcome = 'Upheld in part'
           sar_ir.team_responsible_for_outcome_id = 1
           sar_ir.save
-          expect(sar_ir.errors[:team_responsible_for_outcome]).to eq [] 
+          expect(sar_ir.errors[:team_responsible_for_outcome_id]).to eq [] 
         end
       end
     end


### PR DESCRIPTION
## Description
Allows manager to close case and add case closure outcomes. Edit closure to follow shortly, wanted to keep this PR _relatively_ short.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
New screens:

Close page:
<img width="990" alt="Screenshot 2022-01-21 at 13 43 38" src="https://user-images.githubusercontent.com/13377553/150537572-f01155e6-e3cf-410c-ba77-8e4d5c5609b1.png">

Closure outcomes:
<img width="791" alt="Screenshot 2022-01-21 at 13 44 05" src="https://user-images.githubusercontent.com/13377553/150537655-6394f367-b7b8-45f3-8acd-1f6b3cfb9cac.png">

When not upheld:
<img width="496" alt="Screenshot 2022-01-21 at 13 44 46" src="https://user-images.githubusercontent.com/13377553/150537690-c3b6d6a7-9eac-4d70-a5b5-09f167191553.png">

Show page:
<img width="744" alt="Screenshot 2022-01-21 at 13 45 28" src="https://user-images.githubusercontent.com/13377553/150537735-7ea2837b-71cd-4f8c-beb2-15c41cfb364e.png">


### Related JIRA tickets
[CT-3991](https://dsdmoj.atlassian.net/browse/CT-3991)

### Deployment
@ymao2 what do you think the best way to seed the metadata is? I wanted to check with you whether this is done automatically or not before I add a specific data migration 👍 

### Manual testing instructions
- Take a case through to closure and check that the correct fields are displayed.
- 
