### PR TITLE
CT-4145 free text other option

### DIFF
--- a/app/assets/javascripts/modules/CaseClosure.js
+++ b/app/assets/javascripts/modules/CaseClosure.js
@@ -62,7 +62,10 @@ moj.Modules.CaseClosure = {
   },
 
   showHideOtherOverturned: function() {
-      if (this.$outcomeReasonOtherOption.is(':checked')) {
+      var other_is_checked = this.$outcomeReasonOtherOption.is(':checked');
+      var other_overturned_has_value = $('#sar_internal_review_other_overturned').val() ? true : false;
+
+      if (other_is_checked || other_overturned_has_value) {
         this.$otherOverturned.show();
       } else {
         this.$otherOverturned.hide();

--- a/app/assets/javascripts/modules/CaseClosure.js
+++ b/app/assets/javascripts/modules/CaseClosure.js
@@ -26,7 +26,7 @@ moj.Modules.CaseClosure = {
   $outcomeExplanationGroups : $('.responsible-for-outcome-group, .outcome-reasons-group'),
 
   $otherOverturned : $('.js-other-overturned'),
-  $outcomeReasonOtherOption : $('label:contains("Other")').siblings().first(),
+  $outcomeReasonOtherOption : $('#sar_internal_review_other'),
 
   init: function() {
     var self = this;

--- a/app/assets/javascripts/modules/CaseClosure.js
+++ b/app/assets/javascripts/modules/CaseClosure.js
@@ -37,15 +37,10 @@ moj.Modules.CaseClosure = {
 
     self.showHideOutcomeExplantionGroups();
 
-    self.$otherOverturned.hide();
+    self.showHideOtherOverturned();
 
     self.$outcomeReasonOtherOption.on('click', function() {
-      console.log(this.checked);
-      if (this.checked) {
-        self.$otherOverturned.show();
-      } else {
-        self.$otherOverturned.hide();
-      }
+      self.showHideOtherOverturned();
     });
 
     self.$sarIrOutcomeGroup.on('change', ':radio', function() {
@@ -64,6 +59,14 @@ moj.Modules.CaseClosure = {
     self.$otherReasons.on('change', ':radio', function() {
       self.showHideExemption();
     });
+  },
+
+  showHideOtherOverturned: function() {
+      if (this.$outcomeReasonOtherOption.is(':checked')) {
+        this.$otherOverturned.show();
+      } else {
+        this.$otherOverturned.hide();
+      }
   },
 
   showHideOutcomeExplantionGroups: function() {

--- a/app/assets/javascripts/modules/CaseClosure.js
+++ b/app/assets/javascripts/modules/CaseClosure.js
@@ -63,9 +63,9 @@ moj.Modules.CaseClosure = {
 
   showHideOtherOverturned: function() {
       var other_is_checked = this.$outcomeReasonOtherOption.is(':checked');
-      var other_overturned_has_value = $('#sar_internal_review_other_overturned').val() ? true : false;
+      var other_option_details_has_value = $('#sar_internal_review_other_option_details').val() ? true : false;
 
-      if (other_is_checked || other_overturned_has_value) {
+      if (other_is_checked || other_option_details_has_value) {
         this.$otherOverturned.show();
       } else {
         this.$otherOverturned.hide();

--- a/app/assets/javascripts/modules/CaseClosure.js
+++ b/app/assets/javascripts/modules/CaseClosure.js
@@ -25,6 +25,9 @@ moj.Modules.CaseClosure = {
   $sarIrOutcomeOverturned : $('#sar_internal_review_sar_ir_outcome_overturned'),
   $outcomeExplanationGroups : $('.responsible-for-outcome-group, .outcome-reasons-group'),
 
+  $otherOverturned : $('.js-other-overturned'),
+  $outcomeReasonOtherOption : $('label:contains("Other")').siblings().first(),
+
   init: function() {
     var self = this;
 
@@ -33,6 +36,17 @@ moj.Modules.CaseClosure = {
     self.showHideExemption();
 
     self.showHideOutcomeExplantionGroups();
+
+    self.$otherOverturned.hide();
+
+    self.$outcomeReasonOtherOption.on('click', function() {
+      console.log(this.checked);
+      if (this.checked) {
+        self.$otherOverturned.show();
+      } else {
+        self.$otherOverturned.hide();
+      }
+    });
 
     self.$sarIrOutcomeGroup.on('change', ':radio', function() {
       self.showHideOutcomeExplantionGroups();

--- a/app/controllers/concerns/sar_internal_review_cases_params.rb
+++ b/app/controllers/concerns/sar_internal_review_cases_params.rb
@@ -56,6 +56,7 @@ module SARInternalReviewCasesParams
       :sar_ir_outcome,
       :late_team_id,
       :team_responsible_for_outcome_id,
+      :other_overturned,
       outcome_reason_ids: []
     )
   end

--- a/app/controllers/concerns/sar_internal_review_cases_params.rb
+++ b/app/controllers/concerns/sar_internal_review_cases_params.rb
@@ -56,7 +56,7 @@ module SARInternalReviewCasesParams
       :sar_ir_outcome,
       :late_team_id,
       :team_responsible_for_outcome_id,
-      :other_overturned,
+      :other_option_details,
       outcome_reason_ids: []
     )
   end

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -15,7 +15,9 @@ class Case::SAR::InternalReview < Case::SAR::Standard
 
   jsonb_accessor :properties,
                  sar_ir_subtype: :string,
-                 team_responsible_for_outcome_id: :integer
+                 team_responsible_for_outcome_id: :integer,
+                 other_overturned: :string
+                
 
   HUMANIZED_ATTRIBUTES = {
     sar_ir_subtype: 'Case type',

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -11,14 +11,14 @@ class Case::SAR::InternalReview < Case::SAR::Standard
   validates_presence_of :original_case
   validates_presence_of :sar_ir_subtype
 
-  validate :validate_other_overturned
+  validate :validate_other_option_details
 
   attr_accessor :original_case_number
 
   jsonb_accessor :properties,
                  sar_ir_subtype: :string,
                  team_responsible_for_outcome_id: :integer,
-                 other_overturned: :string
+                 other_option_details: :string
                 
 
   HUMANIZED_ATTRIBUTES = {
@@ -74,21 +74,21 @@ class Case::SAR::InternalReview < Case::SAR::Standard
     self.appeal_outcome = CaseClosure::AppealOutcome.by_name(name)
   end
 
-  def validate_other_overturned
+  def validate_other_option_details
     other_is_selected = outcome_reasons.map(&:abbreviation).include?('other')
     other_not_selected = !other_is_selected 
 
-    if other_not_selected && other_overturned.present?
+    if other_not_selected && other_option_details.present?
       errors.add(
-        :other_overturned,
-        message: I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_overturned.present')
+        :other_option_details,
+        message: I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_option_details.present')
       )
     end
 
-    if other_is_selected && !other_overturned.present?
+    if other_is_selected && !other_option_details.present?
       errors.add(
-        :other_overturned,
-        message: I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_overturned.absent')
+        :other_option_details,
+        message: I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_option_details.absent')
       )
     end
   end

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -75,9 +75,8 @@ class Case::SAR::InternalReview < Case::SAR::Standard
   end
 
   def validate_other_overturned
-    other_reason_id = CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id
-    other_not_selected = outcome_reason_ids.exclude?(other_reason_id)
-    other_is_selected = outcome_reason_ids.include?(other_reason_id)
+    other_is_selected = outcome_reasons.map(&:abbreviation).include?('other')
+    other_not_selected = !other_is_selected 
 
     if other_not_selected && other_overturned.present?
       errors.add(

--- a/app/views/cases/sar_internal_review/_close_form.html.slim
+++ b/app/views/cases/sar_internal_review/_close_form.html.slim
@@ -28,7 +28,7 @@
         kase: @case, f: f }
     
   .js-other-overturned
-    = f.text_field :other_overturned, label_options: { value: t('cases.sar_internal_review.other_overturned') }
+    = f.text_field :other_option_details, label_options: { value: t('cases.sar_internal_review.other_option_details') }
 
   .grid-row
     .column-two-thirds

--- a/app/views/cases/sar_internal_review/_close_form.html.slim
+++ b/app/views/cases/sar_internal_review/_close_form.html.slim
@@ -26,6 +26,9 @@
         heading: t('cases.sar_internal_review.outcome_reasons.heading'),
         hint: 'Select all that apply', 
         kase: @case, f: f }
+    
+  .js-other-overturned
+    = f.text_field :other_overturned
 
   .grid-row
     .column-two-thirds

--- a/app/views/cases/sar_internal_review/_close_form.html.slim
+++ b/app/views/cases/sar_internal_review/_close_form.html.slim
@@ -28,7 +28,7 @@
         kase: @case, f: f }
     
   .js-other-overturned
-    = f.text_field :other_overturned
+    = f.text_field :other_overturned, label_options: { value: t('cases.sar_internal_review.other_overturned') }
 
   .grid-row
     .column-two-thirds

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -24,7 +24,7 @@
         kase: @case, f: f }
 
   .js-other-overturned
-    = f.text_field :other_overturned, label_options: { value: t('cases.sar_internal_review.other_overturned') }
+    = f.text_field :other_option_details, label_options: { value: t('cases.sar_internal_review.other_option_details') }
 
   .grid-row
     .column-two-thirds

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -23,6 +23,9 @@
         hint: t('cases.sar_internal_review.outcome_reasons.hint'),
         kase: @case, f: f }
 
+  .js-other-overturned
+    = f.text_field :other_overturned
+
   .grid-row
     .column-two-thirds
       .button-holder

--- a/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
+++ b/app/views/cases/sar_internal_review/_closure_outcomes_form.html.slim
@@ -24,7 +24,7 @@
         kase: @case, f: f }
 
   .js-other-overturned
-    = f.text_field :other_overturned
+    = f.text_field :other_overturned, label_options: { value: t('cases.sar_internal_review.other_overturned') }
 
   .grid-row
     .column-two-thirds

--- a/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
+++ b/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
@@ -8,5 +8,9 @@
 
     = collection_check_boxes(:sar_internal_review, :outcome_reason_ids, outcome_reasons, :id, :name) do |b|
       - content_tag :div, class: "multiple-choice" do
-        - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids)) \
-            + b.label(for: "sar_internal_review_outcome_reason_ids_#{b.object.id}")
+        - if b.object.abbreviation == 'other'
+          - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids)) \
+              + b.label(for: "sar_internal_review_outcome_reason_ids_#{b.object.id}")
+        - else
+          - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids)) \
+              + b.label(for: "sar_internal_review_outcome_reason_ids_#{b.object.id}")

--- a/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
+++ b/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
@@ -7,10 +7,11 @@
         = hint
 
     = collection_check_boxes(:sar_internal_review, :outcome_reason_ids, outcome_reasons, :id, :name) do |b|
+      - check_box_id = "sar_internal_review_#{b.object.abbreviation}"
       - content_tag :div, class: "multiple-choice" do
         - if b.object.abbreviation == 'other'
-          - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids)) \
-              + b.label(for: "sar_internal_review_outcome_reason_ids_#{b.object.id}")
+          - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids), id: check_box_id) \
+              + b.label(for: "sar_internal_review_outcome_reason_ids_#{b.object.id}") 
         - else
-          - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids)) \
+          - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids), id: check_box_id) \
               + b.label(for: "sar_internal_review_outcome_reason_ids_#{b.object.id}")

