### PR TITLE
Remove missing info from SAR IR case closure

### DIFF
--- a/app/controllers/concerns/sar_internal_review_cases_params.rb
+++ b/app/controllers/concerns/sar_internal_review_cases_params.rb
@@ -57,7 +57,7 @@ module SARInternalReviewCasesParams
       :late_team_id,
       :team_responsible_for_outcome_id,
       outcome_reason_ids: []
-    ).merge(refusal_reason_abbreviation: missing_info_to_tmm)
+    )
   end
 
   def respond_sar_internal_review_params
@@ -74,15 +74,6 @@ module SARInternalReviewCasesParams
     if params[:sar_internal_review][:sar_ir_outcome] == "Upheld"
       params[:sar_internal_review][:team_responsible_for_outcome_id] = nil
       params[:sar_internal_review][:outcome_reason_ids] = []
-    end
-  end
-
-  def missing_info_to_tmm
-    if params[:sar_internal_review][:missing_info] == "yes"
-      @case.missing_info = true
-      CaseClosure::RefusalReason.sar_tmm.abbreviation
-    elsif params[:sar_internal_review][:missing_info] == "no"
-      @case.missing_info = false
     end
   end
 

--- a/app/validators/closed_case_validator.rb
+++ b/app/validators/closed_case_validator.rb
@@ -33,8 +33,7 @@ class ClosedCaseValidator < ActiveModel::Validator
   # the form to close a case, and is only required at that time.
   PROCESSING_CLOSURE_VALIDATIONS = {
     'SAR'=>                 [:validate_tmm],
-    'SAR_INTERNAL_REVIEW'=> [:validate_tmm, 
-                             :validate_sar_ir_outcome,
+    'SAR_INTERNAL_REVIEW'=> [:validate_sar_ir_outcome,
                              :validate_team_responsible],
     'FOI'=>                 [],
     'ICO'=>                 [],

--- a/app/views/cases/sar_internal_review/_close_form.html.slim
+++ b/app/views/cases/sar_internal_review/_close_form.html.slim
@@ -27,9 +27,6 @@
         hint: 'Select all that apply', 
         kase: @case, f: f }
 
-  .missing-info
-    = f.radio_button_fieldset :missing_info
-
   .grid-row
     .column-two-thirds
       .button-holder

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -23,8 +23,6 @@
         hint: t('cases.sar_internal_review.outcome_reasons.hint'),
         kase: @case, f: f }
 
-  .missing-info
-    = f.radio_button_fieldset :missing_info
   .grid-row
     .column-two-thirds
       .button-holder

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,7 +523,6 @@ en:
         late_team_id: Who was responsible for lateness?
         sar_ir_outcome: SAR IR Outcome?
         team_responsible_for_outcome_id: Who was responsible for outcome being partially upheld or overturned?
-        missing_info:  Was the response asking for missing information (e.g. proof of ID), or clarification, i.e. a TTM?
       offender_sar_complaint:
         original_case_number: Is this the correct case?
         complaint_type: What sort of complaint is this?

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -48,7 +48,7 @@ feature 'SAR Internal Review Case can be closed', js:true do
         cases_closure_outcomes_page.sar_ir_responsible_for_outcome.disclosure.click
         cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
         cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Incorrect exemption engaged", visible: false
-        cases_closure_outcomes_page.missing_info.sar_ir_yes.click
+
         cases_closure_outcomes_page.submit_button.click
 
         expect(cases_show_page).to have_content("You've closed this case")
@@ -70,7 +70,6 @@ feature 'SAR Internal Review Case can be closed', js:true do
         on_load_field_expectations
 
         cases_closure_outcomes_page.sar_ir_outcome.upheld.click
-        cases_closure_outcomes_page.missing_info.sar_ir_yes.click
 
         hidden_fields_expectations(should_be_shown: false)
 
@@ -91,7 +90,6 @@ feature 'SAR Internal Review Case can be closed', js:true do
     end
 
     expect(page).to have_content("SAR IR Outcome?")
-    expect(page).to have_content("Was the response asking for missing information (e.g. proof of ID), or clarification, i.e. a TTM?")
   end
 
   def hidden_fields_expectations(should_be_shown: true)

--- a/spec/features/cases/sar_internal_review/case_editing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_editing_spec.rb
@@ -143,7 +143,6 @@ feature 'SAR Internal Review Case can be edited', js:true do
     cases_edit_closure_page.sar_ir_responsible_for_outcome.disclosure.click
     cases_edit_closure_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
     cases_edit_closure_page.sar_ir_outcome_reasons.check "Incorrect exemption engaged", visible: false
-    cases_edit_closure_page.missing_info.sar_ir_yes.click
     cases_edit_closure_page.submit_button.click
   end
 

--- a/spec/site_prism/page_objects/pages/cases/close_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/close_page.rb
@@ -70,8 +70,6 @@ module PageObjects
         end
 
         section :missing_info, '.missing-info' do
-          element :sar_ir_yes, 'input#sar_internal_review_missing_info_yes', visible: false
-          element :sar_ir_no,  'input#sar_internal_review_missing_info_no', visible: false
           element :yes, 'input#sar_missing_info_yes', visible: false
           element :no,  'input#sar_missing_info_no', visible: false
         end

--- a/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
@@ -79,8 +79,6 @@ module PageObjects
         end
 
         section :missing_info, '.missing-info' do
-          element :yes, 'input#sar_missing_info_yes', visible: false
-          element :no,  'input#sar_missing_info_no', visible: false
           element :sar_ir_yes, 'input#sar_internal_review_missing_info_yes', visible: false
           element :sar_ir_no,  'input#sar_internal_review_missing_info_no', visible: false
         end

--- a/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
@@ -79,8 +79,8 @@ module PageObjects
         end
 
         section :missing_info, '.missing-info' do
-          element :sar_ir_yes, 'input#sar_internal_review_missing_info_yes', visible: false
-          element :sar_ir_no,  'input#sar_internal_review_missing_info_no', visible: false
+          element :yes, 'input#sar_missing_info_yes', visible: false
+          element :no,  'input#sar_missing_info_no', visible: false
         end
 
         section :ico,

--- a/spec/validators/closed_case_validator_spec.rb
+++ b/spec/validators/closed_case_validator_spec.rb
@@ -562,7 +562,7 @@ describe 'ClosedCaseValidator' do
     end
   end
 
-  fcontext 'SAR IR cases' do
+  context 'SAR IR cases' do
 
     let!(:sar_ir) { create(:ready_to_close_sar_internal_review) }
     let(:outcome_reason_ids) { CaseClosure::OutcomeReason.all.map(&:id) }


### PR DESCRIPTION
## Description
Removes the "Missing information" questions from SAR IR case closure forms.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
Before:
<img width="497" alt="Screenshot 2022-03-21 at 11 15 54" src="https://user-images.githubusercontent.com/13377553/159251499-ae77c82c-f39e-4f7d-9058-8208d6e8c531.png">

After:
<img width="664" alt="Screenshot 2022-03-21 at 11 13 31" src="https://user-images.githubusercontent.com/13377553/159251525-7e1380a7-8df7-47cd-988d-6741371c36b5.png">

### Related JIRA tickets
[CT-4147](https://dsdmoj.atlassian.net/browse/CT-4147)

### Manual testing instructions
- take a case to closure - there should be no missing info question anymore, but the case should be able to closed as before without firing the missing info validation.
