### PR TITLE
Allow SAR IR to be used by users if SARs are allowed

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -241,6 +241,7 @@ class CasesController < ApplicationController
   end
 
   def add_sar_ir_to_permitted_types_if_sars_allowed(types)
+    types.delete(CorrespondenceType.sar_internal_review)
     if types.include?(CorrespondenceType.sar)
       types << CorrespondenceType.sar_internal_review
     end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -229,13 +229,21 @@ class CasesController < ApplicationController
               managing_teams.  
               first.  
               correspondence_types.  
-              menu_visible.  
+              menu_visible.
               order(:name).to_a
+
+    add_sar_ir_to_permitted_types_if_sars_allowed(types)
 
     sar_ir_enabled = FeatureSet.sar_internal_review.enabled?
 
     types.delete(CorrespondenceType.sar_internal_review) unless sar_ir_enabled
     types
+  end
+
+  def add_sar_ir_to_permitted_types_if_sars_allowed(types)
+    if types.include?(CorrespondenceType.sar)
+      types << CorrespondenceType.sar_internal_review
+    end
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,6 +221,7 @@ class User < ApplicationRecord
   end
 
   def add_sar_ir_to_permitted_types_if_sars_allowed(types)
+    types.delete(CorrespondenceType.sar_internal_review)
     if types.include?(CorrespondenceType.sar)
       types << CorrespondenceType.sar_internal_review
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -209,6 +209,8 @@ class User < ApplicationRecord
   def permitted_correspondence_types
     types = all_possible_user_correspondence_types
     
+    add_sar_ir_to_permitted_types_if_sars_allowed(types)
+    
     types.delete(CorrespondenceType.sar) unless FeatureSet.sars.enabled?
     types.delete(CorrespondenceType.ico) unless FeatureSet.ico.enabled?
     types.delete(CorrespondenceType.offender_sar) unless FeatureSet.offender_sars.enabled?
@@ -216,6 +218,12 @@ class User < ApplicationRecord
     types << CorrespondenceType.overturned_foi if types.include?(CorrespondenceType.foi)
     types << CorrespondenceType.overturned_sar if types.include?(CorrespondenceType.sar)
     types
+  end
+
+  def add_sar_ir_to_permitted_types_if_sars_allowed(types)
+    if types.include?(CorrespondenceType.sar)
+      types << CorrespondenceType.sar_internal_review
+    end
   end
 
   def other_teams_names(current_team)

--- a/db/data_migrations/20220214155411_remove_sar_ir_from_ct_menu.rb
+++ b/db/data_migrations/20220214155411_remove_sar_ir_from_ct_menu.rb
@@ -1,0 +1,11 @@
+class RemoveSarIrFromCtMenu < ActiveRecord::DataMigration
+  def up
+    rec = CorrespondenceType.find_by(abbreviation: 'SAR_INTERNAL_REVIEW')
+    rec.update!(show_on_menu: false)
+  end
+
+  def down
+    rec = CorrespondenceType.find_by(abbreviation: 'SAR_INTERNAL_REVIEW')
+    rec.update!(show_on_menu: true)
+  end
+end

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -103,7 +103,7 @@ class CorrespondenceTypeSeeder
     rec = CorrespondenceType.new if rec.nil?
     rec.update!(name: 'Subject access request internal review',
                 abbreviation: 'SAR_INTERNAL_REVIEW',
-                show_on_menu: true, 
+                show_on_menu: false, 
                 report_category_name: '', 
                 escalation_time_limit: 0,
                 internal_time_limit: 10,


### PR DESCRIPTION
## Description
Allows users to see SAR IRs if the are allowed to see SARs + removes it from the CorrespondenceType checkboxes from the Admin page for BusinessUnits

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-4089](https://dsdmoj.atlassian.net/browse/CT-4089)

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
- For a user with access to SARs they should also see SAR IRs. SAR IRs also won't appear in the admin menu for CorrespondenceTypes
