### PR TITLE
Remove inline boolean logic and replace with methods

### DIFF
--- a/app/models/case/sar/standard.rb
+++ b/app/models/case/sar/standard.rb
@@ -89,9 +89,11 @@ class Case::SAR::Standard < Case::Base
   validates_presence_of :subject_full_name
   validates :third_party, inclusion: {in: [ true, false ], message: "Please choose yes or no" }
 
-  validates_presence_of :name, :third_party_relationship, if: -> { third_party }
   validates_presence_of :reply_method
   validates_presence_of :subject_type
+
+  validate :validate_name
+  validate :validate_third_party_relationship
   validate :validate_email_address
   validate :validate_postal_address
   validates :subject, presence: true, length: { maximum: 100 }
@@ -105,6 +107,24 @@ class Case::SAR::Standard < Case::Base
 
   # The method below is overriding the close method in the case_states.rb file.
   # This is so that the case is closed with the responder's team instead of the manager's team
+
+  def validate_name
+    if third_party && name.blank?
+      errors.add(
+        :name,
+        :blank
+      )
+    end
+  end
+
+  def validate_third_party_relationship
+    if third_party && third_party_relationship.blank?
+      errors.add(
+        :third_party_relationship,
+        :blank
+      )
+    end
+  end
 
   def respond_and_close(current_user)
     state_machine.respond!(acting_user: current_user, acting_team: self.responding_team)


### PR DESCRIPTION
## Description
Fixes some validation bugs to do with the received date field. All of these bugs basically come from the `application_record#valid_attributes?` method that does not work with inline checks declared in models. for instance:

```ruby
validate :thing, if: { some_logic? }
```
Hence replacing them here with validation methods.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed

### Related JIRA tickets
[CT-4092](https://dsdmoj.atlassian.net/browse/CT-4092)
[CT-4087](https://dsdmoj.atlassian.net/browse/CT-4087)

### Manual testing instructions
Look at the tickets for steps on how recreate
