### PR TITLE
Ct 4077 case closure error message

### DIFF
--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -942,7 +942,7 @@ class Case::Base < ApplicationRecord
         :date_draft_compliant,
         I18n.t('activerecord.errors.models.case.attributes.date_draft_compliant.not_in_future')
       )
-    elsif self.date_responded.present? && self.date_draft_compliant > self.date_responded
+    elsif (self.date_responded.present? && self.date_draft_compliant > self.date_responded) && !self.is_sar_internal_review?
       errors.add(
         :date_draft_compliant,
         I18n.t('activerecord.errors.models.case.attributes.date_draft_compliant.after_date_responded')

--- a/spec/controllers/cases/links_controller_spec.rb
+++ b/spec/controllers/cases/links_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Cases::LinksController, type: :controller do
       {
         case_id: kase.id,
         case: {
-          id: link_case.number
+          number_to_link: link_case.number
         }
       }
     }
@@ -53,7 +53,7 @@ RSpec.describe Cases::LinksController, type: :controller do
       expect(CaseLinkingService).to have_received(:new).with(
         manager,
         kase,
-        post_params[:case][:id]
+        post_params[:case][:number_to_link]
       )
 
       expect(service).to have_received(:create)

--- a/spec/features/cases/sar_internal_review/case_creating_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_creating_spec.rb
@@ -91,7 +91,7 @@ feature 'SAR Internal Review Case creation by a manager' do
     click_link latest_sar_ir_number
 
     cases_show_page.actions.mark_as_sent.click
-    cases_respond_page.today_button.click
+    cases_respond_page.fill_in_date_responded(Date.today)
     cases_respond_page.submit_button.click
 
     expect(page).to have_content("The response has been marked as sent")

--- a/spec/features/cases/sar_internal_review/case_creating_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_creating_spec.rb
@@ -122,7 +122,7 @@ feature 'SAR Internal Review Case creation by a manager' do
   end
 
   def and_that_the_case_is_a_trigger_case
-    expect(page).to have_content("SAR Internal Review\nTrigger")
+    expect(page).to have_content("SAR Internal Review - compliance\nTrigger")
   end
 
   def when_i_assign_the_case
@@ -153,7 +153,7 @@ feature 'SAR Internal Review Case creation by a manager' do
 
   def then_i_shoul_expect_to_see_an_error
     page = case_new_sar_ir_link_case_page
-    error_message = "Original case cannot link a SAR Internal review case to a FOI as a original case" 
+    error_message = "The original case must be a SAR (Subject Access Request) correspondence type" 
     expect(page).to have_content(error_message)
   end
 
@@ -228,7 +228,7 @@ feature 'SAR Internal Review Case creation by a manager' do
   end
 
   def then_the_case_should_be_successfully_created
-    expect(page).to have_content("SAR Internal Review case created")
+    expect(page).to have_content("SAR Internal Review - compliance case created")
     expect(page).to have_content("Create case")
     expect(page).to have_content("Assign case")
   end

--- a/spec/site_prism/support/case_type_element_selector.rb
+++ b/spec/site_prism/support/case_type_element_selector.rb
@@ -1,3 +1,3 @@
 Capybara.add_selector(:case_form_element) do
-  xpath { |id| "//*[@id=\"foi_#{id}\"]|//*[@id=\"sar_#{id}\"]|//*[@id=\"offender_sar_#{id}\"]|//*[@id=\"offender_sar_complaint_#{id}\"]|//*[@id=\"ico_#{id}\"]|//*[@id=\"ico_foi_#{id}\"]|//*[@id=\"ico_sar_#{id}\"]|//*[@id=\"overturned_foi_#{id}\"]|//*[@id=\"overturned_sar_#{id}\"]" }
+  xpath { |id| "//*[@id=\"foi_#{id}\"]|//*[@id=\"sar_#{id}\"]|//*[@id=\"offender_sar_#{id}\"]|//*[@id=\"offender_sar_complaint_#{id}\"]|//*[@id=\"ico_#{id}\"]|//*[@id=\"ico_foi_#{id}\"]|//*[@id=\"ico_sar_#{id}\"]|//*[@id=\"overturned_foi_#{id}\"]|//*[@id=\"overturned_sar_#{id}\"]|//*[@id=\"sar_internal_review_#{id}\"]" }
 end


### PR DESCRIPTION
## Description
Stops date_draft compliant valdation firing for SAR IRs as it is not relevant for such cases

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed

### Related JIRA tickets
[CT-4077](https://dsdmoj.atlassian.net/browse/CT-4077)

### Manual testing instructions
Take a SAR IR case to the point where a responder can "Mark a case as sent" and then add a date in the past - the error "Date compliant draft uploaded cannot be after the date responded" should no longer appear but "Date responded cannot be before date received at MoJ"
