### PR TITLE
fix validation issues with email and postal address

### DIFF
--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -205,7 +205,7 @@ class Case::Base < ApplicationRecord
   scope :updated_since, ->(date) { where('updated_at >= ?', date) }
 
   validates :current_state, presence: true, on: :update
-  validates :email, format: { with: /\A.+@.+\z/ }, if: -> { email.present? }
+  validate :validate_email_format
   validates_presence_of :received_date
   validates :type, presence: true, exclusion: { in: %w{Case}, message: "Case type cannot be blank" }
   validates :workflow, inclusion: { in: %w{ standard trigger full_approval }, message: "invalid" }
@@ -217,6 +217,7 @@ class Case::Base < ApplicationRecord
   validates_with ::ClosedCaseValidator
 
   validates_presence_of :reason_for_deletion, if: -> { deleted }
+
 
   has_many :assignments, inverse_of: :case, dependent: :destroy, foreign_key: :case_id
 
@@ -929,6 +930,15 @@ class Case::Base < ApplicationRecord
       ) unless type_of_offender_sar?
     end
     errors[:received_date].any?
+  end
+
+  def validate_email_format
+    if email =~ /\A.+@.+\z/ && email.present?
+      errors.add(
+        :email,
+        :invalid
+      )
+    end
   end
 
   def validate_date_draft_compliant

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -933,7 +933,7 @@ class Case::Base < ApplicationRecord
   end
 
   def validate_email_format
-    if email =~ /\A.+@.+\z/ && email.present?
+    if email.present? && email =~ /\A.+@.+\z/ 
       errors.add(
         :email,
         :invalid

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -933,7 +933,7 @@ class Case::Base < ApplicationRecord
   end
 
   def validate_email_format
-    if email.present? && email =~ /\A.+@.+\z/ 
+    if email.present? && !(email =~ /\A.+@.+\z/)
       errors.add(
         :email,
         :invalid

--- a/app/models/case/sar/standard.rb
+++ b/app/models/case/sar/standard.rb
@@ -92,8 +92,8 @@ class Case::SAR::Standard < Case::Base
   validates_presence_of :name, :third_party_relationship, if: -> { third_party }
   validates_presence_of :reply_method
   validates_presence_of :subject_type
-  validates_presence_of :email,          if: :send_by_email?
-  validates_presence_of :postal_address, if: :send_by_post?
+  validate :validate_email_address
+  validate :validate_postal_address
   validates :subject, presence: true, length: { maximum: 100 }
   validate :validate_message_or_uploaded_request_files, on: :create
   validate :validate_message_or_attached_request_files, on: :update
@@ -196,6 +196,24 @@ class Case::SAR::Standard < Case::Base
     self.name = self.subject_full_name
   end
 
+  def validate_postal_address
+    if send_by_post? && postal_address.blank?
+      errors.add(
+        :postal_address,
+        :blank
+      )
+    end
+  end
+
+  def validate_email_address
+    if send_by_email? && email.blank?
+      errors.add(
+        :email,
+        :blank
+      )
+    end
+  end
+
   def validate_message_or_uploaded_request_files
     if message.blank? && uploaded_request_files.blank?
       errors.add(
@@ -221,8 +239,6 @@ class Case::SAR::Standard < Case::Base
       )
     end
   end
+
 end
-
-
-
 


### PR DESCRIPTION
## Description
The validations for email and postal address are still firing when they shouldn’t as the valid_attribute?

 method doesn’t respect the inline conditionals of :send_by_post? and :send_by_email?

This PR also creates a method for the email format validator as this was impacted in the same way.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-4087](https://dsdmoj.atlassian.net/browse/CT-4087)

### Manual testing instructions
- validations for postal / email address was firing if the message / upload field was left empty if even if the radio for each respectively was not checked.
- Create a new SAR IR leave the message field blank and then select email and add an email address. The validation for postal address should not fire
- do the same for email, select postal address and submit and the validation emails should not fire.