--- a/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
+++ b/app/views/cases/sar_internal_review/_outcome_reason_checkbox_section.html.slim
@@ -9,9 +9,5 @@
     = collection_check_boxes(:sar_internal_review, :outcome_reason_ids, outcome_reasons, :id, :name) do |b|
       - check_box_id = "sar_internal_review_#{b.object.abbreviation}"
       - content_tag :div, class: "multiple-choice" do
-        - if b.object.abbreviation == 'other'
           - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids), id: check_box_id) \
               + b.label(for: "sar_internal_review_outcome_reason_ids_#{b.object.id}") 
-        - else
-          - b.check_box(checked: b.object.id.in?(kase.outcome_reason_ids), id: check_box_id) \
-              + b.label(for: "sar_internal_review_outcome_reason_ids_#{b.object.id}")

--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -44,7 +44,7 @@ tbody.response-details
       th = t('common.case.outcome_reason')
       td = case_details.pretty_outcome_reasons
 
-  - if case_details.sar_internal_review? && case_details.other_overturned.present?
+  - if case_details.is_sar_internal_review? && case_details.other_overturned.present?
     tr.outcome-reasons
       th = t('common.case.other_overturned')
       td = case_details.other_overturned

--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -44,8 +44,8 @@ tbody.response-details
       th = t('common.case.outcome_reason')
       td = case_details.pretty_outcome_reasons
 
