### PR TITLE
CT-3991 editing closure outcomes

### DIFF
--- a/app/controllers/concerns/closable.rb
+++ b/app/controllers/concerns/closable.rb
@@ -168,6 +168,8 @@ module Closable
 
     service = UpdateClosureService.new(@case, current_user, close_params)
     service.call
+    
+    @team_collection = CaseTeamCollection.new(@case)
 
     if service.result == :ok
       set_permitted_events

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -25,11 +25,6 @@ class Case::SAR::InternalReview < Case::SAR::Standard
     self.workflow = 'trigger'
   end
 
-  def respond_and_close(current_user)
-    state_machine.respond!(acting_user: current_user, acting_team: self.managing_team)
-    state_machine.close!(acting_user: current_user, acting_team: self.managing_team)
-  end
-
   class << self
     def type_abbreviation
       # This string is used when constructing paths or methods in other parts of

--- a/app/services/update_closure_service.rb
+++ b/app/services/update_closure_service.rb
@@ -30,6 +30,10 @@ class UpdateClosureService
   end
 
   def find_user_role
+    if @kase.is_sar_internal_review? 
+      return :approver if @user.approver?
+    end
+
     @user.manager? ? :manager : :responder
   end
 end

--- a/app/state_machines/configurable_state_machine/machine.rb
+++ b/app/state_machines/configurable_state_machine/machine.rb
@@ -275,6 +275,7 @@ module ConfigurableStateMachine
     def trigger_event(event:, params:)
       event = event.to_sym
       raise ::ConfigurableStateMachine::ArgumentError.new(kase: @kase, event: event, params: params) if !params.key?(:acting_user) || !params.key?(:acting_team)
+
       role =  params[:acting_team].role
       user_role_config = @config.user_roles[role]
       if user_role_config.nil?

--- a/app/views/cases/_case_attachments.html.slim
+++ b/app/views/cases/_case_attachments.html.slim
@@ -1,16 +1,17 @@
 .case-attachments
-  h2.request--heading
-    = translate_for_case(case_details, 'cases.show', 'attachments_heading')
-  .request--message
-    - case_details.upload_response_groups.each do |ug|
-      .case-attachments-group
-        h3.case-attachments--primary
-          = ug.date_time
-          span.case-attachments--secondary
-            = " #{ug.user.full_name} "
-          span.case-attachments--secondary
-            = " #{ ug.team_name }"
+  - if case_details.upload_response_groups.any? 
+    h2.request--heading
+      = translate_for_case(case_details, 'cases.show', 'attachments_heading')
+    .request--message
+      - case_details.upload_response_groups.each do |ug|
+        .case-attachments-group
+          h3.case-attachments--primary
+            = ug.date_time
+            span.case-attachments--secondary
+              = " #{ug.user.full_name} "
+            span.case-attachments--secondary
+              = " #{ ug.team_name }"
 
-        = render partial: 'cases/attachment_report',
-                locals: {attachments: ug.collection,
-                        case_details: case_details}
+          = render partial: 'cases/attachment_report',
+                  locals: {attachments: ug.collection,
+                          case_details: case_details}

--- a/app/views/cases/sar_internal_review/_close_form.html.slim
+++ b/app/views/cases/sar_internal_review/_close_form.html.slim
@@ -1,10 +1,34 @@
 - url = defined?(form_url) ? form_url : polymorphic_path(@case, action: :process_closure)
-
 = form_for @case, as: :sar_internal_review, url: url do |f|
   .form-group
     = f.gov_uk_date_field :date_responded, { legend_text: t('cases.sar.close_form.close_date'),
             form_hint_text: t('cases.sar.close_form.date_example'),
             today_button: {class: ''} }
+
+  .js-sar-internal-review
+
+  - if @case.responded_late?
+    .responsible-for-lateness-group
+      = render partial: 'cases/shared/team_caused_late_response', locals: {kase: @case, f: f}
+
+  .appeal-outcome-group
+    = f.radio_button_fieldset :sar_ir_outcome, choices: CaseClosure::AppealOutcome.active.map(&:name)
+
+  .responsible-for-outcome-group
+    = f.radio_button_fieldset :team_responsible_for_outcome_id, 
+      choices: @team_collection.teams, 
+      text_method: :name, 
+      value_method: :id
+
+  .outcome-reasons-group
+    = render partial: 'cases/sar_internal_review/outcome_reason_checkbox_section', 
+      locals: { outcome_reasons: CaseClosure::OutcomeReason.all, 
+        heading: 'Reason(s) for outcome being partially upheld out overturned?', 
+        hint: 'Select all that apply', 
+        kase: @case, f: f }
+
+  .missing-info
+    = f.radio_button_fieldset :missing_info
 
   .grid-row
     .column-two-thirds

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -1,4 +1,4 @@
-- url = defined?(form_url) ? form_url : polymorphic_path(@case, action: :process_respond_and_close)
+- url = defined?(form_url) ? form_url : polymorphic_path(@case, action: :process_closure)
 = form_for kase, as: :sar_internal_review, url: url do |f|
 
   .js-sar-internal-review
