### PR TITLE
CT-2343 Strip the spaces from user's name at creation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -88,6 +88,7 @@ class UsersController < ApplicationController
   end
 
   def create_user_params
+    params[:user][:full_name] =  params[:user][:full_name].strip()
     params.require(:user).permit(
       :full_name,
       :email,

--- a/app/services/user_creation_service.rb
+++ b/app/services/user_creation_service.rb
@@ -53,7 +53,7 @@ class UserCreationService
   end
 
   def full_names_match
-    @user.full_name.downcase == @params[:full_name].downcase
+    @user.full_name.strip().downcase == @params[:full_name].strip().downcase
   end
 
   def add_user_to_teams

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -70,10 +70,27 @@ RSpec.describe UsersController, type: :controller do
      }
     end
 
+    let(:params_with_spaces_around) do
+      {
+        user: {
+          full_name: '  TEst Er  ',
+          email:     'test.er@localhost',
+        },
+        team_id: dacu.id
+     }
+    end
+
     before { sign_in manager }
 
     it 'creates a user with the given params' do
       post :create, params: params
+
+      expect(User.last).to have_attributes full_name: 'TEst Er',
+                                           email: 'test.er@localhost'
+    end
+
+    it 'creates a user with a name being wrapped with spaces ' do
+      post :create, params: params_with_spaces_around
 
       expect(User.last).to have_attributes full_name: 'TEst Er',
                                            email: 'test.er@localhost'
@@ -115,6 +132,22 @@ RSpec.describe UsersController, type: :controller do
       it 'redirects to the team details page' do
         post :create, params: params
         expect(response).to redirect_to(team_path(id: dacu.id))
+      end
+
+      it 'adds the existing user to new given team with the given role' do
+        responder = find_or_create :foi_responder
+        test_params = {
+          user: {
+            full_name: "  #{responder.full_name}  ",
+            email: responder.email
+          },
+          team_id: dacu.id
+       }
+        post :create, params: test_params
+
+        responder.reload
+        expect(dacu.managers).to include responder
+        expect(responder.teams).to include dacu
       end
     end
 


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR is to fix the spaces around full_name of user during creation 
## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [X] (3) Tests passing
* [X] (4) Branch ready to be merged (not work in progress)
* [X] (5) No superfluous changes in diff
* [X] (6) No TODO's without new ticket numbers
* [X] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [X] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/browse/CT-2343
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