-  - if case_details.other_overturned.present?
-    tr.outcome
+  - if case_details.sar_internal_review? && case_details.other_overturned.present?
+    tr.outcome-reasons
       th = t('common.case.other_overturned')
       td = case_details.other_overturned
 

--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -44,6 +44,11 @@ tbody.response-details
       th = t('common.case.outcome_reason')
       td = case_details.pretty_outcome_reasons
 
+  - if case_details.other_overturned.present?
+    tr.outcome
+      th = t('common.case.other_overturned')
+      td = case_details.other_overturned
+
   - if case_details.refusal_reason.present?
     tr.refusal-reason
       th = t('common.case.reason_for_refusal')
@@ -61,3 +66,4 @@ tbody.response-details
     tr.outcome
       th = t('common.case.outcome')
       td = case_details.pretty_ico_decision
+

--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -44,10 +44,10 @@ tbody.response-details
       th = t('common.case.outcome_reason')
       td = case_details.pretty_outcome_reasons
 
-  - if case_details.is_sar_internal_review? && case_details.other_overturned.present?
+  - if case_details.is_sar_internal_review? && case_details.other_option_details.present?
     tr.outcome-reasons
-      th = t('common.case.other_overturned')
-      td = case_details.other_overturned
+      th = t('common.case.other_option_details')
+      td = case_details.other_option_details
 
   - if case_details.refusal_reason.present?
     tr.refusal-reason

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,6 +523,7 @@ en:
         late_team_id: Who was responsible for lateness?
         sar_ir_outcome: SAR IR Outcome?
         team_responsible_for_outcome_id: Who was responsible for outcome being partially upheld or overturned?
