### PR TITLE
CT-3925 - Add SAR IR to open / close reports

### DIFF
--- a/app/decorators/case/sar/internal_review_decorator.rb
+++ b/app/decorators/case/sar/internal_review_decorator.rb
@@ -9,7 +9,8 @@ class Case::SAR::InternalReviewDecorator < Case::SAR::StandardDecorator
   end
 
   def pretty_type
-    I18n.t("helpers.label.correspondence_types.sar_internal_review_long")
+    I18n.t("helpers.label.correspondence_types.sar_internal_review_long",
+           formatted_sar_ir_subtype: formatted_sar_ir_subtype)
   end
 
   def case_route_path
@@ -33,6 +34,12 @@ class Case::SAR::InternalReviewDecorator < Case::SAR::StandardDecorator
       .map { |reason| reason.name }
       .join(",<br>")
       .html_safe
+  end
+
+  private
+
+  def formatted_sar_ir_subtype
+    sar_ir_subtype ? " - #{sar_ir_subtype}" : ''
   end
 
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -855,7 +855,7 @@ en:
         foi: FOI
         sar: SAR
         sar_internal_review: SAR IR
-        sar_internal_review_long: SAR Internal Review
+        sar_internal_review_long: SAR Internal Review%{formatted_sar_ir_subtype}
         ico: ICO
         overturned_sar: Overturned SAR
         overturned_foi: Overturned FOI

--- a/db/data_migrations/20220204141138_remove_specific_report_from_sar_ir.rb
+++ b/db/data_migrations/20220204141138_remove_specific_report_from_sar_ir.rb
@@ -1,0 +1,17 @@
+class RemoveSpecificReportFromSarIr < ActiveRecord::DataMigration
+  def up
+    ct = CorrespondenceType.find_by(abbreviation: 'SAR_INTERNAL_REVIEW')
+    if ct.present?
+      ct.report_category_name = ''
+      ct.save
+    end
+  end
+
+  def down
+    ct = CorrespondenceType.find_by(abbreviation: 'SAR_INTERNAL_REVIEW')
+    if ct.present?
+      ct.report_category_name = 'SAR report'
+      ct.save
+    end
+  end
+end

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -104,7 +104,7 @@ class CorrespondenceTypeSeeder
     rec.update!(name: 'Subject access request internal review',
                 abbreviation: 'SAR_INTERNAL_REVIEW',
                 show_on_menu: true, 
-                report_category_name: 'SAR report', 
+                report_category_name: '', 
                 escalation_time_limit: 0,
                 internal_time_limit: 10,
                 external_time_limit: 1,

--- a/spec/decorators/case/sar/sar_internal_review_decorator_spec.rb
+++ b/spec/decorators/case/sar/sar_internal_review_decorator_spec.rb
@@ -19,7 +19,7 @@ describe Case::SAR::InternalReviewDecorator do
 
   describe '#pretty_type' do
     it 'pretty prints case type name' do
-      expect(sar_ir_case.decorate.pretty_type).to eq 'SAR Internal Review'
+      expect(sar_ir_case.decorate.pretty_type).to eq 'SAR Internal Review - compliance'
     end
   end
 


### PR DESCRIPTION
## Description
Amends the cases reports so as allow for SAR IRs. Adds new column to reports to show whether a SAR IR is for 'timeliness' or 'compliance'.

New column title is: 'SAR IR - timeliness or compliance'

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [x] (8) Data migration script is created if any of letter templates is changed

### Related JIRA tickets
[CT-3925](https://dsdmoj.atlassian.net/browse/CT-3925)

### Manual testing instructions
- you should already be able to search of SAR IR cases, so please check that you can.
- download the open cases report - you should be able to see a new column in the report that reports the SAR IR subtypes of 'timeliness' or 'compliance'