@@ -25,7 +25,6 @@
 
   .missing-info
     = f.radio_button_fieldset :missing_info
-
   .grid-row
     .column-two-thirds
       .button-holder

--- a/config/state_machine/configs/00_moj/60_sar_internal_review/30_sar_internal_review_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/60_sar_internal_review/30_sar_internal_review_trigger_workflow.yml
@@ -246,5 +246,7 @@
               closed:
                 add_message_to_case:
                   if: Workflows::Predicates#user_is_approver_on_case?
+                update_closure:
+                  if: Workflows::Predicates#user_is_approver_on_case?
                 edit_case:
                   if: Workflows::Predicates#user_is_approver_on_case?

--- a/config/state_machine/configs/00_moj/60_sar_internal_review/30_sar_internal_review_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/60_sar_internal_review/30_sar_internal_review_trigger_workflow.yml
@@ -77,7 +77,6 @@
               responded:
                 add_message_to_case:
                   after_transition: Workflows::Hooks#notify_responder_message_received
-                respond:
                 close:
                   transition_to: closed
                 destroy_case:

--- a/config/state_machine/configs/00_moj/60_sar_internal_review/30_sar_internal_review_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/60_sar_internal_review/30_sar_internal_review_trigger_workflow.yml
@@ -155,8 +155,6 @@
               closed:
                 add_message_to_case:
                   if: Workflows::Predicates#responder_is_member_of_assigned_team?
-                update_closure:
-                  if: Workflows::Predicates#overturned_editing_enabled_and_responder_in_assigned_team?
 
           ########################### SAR INTERNAL REVIEW :: STANDARD WORKFLOW :: APPROVER ########################
           approver:

--- a/spec/factories/case/sar_internal_reviews.rb
+++ b/spec/factories/case/sar_internal_reviews.rb
@@ -254,15 +254,17 @@ FactoryBot.define do
     end
   end
 
-  factory :closed_sar_internal_review, parent: :accepted_sar_internal_review do
+  factory :closed_sar_internal_review, parent: :approved_sar_internal_review do
     missing_info { false }
-
-    transient do
-      identifier { "closed sar" }
-    end
 
     received_date  { 22.business_days.ago }
     date_responded { 4.business_days.ago }
+
+    transient do
+      identifier { "closed sar internal review" }
+      date_draft_compliant { received_date + 2.days }
+    end
+
 
     after(:create) do |kase, evaluator|
       if evaluator.flag_for_disclosure
@@ -277,6 +279,7 @@ FactoryBot.define do
                acting_team: evaluator.approving_team,
                acting_user: evaluator.approver
       end
+
 
       create :case_transition_respond,
              case: kase,

--- a/spec/factories/case_closure_metadata.rb
+++ b/spec/factories/case_closure_metadata.rb
@@ -397,6 +397,28 @@ FactoryBot.define do
     end
   end
 