+        other_overturned: Please provide more details
       offender_sar_complaint:
         original_case_number: Is this the correct case?
         complaint_type: What sort of complaint is this?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1022,6 +1022,7 @@ en:
       original_external_deadline: Original external deadline
       original_internal_deadline: Original internal deadline
       original_date_responded: Original date response sent to ICO
+      other_overturned: More details on other reason for outcome
     case/ico:
       close: "Record ICO's decision"
       respond: Mark as sent to ICO

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -239,6 +239,9 @@ en:
               blank: cannot be blank
             linked_case:
               wrong_type: must be a SAR (Subject Access Request) correspondence type
+            other_overturned:
+              present: must be only be present if 'other' reason selected
+              absent: must be submitted if 'other' reason selected
 
         case/sar/offender:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -526,7 +526,7 @@ en:
         late_team_id: Who was responsible for lateness?
         sar_ir_outcome: SAR IR Outcome?
         team_responsible_for_outcome_id: Who was responsible for outcome being partially upheld or overturned?
-        other_overturned: Please provide more details
+        over_overturned: Please provide more details
       offender_sar_complaint:
         original_case_number: Is this the correct case?
         complaint_type: What sort of complaint is this?
@@ -1370,6 +1370,7 @@ en:
       outcome_reasons: 
         heading: Reason(s) for outcome being partially upheld or overturned?
         hint: Select all that apply
+      other_overturned: Please provide more details 
     search_bar:
       heading: Case number, requester name or keyword
       hint: For example, 170113001, John Smith or prison meals

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -239,7 +239,7 @@ en:
               blank: cannot be blank
             linked_case:
               wrong_type: must be a SAR (Subject Access Request) correspondence type
