### PR TITLE
CT-4076 Add virtual attribute to deal for case link new

### DIFF
--- a/app/controllers/cases/links_controller.rb
+++ b/app/controllers/cases/links_controller.rb
@@ -12,7 +12,7 @@ module Cases
     def create
       authorize @case, :new_case_link?
 
-      link_case_number = params[:case][:id]
+      link_case_number = params[:case][:number_to_link]
       service = CaseLinkingService.new current_user, @case, link_case_number
       result = service.create
 

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -70,6 +70,8 @@ class Case::Base < ApplicationRecord
 
   attr_reader :deadline_calculator
 
+  attr_accessor :number_to_link
+
   acts_as_gov_uk_date :date_responded,
                       :date_draft_compliant,
                       :external_deadline,

--- a/app/views/cases/links/new.html.slim
+++ b/app/views/cases/links/new.html.slim
@@ -22,7 +22,7 @@
       = @case.subject
 
 = form_for @case, as: :case, url: case_links_path(@case), method: :post do |f|
-  = f.text_field :id, label_options: { value: t('.linked_case_number') }
+  = f.text_field :number_to_link, label_options: { value: t('.linked_case_number') }
 
   .button-holder
     = f.submit 'Add link', class: 'button'


### PR DESCRIPTION


## Description
creates a virtual attribute that the form uses to represent the linked
case number this was prepopulating with the case_id as it was called
{case: { id: }} before so it mapped to the current cases ID which is not
correct.


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
Before:
![Screenshot 2022-02-09 at 13 31 16](https://user-images.githubusercontent.com/13377553/153211278-05d9e22d-4e70-446e-8139-599c31d8cad6.png)

After:
![Screenshot 2022-02-09 at 13 28 41](https://user-images.githubusercontent.com/13377553/153211111-3083bf5c-be16-4ce5-a762-1009853b0e3a.png)


### Related JIRA tickets
[CT-4076](https://dsdmoj.atlassian.net/browse/CT-4076)

### Manual testing instructions
Try to create a new link from the show page of any case, the link field should no longer be populated with the current case ID on page load.