+  factory :outcome_reason, class: CaseClosure::OutcomeReason do
+    subtype                       { nil }
+
+    trait :missing_info do
+      name { 'Proper searches not carried out/missing information' }
+      abbreviation { 'missing_info' }
+      sequence_id { 900 }
+    end
+
+    trait :wrong_exemp do
+      name { 'Incorrect exemption engaged' }
+      abbreviation { 'wrong_exemp' }
+      sequence_id { 905 }
+    end
+
+    trait :excess_redacts do
+      name { 'Excessive redaction(s)' }
+      abbreviation { 'excess_redacts' }
+      sequence_id { 910 }
+    end
+  end
+
   factory :offender_complaint_outcome, class: CaseClosure::OffenderComplaintOutcome do
     subtype { nil }
 

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -11,8 +11,8 @@ feature 'SAR Internal Review Case can be closed', js:true do
   let!(:sar_ir) { create(:ready_to_close_sar_internal_review) }
 
   let!(:late_sar_ir) { 
-    create(:ready_to_close_sar_internal_review, 
-            date_responded: Date.today,
+    create(:ready_to_close_sar_internal_review,
+            date_responded: 1.business_days.ago,
             external_deadline: 30.business_days.ago) 
   }
 
@@ -37,6 +37,7 @@ feature 'SAR Internal Review Case can be closed', js:true do
         cases_page.load
         click_link "#{late_sar_ir.number}"
         cases_show_page.actions.close_case.click
+        cases_close_page.submit_button.click
         cases_close_page.submit_button.click
 
         on_load_field_expectations(lateness: true)

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -54,7 +54,7 @@ feature 'SAR Internal Review Case can be closed', js:true do
         cases_closure_outcomes_page.missing_info.sar_ir_yes.click
         cases_closure_outcomes_page.submit_button.click
 
-        expect(cases_show_page).to have_content("You've closed this case.")
+        expect(cases_show_page).to have_content("You've closed this case")
         expect(cases_show_page).to have_content("Excessive redaction(s)")
         expect(cases_show_page).to have_content("Incorrect exemption engaged")
         expect(cases_show_page).to have_content("Business unit responsible for appeal outcome")
@@ -79,7 +79,7 @@ feature 'SAR Internal Review Case can be closed', js:true do
 
         cases_closure_outcomes_page.submit_button.click
 
-        expect(cases_show_page).to have_content("You've closed this case.")
+        expect(cases_show_page).to have_content("You've closed this case")
       end
     end
   end

--- a/spec/features/cases/sar_internal_review/case_editing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_editing_spec.rb
@@ -3,10 +3,16 @@ require 'rails_helper'
 feature 'SAR Internal Review Case can be edited', js:true do
 
   given(:responder)       { find_or_create(:sar_responder) }
-  given(:responding_team) { create :responding_team, responders: [responder] }
+  given(:responding_team) { find_or_create :responding_team, responders: [responder] }
   given(:manager)         { find_or_create :disclosure_bmt_user }
-  given(:managing_team)   { create :managing_team, managers: [manager] }
-  given(:approver)        { (find_or_create :team_dacu_disclosure).users.first }
+  given(:managing_team)   { find_or_create :managing_team, managers: [manager] }
+  given(:approving_team)  { find_or_create :team_dacu_disclosure }
+  given(:approver)        { approving_team.users.first }
+
+  given(:outcome_reasons)  { 
+    [ find(:outcome_reason, :excess_redacts), 
+      find(:outcome_reason, :wrong_exemp)]
+  }
 
   let(:sar_ir) { create(:sar_internal_review) }
 
@@ -22,9 +28,21 @@ feature 'SAR Internal Review Case can be edited', js:true do
   }
 
   let(:closed_sar_ir) {
-      create(:closed_sar_internal_review)
+    kase = create(:closed_sar_internal_review, 
+           responder: responder,
+           responding_team: responding_team,
+           outcome_reasons: outcome_reasons,
+           approver: approver,
+           approving_team: approving_team,
+           team_responsible_for_outcome: responding_team,
+           team_responsible_for_outcome_id: responding_team.id,
+           late_team: responding_team)
+    appeal_outcome = CaseClosure::AppealOutcome.overturned
+    kase.appeal_outcome_id = appeal_outcome.id
+    kase.save!
+    kase
   }
-
+  
   let(:new_message) { 'This is an updated message' }
   let(:new_name) { 'Newthaniel Newname' }
   let(:new_third_party_relationship) { 'Barrister' }
@@ -34,11 +52,28 @@ feature 'SAR Internal Review Case can be edited', js:true do
     find_or_create :team_dacu_disclosure
   end
 
+  before :all do
+    require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
+    CaseClosure::MetadataSeeder.seed!
+  end
+
+
+  after :all do
+    CaseClosure::MetadataSeeder.unseed!
+  end
+
   context 'as a manager' do
     it 'will allow me to edit a SAR IR case details' do
       when_a_manager_logs_in
       and_they_edit_the_case_details(sar_ir)
       then_they_expect_the_new_details_to_be_reflected_on_the_case_show_page
+    end
+
+    it 'will allow me to edit the details of a case closure' do
+      when_a_manager_logs_in
+      and_loads_the_case_show_page(closed_sar_ir)
+      and_they_edit_case_closure_details
+      then_the_changes_are_reflected_on_the_case_show_page
     end
   end
 
@@ -47,6 +82,13 @@ feature 'SAR Internal Review Case can be edited', js:true do
       when_an_approver_logs_in
       and_they_edit_the_case_details(approved_sar_ir)
       then_they_expect_the_new_details_to_be_reflected_on_the_case_show_page
+    end
+
+    fit 'will allow me to edit the details of a case closure' do
+      when_an_approver_logs_in
+      and_loads_the_case_show_page(closed_sar_ir)
+      and_they_edit_case_closure_details
+      then_the_changes_are_reflected_on_the_case_show_page
     end
   end
 