-            other_overturned:
+            other_option_details:
               present: must be only be present if 'other' reason selected
               absent: must be submitted if 'other' reason selected
 
@@ -1022,7 +1022,7 @@ en:
       original_external_deadline: Original external deadline
       original_internal_deadline: Original internal deadline
       original_date_responded: Original date response sent to ICO
-      other_overturned: More details on other reason for outcome
+      other_option_details: More details on other reason for outcome
     case/ico:
       close: "Record ICO's decision"
       respond: Mark as sent to ICO
@@ -1371,7 +1371,7 @@ en:
       outcome_reasons: 
         heading: Reason(s) for outcome being partially upheld or overturned?
         hint: Select all that apply
-      other_overturned: Please provide more details 
+      other_option_details: Please provide more details 
     search_bar:
       heading: Case number, requester name or keyword
       hint: For example, 170113001, John Smith or prison meals

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2224,3 +2224,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210917113753'),
 ('20220117091139'),
 ('20220319002602');
+
+

--- a/spec/decorators/case/base_decorator_spec.rb
+++ b/spec/decorators/case/base_decorator_spec.rb
@@ -44,7 +44,6 @@ describe Case::BaseDecorator, type: :model do
 
   end
 
-
   describe '#who_its_with' do
     context 'case has no responding team assigned' do
       it 'returns the managing teams name' do

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -52,7 +52,7 @@ feature 'SAR Internal Review Case can be closed', js:true do
 
         expect(cases_show_page).to have_content("Please provide more details")
 
-        cases_closure_outcomes_page.other_overturned.set("Reason for other option")
+        cases_closure_outcomes_page.other_option_details.set("Reason for other option")
 
         cases_closure_outcomes_page.submit_button.click
 

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -46,9 +46,10 @@ feature 'SAR Internal Review Case can be closed', js:true do
         hidden_fields_expectations
 
         cases_closure_outcomes_page.sar_ir_responsible_for_outcome.disclosure.click
-        cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
-        cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Incorrect exemption engaged", visible: false
-        cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Other", visible: false
+
+        cases_closure_outcomes_page.sar_ir_outcome_reasons.exessive_redactions.check
+        cases_closure_outcomes_page.sar_ir_outcome_reasons.wrong_exemption.check
+        cases_closure_outcomes_page.sar_ir_outcome_reasons.other.check
 
         expect(cases_show_page).to have_content("Please provide more details")
 

--- a/spec/features/cases/sar_internal_review/case_closing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_closing_spec.rb
@@ -48,14 +48,22 @@ feature 'SAR Internal Review Case can be closed', js:true do
         cases_closure_outcomes_page.sar_ir_responsible_for_outcome.disclosure.click
         cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
         cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Incorrect exemption engaged", visible: false
+        cases_closure_outcomes_page.sar_ir_outcome_reasons.check "Other", visible: false
+
+        expect(cases_show_page).to have_content("Please provide more details")
+
+        cases_closure_outcomes_page.other_overturned.set("Reason for other option")
 
         cases_closure_outcomes_page.submit_button.click
 
+        expect(cases_show_page).to have_content("You've closed this case")
         expect(cases_show_page).to have_content("You've closed this case")
         expect(cases_show_page).to have_content("Excessive redaction(s)")
         expect(cases_show_page).to have_content("Incorrect exemption engaged")
         expect(cases_show_page).to have_content("Business unit responsible for appeal outcome")
         expect(cases_show_page).to have_content("Disclosure BMT")
+        expect(cases_show_page).to have_content("More details on other reason for outcome")
+        expect(cases_show_page).to have_content("Reason for other option")
       end
     end
 

--- a/spec/features/cases/sar_internal_review/case_creating_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_creating_spec.rb
@@ -63,7 +63,6 @@ feature 'SAR Internal Review Case creation by a manager' do
     then_they_can_mark_the_case_as_sent
 
     when_a_manager_logs_in
-    binding.pry
     they_see_the_option_to_close_the_case
   end
 

