### PR TITLE
CT-4051 Don't show field when requestor name is not present

### DIFF
--- a/app/views/cases/shared/_requester_name.html.slim
+++ b/app/views/cases/shared/_requester_name.html.slim
@@ -1,3 +1,4 @@
-tr.requester-name
-  th = t('common.case.name')
-  td = case_details.name
+- if case_details.name.present?
+  tr.requester-name
+    th = t('common.case.name')
+    td = case_details.name


### PR DESCRIPTION
## Description
After "Has this been requested on someone else's behalf?" was changed to know - the show view had a blank for the requestor as it is set to `nil`. Added in a check to only display the field if there is a value present.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots

Before:
<img width="979" alt="Screenshot 2022-02-22 at 16 38 48" src="https://user-images.githubusercontent.com/13377553/155177424-d457e72a-9caa-4e09-8f5e-4845568744a5.png">

After:
<img width="1002" alt="Screenshot 2022-02-22 at 16 39 36" src="https://user-images.githubusercontent.com/13377553/155177563-a3ea384a-7000-4964-932e-403796730b40.png">

### Related JIRA tickets
[CT-4051](https://dsdmoj.atlassian.net/browse/CT-4051)

### Manual testing instructions
- Create a SAR IR case where the answer to the question "Has this been requested on someone else's behalf?" is "No"
- on the show page there should be no blank requestor field now.