@@ -57,7 +99,7 @@ feature 'SAR Internal Review Case can be edited', js:true do
       they_cannot_edit_the_case
     end
 
-    fit 'won\'t allow me to edit the details of a case closure' do
+    it 'won\'t allow me to edit the details of a case closure' do
       when_a_responder_logs_in
       and_loads_the_case_show_page(closed_sar_ir)
       then_they_should_not_be_able_to_edit_the_case_closure_details
@@ -85,14 +127,32 @@ feature 'SAR Internal Review Case can be edited', js:true do
     cases_page.load
   end
 
-  def and_loads_the_case_show_page(sar_ir)
-    cases_show_page.load(id: sar_ir.id)
+  def and_loads_the_case_show_page(sar_internal_review)
+    cases_show_page.load(id: sar_internal_review.id)
   end
 
   def they_cannot_edit_the_case
     page = case_new_sar_ir_case_details_page
     expect(page).to have_content(responding_sar_ir.number.to_s)
     expect(page).to_not have_content('Edit case details')
+  end
+
+  def and_they_edit_case_closure_details
+    click_link("Edit closure details")
+
+    cases_edit_closure_page.sar_ir_responsible_for_outcome.disclosure.click
+    cases_edit_closure_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
+    cases_edit_closure_page.sar_ir_outcome_reasons.check "Incorrect exemption engaged", visible: false
+    cases_edit_closure_page.missing_info.sar_ir_yes.click
+    cases_edit_closure_page.submit_button.click
+  end
+
+  def then_the_changes_are_reflected_on_the_case_show_page
+    expect(cases_show_page).to have_content("You have updated the closure details for this case.")
+    expect(cases_show_page).to have_content("Excessive redaction(s)")
+    expect(cases_show_page).to have_content("Incorrect exemption engaged")
+    expect(cases_show_page).to have_content("Business unit responsible for appeal outcome")
+    expect(cases_show_page).to have_content("Disclosure BMT")
   end
 
   def and_they_edit_the_case_details(sar_internal_review)

--- a/spec/features/cases/sar_internal_review/case_editing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_editing_spec.rb
@@ -9,8 +9,21 @@ feature 'SAR Internal Review Case can be edited', js:true do
   given(:approver)        { (find_or_create :team_dacu_disclosure).users.first }
 
   let(:sar_ir) { create(:sar_internal_review) }
-  let(:approved_sar_ir) { create(:approved_sar_internal_review, approver: approver) }
-  let(:responding_sar_ir) { create(:approved_sar_internal_review, responder: responder, responding_team: responding_team) }
+
+  let(:approved_sar_ir) { 
+    create(:approved_sar_internal_review,
+           approver: approver) 
+  }
+
+  let(:responding_sar_ir) { 
+    create(:approved_sar_internal_review,
+           responder: responder,
+           responding_team: responding_team) 
+  }
+
+  let(:closed_sar_ir) {
+      create(:closed_sar_internal_review)
+  }
 
   let(:new_message) { 'This is an updated message' }
   let(:new_name) { 'Newthaniel Newname' }
@@ -40,8 +53,14 @@ feature 'SAR Internal Review Case can be edited', js:true do
   context 'as a responder' do
     it 'won\'t allow me to edit a SAR IR case details' do
       when_a_responder_logs_in
-      and_loads_the_case_show_page
+      and_loads_the_case_show_page(responding_sar_ir)
       they_cannot_edit_the_case
+    end
+
+    fit 'won\'t allow me to edit the details of a case closure' do
+      when_a_responder_logs_in
+      and_loads_the_case_show_page(closed_sar_ir)
+      then_they_should_not_be_able_to_edit_the_case_closure_details
     end
   end
 
@@ -50,6 +69,10 @@ feature 'SAR Internal Review Case can be edited', js:true do
   def when_a_manager_logs_in
     login_as manager
     cases_page.load
+  end
+
+  def then_they_should_not_be_able_to_edit_the_case_closure_details
+    expect(page).to_not have_content("Edit closure details")
   end
 
   def when_an_approver_logs_in
@@ -62,8 +85,8 @@ feature 'SAR Internal Review Case can be edited', js:true do
     cases_page.load
   end
 
-  def and_loads_the_case_show_page
-    cases_show_page.load(id: responding_sar_ir.id)
+  def and_loads_the_case_show_page(sar_ir)
+    cases_show_page.load(id: sar_ir.id)
   end
 
   def they_cannot_edit_the_case

--- a/spec/site_prism/page_objects/pages/cases/close_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/close_page.rb
@@ -70,6 +70,8 @@ module PageObjects
         end
 
         section :missing_info, '.missing-info' do