--- a/spec/features/cases/sar_internal_review/case_creating_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_creating_spec.rb
@@ -63,6 +63,7 @@ feature 'SAR Internal Review Case creation by a manager' do
     then_they_can_mark_the_case_as_sent
 
     when_a_manager_logs_in
+    binding.pry
     they_see_the_option_to_close_the_case
   end
 

--- a/spec/features/cases/sar_internal_review/case_editing_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_editing_spec.rb
@@ -141,8 +141,8 @@ feature 'SAR Internal Review Case can be edited', js:true do
     click_link("Edit closure details")
 
     cases_edit_closure_page.sar_ir_responsible_for_outcome.disclosure.click
-    cases_edit_closure_page.sar_ir_outcome_reasons.check "Excessive redaction(s)", visible: false
-    cases_edit_closure_page.sar_ir_outcome_reasons.check "Incorrect exemption engaged", visible: false
+    cases_closure_outcomes_page.sar_ir_outcome_reasons.exessive_redactions.check
+    cases_closure_outcomes_page.sar_ir_outcome_reasons.wrong_exemption.check
     cases_edit_closure_page.submit_button.click
   end
 

--- a/spec/features/cases/sar_internal_review/editing_closure_details_spec.rb
+++ b/spec/features/cases/sar_internal_review/editing_closure_details_spec.rb
@@ -14,9 +14,10 @@ feature 'editing case closure information' do
 
   scenario 'bmt changes case closure information', js: true do
     outcome_reasons = [
-      CaseClosure::OutcomeReason.first,
-      CaseClosure::OutcomeReason.last
+      CaseClosure::OutcomeReason.first
     ]
+
+    other_overturned_text = 'More info on other reasons'
 
     responsible_team = Team.find_by(code: 'DISCLOSURE').id
 

--- a/spec/features/cases/sar_internal_review/editing_closure_details_spec.rb
+++ b/spec/features/cases/sar_internal_review/editing_closure_details_spec.rb
@@ -17,8 +17,6 @@ feature 'editing case closure information' do
       CaseClosure::OutcomeReason.first
     ]
 
