### PR TITLE
Add virtual attribute to deal for case link new (#1890)

### DIFF
--- a/app/controllers/cases/links_controller.rb
+++ b/app/controllers/cases/links_controller.rb
@@ -12,7 +12,7 @@ module Cases
     def create
       authorize @case, :new_case_link?
 
-      link_case_number = params[:case][:id]
+      link_case_number = params[:case][:number_to_link]
       service = CaseLinkingService.new current_user, @case, link_case_number
       result = service.create
 

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -70,6 +70,8 @@ class Case::Base < ApplicationRecord
 
   attr_reader :deadline_calculator
 
+  attr_accessor :number_to_link
+
   acts_as_gov_uk_date :date_responded,
                       :date_draft_compliant,
                       :external_deadline,

--- a/app/views/cases/links/new.html.slim
+++ b/app/views/cases/links/new.html.slim
@@ -22,7 +22,7 @@
       = @case.subject
 
 = form_for @case, as: :case, url: case_links_path(@case), method: :post do |f|
-  = f.text_field :id, label_options: { value: t('.linked_case_number') }
+  = f.text_field :number_to_link, label_options: { value: t('.linked_case_number') }
 
   .button-holder
     = f.submit 'Add link', class: 'button'

--- a/db/data_migrations/20220210161248_add_other_option_to_outcome_reason.rb
+++ b/db/data_migrations/20220210161248_add_other_option_to_outcome_reason.rb
@@ -1,0 +1,17 @@
+class AddOtherOptionToOutcomeReason < ActiveRecord::DataMigration
+  def up
+    CaseClosure::OutcomeReason.find_or_create_by!(
+      name: 'Other',
+      abbreviation: 'other',
+      sequence_id: 915)
+  end
+
+  def down
+    ['other'].each do |abbreviation|
+       outcome_reason = CaseClosure::OutcomeReason.find_by(
+         abbreviation: abbreviation
+       )
+       outcome_reason.delete if outcome_reason.nil?
+    end
+  end
+end

--- a/db/seeders/case_closure_metadata_seeder.rb
+++ b/db/seeders/case_closure_metadata_seeder.rb
@@ -263,6 +263,11 @@ module CaseClosure
         name: 'Excessive redaction(s)',
         abbreviation: 'excess_redacts',
         sequence_id: 910)
+
+      OutcomeReason.find_or_create_by!(
+        name: 'Other',
+        abbreviation: 'other',
+        sequence_id: 915)
     end
     #rubocop:enable Metrics/MethodLength
 


### PR DESCRIPTION
creates a virtual attribute that the form uses to represent the linked
case number this was prepopulating with the case_id as it was called
{case: { id: }} before so it mapped to the current cases ID which is not
correct.

## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