+          element :sar_ir_yes, 'input#sar_internal_review_missing_info_yes', visible: false
+          element :sar_ir_no,  'input#sar_internal_review_missing_info_no', visible: false
           element :yes, 'input#sar_missing_info_yes', visible: false
           element :no,  'input#sar_missing_info_no', visible: false
         end

--- a/spec/site_prism/page_objects/pages/cases/edit_closure_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/edit_closure_page.rb
@@ -5,6 +5,19 @@ module PageObjects
     module Cases
       class EditClosurePage < ClosePage
         set_url '/cases/{correspondence_type}/{id}/edit_closure'
+
+        section :sar_ir_outcome, '.appeal-outcome-group' do
+          element :upheld, 'label[for="sar_internal_review_sar_ir_outcome_upheld"]'
+          element :upheld_in_part, 'label[for="sar_internal_review_sar_ir_outcome_upheld_in_part"]'
+          element :overturned, 'label[for="sar_internal_review_sar_ir_outcome_overturned"]'
+        end
+
+        section :sar_ir_responsible_for_outcome, '.responsible-for-outcome-group' do
+          element :disclosure, 'input[id^="sar_internal_review_team_responsible_for_outcome_id_"]', match: :first, visible: false
+        end
+
+        section :sar_ir_outcome_reasons, '.outcome-reasons-group' do
+        end
       end
     end
   end

--- a/spec/state_machines/workflows/sar_internal_review_permitted_events/sar_internal_review_trigger_spec.rb
+++ b/spec/state_machines/workflows/sar_internal_review_permitted_events/sar_internal_review_trigger_spec.rb
@@ -107,7 +107,6 @@ describe ConfigurableStateMachine::Machine do
                   :edit_case,
                   :link_a_case,
                   :remove_linked_case,
-                  :respond,
                   :send_back, 
                   :unassign_from_user]
         end

--- a/spec/state_machines/workflows/sar_internal_review_permitted_events/sar_internal_review_trigger_spec.rb
+++ b/spec/state_machines/workflows/sar_internal_review_permitted_events/sar_internal_review_trigger_spec.rb
@@ -235,8 +235,7 @@ describe ConfigurableStateMachine::Machine do
           k = create :closed_sar_internal_review, :flagged_accepted
           responder = responder_in_assigned_team(k)
           expect(k.current_state).to eq 'closed'
-          expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case,
-                                                                        :update_closure]
+          expect(k.state_machine.permitted_events(responder.id)).to eq [:add_message_to_case ]
         end
       end
     end
@@ -394,8 +393,9 @@ describe ConfigurableStateMachine::Machine do
           k = create :closed_sar_internal_review, :flagged_accepted
           approver = approver_in_assigned_team(k)
           expect(k.current_state).to eq 'closed'
-          expect(k.state_machine.permitted_events(approver.id)).to eq [ :add_message_to_case, 
-                                                                        :edit_case]
+          expect(k.state_machine.permitted_events(approver.id)).to eq [:add_message_to_case, 
+                                                                       :edit_case,
+                                                                       :update_closure]
         end
       end
 

--- a/spec/state_machines/workflows/sar_internal_review_permitted_events/sar_internal_review_trigger_spec.rb
+++ b/spec/state_machines/workflows/sar_internal_review_permitted_events/sar_internal_review_trigger_spec.rb
@@ -93,7 +93,6 @@ describe ConfigurableStateMachine::Machine do
                   :edit_case,
                   :link_a_case,
                   :remove_linked_case,
-                  :respond,
                   :unassign_from_user]
         end
 


### PR DESCRIPTION
## Description
Adds the ability to edit case closure outcomes

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
New link:
<img width="992" alt="Screenshot 2022-01-26 at 13 32 48" src="https://user-images.githubusercontent.com/13377553/151173020-25ac61f7-e4d0-4921-9695-af077295e174.png">

Edit page:
<img width="495" alt="Screenshot 2022-01-26 at 13 33 52" src="https://user-images.githubusercontent.com/13377553/151173109-c108b4ef-59da-4e7c-abed-08238e5c3780.png">

Success message:
<img width="466" alt="Screenshot 2022-01-26 at 13 35 23" src="https://user-images.githubusercontent.com/13377553/151173148-e6e7c1e2-4bc8-44c8-bdff-4dd66147f2f3.png">


### Related JIRA tickets
Second ticket related to [CT-3991](https://dsdmoj.atlassian.net/browse/CT-3991)

### Manual testing instructions
- Take a case up to closure
- As a manager, or an approver you should be able to edit the case details
