### PR TITLE
Default updated / new BUs to have access to SAR IRs

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -241,10 +241,10 @@ class CasesController < ApplicationController
   end
 
   def add_sar_ir_to_permitted_types_if_sars_allowed(types)
-    types.delete(CorrespondenceType.sar_internal_review)
-    if types.include?(CorrespondenceType.sar)
+    does_not_have_sar_ir = types.exclude?(CorrespondenceType.sar_internal_review)
+    has_sar = types.include?(CorrespondenceType.sar)
+    if has_sar && does_not_have_sar_ir 
       types << CorrespondenceType.sar_internal_review
     end
   end
-
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -269,9 +269,7 @@ class TeamsController < ApplicationController
   end
 
   def business_areas_cover_params
-    params.require(:team_property).permit(
-        :value
-    )
+    params.require(:team_property).permit(:value)
   end
 
   def destroy_business_areas_cover_params
@@ -330,11 +328,8 @@ class TeamsController < ApplicationController
   end
 
   def set_destination(team)
-    if team.type == 'BusinessGroup'
-      teams_path
-    else
-      team_path(team.parent_id)
-    end
+    team_is_bu = team.type == 'BusinessGroup'
+    team_is_bu ? teams_path : team_path(team.parent_id)
   end
 
   def default_params_to_include_sar_ir

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -21,6 +21,9 @@ class TeamsController < ApplicationController
 
   before_action :set_areas, only: [:business_areas_covered,
                                    :create_business_areas_covered]
+  
+  before_action :default_params_to_include_sar_ir, only: [:update, 
+                                                          :create] 
 
   def index
     @teams = policy_scope(Team).order(:name)
@@ -79,7 +82,6 @@ class TeamsController < ApplicationController
         flash[:notice] = 'Team created'
         redirect_to params[:team_type] == 'bg' ? teams_path : team_path(@team.parent_id)
       end
-
     else
       @team_type = params[:team_type]
       render :new
@@ -98,7 +100,6 @@ class TeamsController < ApplicationController
       if @team.areas.create(business_areas_cover_params)
         format.js { render 'teams/business_areas/create'}
       end
-
     end
   end
 
@@ -170,7 +171,6 @@ class TeamsController < ApplicationController
     authorize @team, :move?
     @directorate = Directorate.find(params[:directorate_id])
   end
-
 
   def update_business_group
     authorize @team, :move?
@@ -287,7 +287,6 @@ class TeamsController < ApplicationController
     )
   end
 
-
   def post_update_redirect_destination
     if @team.is_a?(BusinessUnit)
       areas_covered_by_team_path(@team)
@@ -328,7 +327,6 @@ class TeamsController < ApplicationController
     else
       "Submit"
     end
-
   end
 
   def set_destination(team)
@@ -339,4 +337,13 @@ class TeamsController < ApplicationController
     end
   end
 
+  def default_params_to_include_sar_ir
+    # include access to SAR::InternalReviews if team has access to standard SARs
+    return unless params[:team].fetch(:correspondence_type_ids, nil)
+    sar_ir_ct_id = CorrespondenceType.sar_internal_review.id.to_s
+    sar_ct_id = CorrespondenceType.sar.id.to_s
+    if params[:team][:correspondence_type_ids].include?(sar_ct_id)
+      params[:team][:correspondence_type_ids] << sar_ir_ct_id
+    end
+  end
 end

--- a/app/models/business_unit.rb
+++ b/app/models/business_unit.rb
@@ -64,7 +64,6 @@ class BusinessUnit < Team
            foreign_key: :team_id,
            class_name: 'Assignment'
 
-
   has_many :pending_accepted_assignments,
            -> { pending_accepted},
            foreign_key: :team_id,
@@ -86,7 +85,6 @@ class BusinessUnit < Team
   scope :active, -> { where(deleted_at: nil) }
 
   after_save :update_search_index