-    other_overturned_text = 'More info on other reasons'
-
     responsible_team = Team.find_by(code: 'DISCLOSURE').id
 
     kase = create(:closed_sar_internal_review,

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -469,33 +469,33 @@ describe Case::SAR::InternalReview do
     end
   end
 
-  describe '#other_overturned' do
+  describe '#other_option_details' do
     let(:sar_internal_review) { build(:sar_internal_review) }
     let(:other_id) { CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id }
     it 'other overtuned is valid' do
       other_id = CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id
-      sar_internal_review.other_overturned = "sample text"
+      sar_internal_review.other_option_details = "sample text"
       sar_internal_review.outcome_reason_ids = [other_id]
 
       expect(sar_internal_review).to be_valid
     end
 
-    it 'outome reasons other is invalid without other_overturned text' do
-      sar_internal_review.other_overturned = nil
+    it 'outome reasons other is invalid without other_option_details text' do
+      sar_internal_review.other_option_details = nil
       sar_internal_review.outcome_reason_ids = [other_id]
 
-      expected_error = I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_overturned.absent')
+      expected_error = I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_option_details.absent')
         
       expect(sar_internal_review).to be_invalid
       expect(sar_internal_review.errors.first.options[:message]).to include(expected_error)
     end
 
-    it 'other_overturned is invalid without reason other being selected' do
+    it 'other_option_details is invalid without reason other being selected' do
       other_id = CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id
-      sar_internal_review.other_overturned = 'sample text'
+      sar_internal_review.other_option_details = 'sample text'
       sar_internal_review.outcome_reason_ids.delete(other_id)
 
-      expected_error = I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_overturned.present')
+      expected_error = I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_option_details.present')
         
       expect(sar_internal_review).to be_invalid
       expect(sar_internal_review.errors.first.options[:message]).to include(expected_error)

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -210,7 +210,7 @@ describe Case::SAR::InternalReview do
                     subject: 'subject B'
     end
 
-    xit 'saves all values in the versions object hash' do
+    it 'saves all values in the versions object hash' do
       version_hash = YAML.load(@kase.versions.last.object)
       expect(version_hash['email']).to eq 'aa@moj.com'
       expect(version_hash['received_date']).to eq Date.today
@@ -459,29 +459,30 @@ describe Case::SAR::InternalReview do
 
   describe '#sar_ir_outcome_abbr' do
     let(:sar_internal_review) { build(:sar_internal_review) }
+
     it 'can return a sar ir outcome abbreviation' do
       sar_internal_review.sar_ir_outcome = "Upheld"
 
       expect(sar_internal_review.sar_ir_outcome_abbr).to match("upheld")
-      expect(sar_internal_review.sar_ir_outcome_abbr).to be_an_instance_of(string)
+      expect(sar_internal_review.sar_ir_outcome_abbr).to be_an_instance_of(String)
       expect(sar_internal_review.sar_ir_outcome_abbr).to match("upheld")
     end
   end
 
   describe '#other_overturned' do
     let(:sar_internal_review) { build(:sar_internal_review) }
+    let(:other_id) { CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id }
     it 'other overtuned is valid' do
       other_id = CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id
       sar_internal_review.other_overturned = "sample text"
-      sar_internal_review.outcome_reason_ids << other_id
+      sar_internal_review.outcome_reason_ids = [other_id]
 
       expect(sar_internal_review).to be_valid
     end
 
     it 'outome reasons other is invalid without other_overturned text' do
-      other_id = CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id
       sar_internal_review.other_overturned = nil
-      sar_internal_review.outcome_reason_ids << other_id
+      sar_internal_review.outcome_reason_ids = [other_id]
 
       expected_error = I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_overturned.absent')
         

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -463,8 +463,41 @@ describe Case::SAR::InternalReview do
       sar_internal_review.sar_ir_outcome = "Upheld"
 
       expect(sar_internal_review.sar_ir_outcome_abbr).to match("upheld")
-      expect(sar_internal_review.sar_ir_outcome_abbr).to be_an_instance_of(String)
+      expect(sar_internal_review.sar_ir_outcome_abbr).to be_an_instance_of(string)
       expect(sar_internal_review.sar_ir_outcome_abbr).to match("upheld")
+    end
+  end
+
+  describe '#other_overturned' do
+    let(:sar_internal_review) { build(:sar_internal_review) }
+    it 'other overtuned is valid' do
+      other_id = CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id
+      sar_internal_review.other_overturned = "sample text"
+      sar_internal_review.outcome_reason_ids << other_id
+
+      expect(sar_internal_review).to be_valid
+    end
+
+    it 'outome reasons other is invalid without other_overturned text' do
+      other_id = CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id
+      sar_internal_review.other_overturned = nil
+      sar_internal_review.outcome_reason_ids << other_id
+
+      expected_error = I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_overturned.absent')
+        
+      expect(sar_internal_review).to be_invalid
+      expect(sar_internal_review.errors.first.options[:message]).to include(expected_error)
+    end
+
+    it 'other_overturned is invalid without reason other being selected' do
+      other_id = CaseClosure::OutcomeReason.find_by(abbreviation: 'other').id
+      sar_internal_review.other_overturned = 'sample text'
+      sar_internal_review.outcome_reason_ids.delete(other_id)
+
+      expected_error = I18n.t('activerecord.errors.models.case/sar/internal_review.attributes.other_overturned.present')
+        
+      expect(sar_internal_review).to be_invalid
+      expect(sar_internal_review.errors.first.options[:message]).to include(expected_error)
     end
   end
 

--- a/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
@@ -29,6 +29,7 @@ module PageObjects
         section :sar_ir_outcome_reasons, '.outcome-reasons-group' do
         end
 
+        element :other_overturned, '#sar_internal_review_other_overturned'
 
         section :appeal_outcome, '.appeal-outcome-group' do
           element :upheld, 'label[for="foi_appeal_outcome_name_upheld"]'

--- a/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
@@ -27,6 +27,10 @@ module PageObjects
         end
 
         section :sar_ir_outcome_reasons, '.outcome-reasons-group' do
+          element :missing_info, 'input#sar_internal_review_missing_info', visible: false
+          element :wrong_exemption, 'input#sar_internal_review_wrong_exemp', visible: false 
+          element :exessive_redactions, 'input#sar_internal_review_excess_redacts', visible: false
+          element :other, 'input#sar_internal_review_other', visible: false
         end
 
         element :other_option_details, '#sar_internal_review_other_option_details'

--- a/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/closure_outcomes_page.rb
@@ -29,7 +29,7 @@ module PageObjects
         section :sar_ir_outcome_reasons, '.outcome-reasons-group' do
         end
 
-        element :other_overturned, '#sar_internal_review_other_overturned'
+        element :other_option_details, '#sar_internal_review_other_option_details'
 
         section :appeal_outcome, '.appeal-outcome-group' do
           element :upheld, 'label[for="foi_appeal_outcome_name_upheld"]'

--- a/spec/site_prism/page_objects/pages/cases/edit_closure_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/edit_closure_page.rb
@@ -17,6 +17,10 @@ module PageObjects
         end
 
         section :sar_ir_outcome_reasons, '.outcome-reasons-group' do
+          element :missing_info, 'input#sar_internal_review_missing_info', visible: false
+          element :wrong_exemption, 'input#sar_internal_review_wrong_exemp', visible: false 
+          element :exessive_redactions, 'input#sar_internal_review_excess_redacts', visible: false
+          element :other, 'input#sar_internal_review_other', visible: false
         end
       end
     end

--- a/spec/support/features/steps/cases/edit_steps.rb
+++ b/spec/support/features/steps/cases/edit_steps.rb
@@ -127,7 +127,7 @@ def edit_sar_ir_case_closure_step(kase:, date_responded: Date.today)
   expect(cases_show_page.case_details).to have_content("Business unit responsible for appeal outcome")
   expect(cases_show_page.case_details).to have_content("Disclosure")
   expect(cases_show_page.case_details).to have_content("Reason for appeal outcome")
-  expect(cases_show_page.case_details).to have_content("Reason for appeal outcome Proper searches not carried out/missing information,\nOther")
+  expect(cases_show_page.case_details).to have_content("Reason for appeal outcome Proper searches not carried out/missing information")
 
   cases_show_page.case_details.edit_closure.click
 
@@ -153,7 +153,7 @@ def edit_sar_ir_case_closure_step(kase:, date_responded: Date.today)
   expect(cases_show_page.case_details).to_not have_content("Business unit responsible for appeal outcome")
   expect(cases_show_page.case_details).to_not have_content("Disclosure")
   expect(cases_show_page.case_details).to_not have_content("Reason for appeal outcome")
-  expect(cases_show_page.case_details).to_not have_content("Reason for appeal outcome Proper searches not carried out/missing information,\nOther")
+  expect(cases_show_page.case_details).to_not have_content("Reason for appeal outcome Proper searches not carried out/missing information")
 end
 
 def edit_sar_case_closure_step(kase:, date_responded: Date.today, tmm: false) # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
## Description
Adds a text field to add more detail when a user chooses 'other' for outcome reasons.

Text field should appear when other option is selected.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
Before:
<img width="642" alt="Screenshot 2022-03-28 at 16 23 01" src="https://user-images.githubusercontent.com/13377553/160431863-f99a2905-db76-4599-8573-d0558e78db10.png">


After:
<img width="636" alt="Screenshot 2022-03-28 at 16 22 31" src="https://user-images.githubusercontent.com/13377553/160431791-4e58c0ef-5433-4221-9d94-bdbc14fdf968.png">

Also on show page:
<img width="1063" alt="Screenshot 2022-03-28 at 16 23 37" src="https://user-images.githubusercontent.com/13377553/160432010-ad828ad0-e0d1-4cb0-87c7-353f7d309fa1.png">


### Related JIRA tickets
[CT-4245](https://dsdmoj.atlassian.net/browse/CT-4145)


### Manual testing instructions
- take a case to closure.
- when selecting reasons for the closure. Select other.
- the "Please provide more details" box should appear
- enter your a reason for selecting other
- submit the form.

Note:
- new text box should not appear if other not selected
- field should not submit if other selected and no further reason given.