### PR TITLE
Remove details if case closure edited to upheld

### DIFF
--- a/app/controllers/concerns/sar_internal_review_cases_params.rb
+++ b/app/controllers/concerns/sar_internal_review_cases_params.rb
@@ -48,6 +48,7 @@ module SARInternalReviewCasesParams
   end
 
   def process_sar_internal_review_closure_params
+    remove_reasons_and_responsible_team_if_upheld
     params.require(:sar_internal_review).permit(
       :date_responded_dd,
       :date_responded_mm,
@@ -68,6 +69,13 @@ module SARInternalReviewCasesParams
   end
 
   private
+
+  def remove_reasons_and_responsible_team_if_upheld
+    if params[:sar_internal_review][:sar_ir_outcome] == "Upheld"
+      params[:sar_internal_review][:team_responsible_for_outcome_id] = nil
+      params[:sar_internal_review][:outcome_reason_ids] = []
+    end
+  end
 
   def missing_info_to_tmm
     if params[:sar_internal_review][:missing_info] == "yes"

--- a/spec/features/cases/sar_internal_review/editing_closure_details_spec.rb
+++ b/spec/features/cases/sar_internal_review/editing_closure_details_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
+
+feature 'editing case closure information' do
+  given(:manager) { find_or_create :disclosure_bmt_user }
+
+  before(:all) do
+    CaseClosure::MetadataSeeder.seed!
+  end
+
+  after(:all) do
+    CaseClosure::MetadataSeeder.unseed!
+  end
+
+  scenario 'bmt changes case closure information', js: true do
+    outcome_reasons = [
+      CaseClosure::OutcomeReason.first,
+      CaseClosure::OutcomeReason.last
+    ]
+
+    responsible_team = Team.find_by(code: 'DISCLOSURE').id
+
+    kase = create(:closed_sar_internal_review,
+                  sar_ir_outcome: 'Upheld in part',
+                  team_responsible_for_outcome_id: responsible_team, 
+                  outcome_reasons: outcome_reasons)
+
+
+    login_as manager
+    cases_show_page.load(id: kase.id)
+    edit_sar_ir_case_closure_step(kase: kase,
+                               date_responded: 10.business_days.ago)
+  end
+end

--- a/spec/support/features/steps/cases/edit_steps.rb
+++ b/spec/support/features/steps/cases/edit_steps.rb
@@ -122,6 +122,40 @@ def edit_foi_case_closure_step(kase:, # rubocop:disable Metrics/MethodLength, Me
   end
 end
 
+def edit_sar_ir_case_closure_step(kase:, date_responded: Date.today)
+  expect(cases_show_page.case_details).to have_edit_closure
+  expect(cases_show_page.case_details).to have_content("Business unit responsible for appeal outcome")
+  expect(cases_show_page.case_details).to have_content("Disclosure")
+  expect(cases_show_page.case_details).to have_content("Reason for appeal outcome")
+  expect(cases_show_page.case_details).to have_content("Reason for appeal outcome Proper searches not carried out/missing information,\nOther")
+
+  cases_show_page.case_details.edit_closure.click
+
+  expect(cases_edit_closure_page.date_responded_day.value)
+    .to eq kase.date_responded.day.to_s
+  expect(cases_edit_closure_page.date_responded_month.value)
+    .to eq kase.date_responded.month.to_s
+  expect(cases_edit_closure_page.date_responded_year.value)
+    .to eq kase.date_responded.year.to_s
+
+  cases_edit_closure_page.sar_ir_outcome.upheld.click
+
+  cases_edit_closure_page.fill_in_date_responded(date_responded)
+
+  cases_edit_closure_page.click_on 'Save changes'
+  expect(cases_show_page).to be_displayed(id: kase.id)
+  expect(cases_show_page.notice.text)
+    .to eq 'You have updated the closure details for this case.'
+  expect(cases_show_page.case_details.response_details.date_responded.data.text)
+    .to eq date_responded.strftime(Settings.default_date_format)
+
+  
+  expect(cases_show_page.case_details).to_not have_content("Business unit responsible for appeal outcome")
+  expect(cases_show_page.case_details).to_not have_content("Disclosure")
+  expect(cases_show_page.case_details).to_not have_content("Reason for appeal outcome")
+  expect(cases_show_page.case_details).to_not have_content("Reason for appeal outcome Proper searches not carried out/missing information,\nOther")
+end
+
 def edit_sar_case_closure_step(kase:, date_responded: Date.today, tmm: false) # rubocop:disable Metrics/MethodLength
   expect(cases_show_page).to be_displayed(id: kase.id)
   expect(cases_show_page.case_details).to have_edit_closure


### PR DESCRIPTION

## Description
Removes details for BU responsible for outcome + reason for appeal
outcome, if case is edited to become upheld.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-4092](https://dsdmoj.atlassian.net/browse/CT-4092)

### Manual testing instructions
- Take a case through to closed, and update the closure to be something other than Upheld - e.g. "Upheld in part"

- then edit the case details and change it to Upheld

- on the show page there should be no details in the case details section for "Business unit responsible for appeal outcome" or "Reason for appeal outcome" anymore. Previously it was not removing these details on submission.