-
 
   def self.responding_for_correspondence_type(correspondence_type)
     joins(:correspondence_type_roles).where(

--- a/app/models/business_unit.rb
+++ b/app/models/business_unit.rb
@@ -43,7 +43,7 @@ class BusinessUnit < Team
            class_name: 'TeamsUsersRole',
            foreign_key: :team_id
 
-           has_many :managers, through: :manager_user_roles, source: :user
+  has_many :managers, through: :manager_user_roles, source: :user
   has_many :responders, through: :responder_user_roles, source: :user
   has_many :approvers, through: :approver_user_roles, source: :user
   has_many :team_admins, through: :team_admin_user_roles, source: :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,8 +221,9 @@ class User < ApplicationRecord
   end
 
   def add_sar_ir_to_permitted_types_if_sars_allowed(types)
-    types.delete(CorrespondenceType.sar_internal_review)
-    if types.include?(CorrespondenceType.sar)
+    does_not_have_sar_ir = types.exclude?(CorrespondenceType.sar_internal_review)
+    has_sar = types.include?(CorrespondenceType.sar)
+    if has_sar && does_not_have_sar_ir 
       types << CorrespondenceType.sar_internal_review
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -209,8 +209,6 @@ class User < ApplicationRecord
   def permitted_correspondence_types
     types = all_possible_user_correspondence_types
     
-    add_sar_ir_to_permitted_types_if_sars_allowed(types)
-    
     types.delete(CorrespondenceType.sar) unless FeatureSet.sars.enabled?
     types.delete(CorrespondenceType.ico) unless FeatureSet.ico.enabled?
     types.delete(CorrespondenceType.offender_sar) unless FeatureSet.offender_sars.enabled?
@@ -218,14 +216,6 @@ class User < ApplicationRecord
     types << CorrespondenceType.overturned_foi if types.include?(CorrespondenceType.foi)
     types << CorrespondenceType.overturned_sar if types.include?(CorrespondenceType.sar)
     types
-  end
-
-  def add_sar_ir_to_permitted_types_if_sars_allowed(types)
-    does_not_have_sar_ir = types.exclude?(CorrespondenceType.sar_internal_review)
-    has_sar = types.include?(CorrespondenceType.sar)
-    if has_sar && does_not_have_sar_ir 
-      types << CorrespondenceType.sar_internal_review
-    end
   end
 
   def other_teams_names(current_team)

--- a/db/data_migrations/20220224094726_add_sar_ir_ct_role_to_bus_sars.rb
+++ b/db/data_migrations/20220224094726_add_sar_ir_ct_role_to_bus_sars.rb
@@ -1,0 +1,55 @@
+class AddSarIrCtRoleToBusSars < ActiveRecord::DataMigration
+  def up
+    sar_ct_id = CorrespondenceType.sar.id
+    bu_with_sars = BusinessUnit
+                    .joins(:correspondence_type_roles)
+                    .where('correspondence_type_roles.correspondence_type_id' => sar_ct_id)
+
+    bu_with_sars.each do |bus_unit|
+      case bus_unit.role
+      when 'manager'
+        set_correspondence_type_roles_for_sar_ir(
+          bus_unit: bus_unit,
+          roles: %w{ view edit manage }
+        )
+      when 'responder'
+        set_correspondence_type_roles_for_sar_ir(
+          bus_unit: bus_unit,
+          roles: %w{ view respond }
+        )
+      when 'approver'
+        set_correspondence_type_roles_for_sar_ir(
+          bus_unit: bus_unit,
+          roles: %w{ view approve }
+        )
+      end
+
+      bus_unit.save
+    end
+  end
+
+  def set_correspondence_type_roles_for_sar_ir(bus_unit:, roles:)
+    ct = CorrespondenceType.sar_internal_review
+    tcr = TeamCorrespondenceTypeRole.find_by(team_id: bus_unit.id, correspondence_type_id: cat.id)
+    if tcr.nil?
+      TeamCorrespondenceTypeRole.create(
+        team_id: bus_unit,
+        correspondence_type_id: ct.id,
+        roles: roles
+      )
+    end
+  end
+
+  def down
+    sar_ir_ct_id = CorrespondenceType.sar_internal_review.id
+
+    bu_with_sars = BusinessUnit
+                    .joins(:correspondence_type_roles)
+                    .where('correspondence_type_roles.correspondence_type_id' => sar_ir_ct_id)
+    
+    sar_ir_ct_team_roles = TeamCorrespondenceTypeRole
+                             .where(team_id: bu_with_sars.ids, 
+                                    correspondence_type_id: sar_ir_ct_id)
+    sar_ir_ct_team_roles.delete_all
+  end
+end

--- a/db/data_migrations/20220224094726_add_sar_ir_ct_role_to_bus_sars.rb
+++ b/db/data_migrations/20220224094726_add_sar_ir_ct_role_to_bus_sars.rb
@@ -10,34 +10,24 @@ class AddSarIrCtRoleToBusSars < ActiveRecord::DataMigration
       when 'manager'
         set_correspondence_type_roles_for_sar_ir(
           bus_unit: bus_unit,
-          roles: %w{ view edit manage }
         )
       when 'responder'
         set_correspondence_type_roles_for_sar_ir(
           bus_unit: bus_unit,
-          roles: %w{ view respond }
         )
       when 'approver'
         set_correspondence_type_roles_for_sar_ir(
           bus_unit: bus_unit,
-          roles: %w{ view approve }
         )
       end
-
-      bus_unit.save
     end
   end
 
-  def set_correspondence_type_roles_for_sar_ir(bus_unit:, roles:)
-    ct = CorrespondenceType.sar_internal_review
-    tcr = TeamCorrespondenceTypeRole.find_by(team_id: bus_unit.id, correspondence_type_id: cat.id)
-    if tcr.nil?
-      TeamCorrespondenceTypeRole.create(
-        team_id: bus_unit,
-        correspondence_type_id: ct.id,
-        roles: roles
-      )
-    end
+  def set_correspondence_type_roles_for_sar_ir(bus_unit:)
+    TeamCorrespondenceTypeRole.find_or_create_by(
+      team: bus_unit,
+      correspondence_type: CorrespondenceType.sar_internal_review,
+    )
   end
 
   def down

--- a/db/migrate/20180620135756_add_ico_to_correspondence_types.rb
+++ b/db/migrate/20180620135756_add_ico_to_correspondence_types.rb
@@ -9,8 +9,8 @@ class AddIcoToCorrespondenceTypes < ActiveRecord::Migration[5.0]
                    default_private_officer: :string
   end
 
-  class TeamCorrespondenceTypeRole < ActiveRecord::Base
-  end
+  # class TeamCorrespondenceTypeRole < ActiveRecord::Base
+  # end
 
   def up
     ico = CorrespondenceType.create!(name: 'Information Commissioner Office appeal.',

--- a/db/seeders/correspondence_type_seeder.rb
+++ b/db/seeders/correspondence_type_seeder.rb
@@ -21,7 +21,7 @@ class CorrespondenceTypeSeeder
 
     rec = CorrespondenceType.find_by(abbreviation: 'SAR')
     rec = CorrespondenceType.new if rec.nil?
-    rec.update!(name: 'Subject access request',
+    rec.update!(name: 'Subject Access request',
                 abbreviation: 'SAR',
                 show_on_menu: true, 
                 report_category_name: 'SAR report', 

--- a/spec/factories/correspondence_types.rb
+++ b/spec/factories/correspondence_types.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     deadline_calculator_class { 'BusinessDays' }
     report_category_name { 'FOI report' }
 
-    initialize_with { CorrespondenceType.find_or_create_by(name: name) }
+    initialize_with { CorrespondenceType.find_or_create_by(abbreviation: abbreviation) }
   end
 
   factory :sar_correspondence_type, parent: :correspondence_type do
@@ -35,12 +35,13 @@ FactoryBot.define do
     report_category_name { 'SAR report' }
 
 
-    initialize_with { CorrespondenceType.find_or_create_by(name: name) }
+    initialize_with { CorrespondenceType.find_or_create_by(abbreviation: abbreviation) }
   end
 
   factory :sar_internal_review_correspondence_type, parent: :correspondence_type do
     name { 'Subject access request internal review' }
     abbreviation { 'SAR_INTERNAL_REVIEW' }
+    show_on_menu { false }
     escalation_time_limit { 3 }
     internal_time_limit { 10 }
     external_time_limit { 1 }
@@ -50,7 +51,7 @@ FactoryBot.define do
     report_category_name { 'SAR report' }
 
 
-    initialize_with { CorrespondenceType.find_or_create_by(name: name) }
+    initialize_with { CorrespondenceType.find_or_create_by(abbreviation: abbreviation) }
   end
 
   factory :offender_sar_correspondence_type, parent: :correspondence_type do
@@ -63,7 +64,7 @@ FactoryBot.define do
     report_category_name { 'Offender SAR report' }
 
 
-    initialize_with { CorrespondenceType.find_or_create_by(name: name) }
+    initialize_with { CorrespondenceType.find_or_create_by(abbreviation: abbreviation) }
   end
 
   factory :offender_sar_complaint_correspondence_type, parent: :correspondence_type do
@@ -76,7 +77,7 @@ FactoryBot.define do
     report_category_name { 'Offender SAR Complaint report' }
     show_on_menu { false }
 
-    initialize_with { CorrespondenceType.find_or_create_by(name: name) }
+    initialize_with { CorrespondenceType.find_or_create_by(abbreviation: abbreviation) }
   end
 
   factory :gq_correspondence_type, parent: :correspondence_type do
@@ -87,7 +88,7 @@ FactoryBot.define do
     deadline_calculator_class { 'BusinessDays' }
     report_category_name { '' }
 
-    initialize_with { CorrespondenceType.find_or_create_by(name: name) }
+    initialize_with { CorrespondenceType.find_or_create_by(abbreviation: abbreviation) }
   end
 
   factory :ico_correspondence_type, parent: :correspondence_type do


### PR DESCRIPTION
## Description
Default updated / new BUs to have access to SAR IRs.

Fixes issue where BUs couldn't be assigned SAR IRs if they were new event though they could view SAR IR cases.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-4089](https://dsdmoj.atlassian.net/browse/CT-4089)
### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
- create a new BU give it access to the SAR correspondence type
- Create a new SAR, it should be able to be assigned to the new BU.
