### PR TITLE
Ct 4142 case ordering, pagination, case counts per tab

### DIFF
--- a/app/controllers/cases/filters_controller.rb
+++ b/app/controllers/cases/filters_controller.rb
@@ -6,7 +6,7 @@ module Cases
 
     before_action :set_url, only: [:open, :closed, :my_open, :retention]
     before_action :set_state_selector, only: [:open, :my_open]
-    before_action :set_cookie_order_flag, only: [:open, :my_open]
+    before_action :set_cookie_order_flag, only: [:open, :my_open, :retention]
     before_action :set_non_current_tab_counts, only: [:my_open]
 
     def show

--- a/app/controllers/cases/filters_controller.rb
+++ b/app/controllers/cases/filters_controller.rb
@@ -141,7 +141,13 @@ module Cases
 
       service = call_search_service(full_list_of_cases, cookies[:search_result_order])
       @query = service.query
-      @cases = service.result_set.by_deadline.decorate
+
+      if service.error?
+        flash.now[:alert] = service.error_message
+      else
+        prepare_open_cases_collection(service)
+      end
+
       respond_to do |format|
         format.html { render :retention }
       end

--- a/app/views/cases/filters/retention.html.slim
+++ b/app/views/cases/filters/retention.html.slim
@@ -12,7 +12,7 @@
 = render partial: 'cases/shared/case_tabs'
 
 section#retention-cases.govuk-tabs__panel
-  - if @query.available_filters(current_user, @current_tab_name)
+  - if @query.available_filters(current_user, @current_tab_name).present?
     = render partial: 'cases/search_filters/filters'
 
     - if @query.filter_crumbs.present?
@@ -23,14 +23,15 @@ section#retention-cases.govuk-tabs__panel
   - if @global_nav_manager.current_page.tabs.present?
     
     = get_cases_order_option_url(request.fullpath, cookies[:search_result_order])
-    .button-holder
-      = submit_tag "Further review needed", class: 'button-secondary', form: 'retention_schedules_form' 
-      = submit_tag "Retain", class: 'button-secondary', form: 'retention_schedules_form' 
-      = submit_tag "Mark for destruction", class: 'button-secondary', form: 'retention_schedules_form' 
-      = submit_tag "Destroy cases", class: 'button-secondary button-destroy', form: 'retention_schedules_form' 
+
 
     .grid-row
       .column-full
+        .button-holder
+          = submit_tag "Further review needed", class: 'button-secondary', form: 'retention_schedules_form' 
+          = submit_tag "Retain", class: 'button-secondary', form: 'retention_schedules_form' 
+          = submit_tag "Mark for destruction", class: 'button-secondary', form: 'retention_schedules_form' 
+          = submit_tag "Destroy cases", class: 'button-secondary button-destroy', form: 'retention_schedules_form' 
         nav.section-tabs
           ul
             - @global_nav_manager.current_page.tabs.each do |tab|

--- a/app/views/cases/filters/retention.html.slim
+++ b/app/views/cases/filters/retention.html.slim
@@ -22,16 +22,9 @@ section#retention-cases.govuk-tabs__panel
 
   - if @global_nav_manager.current_page.tabs.present?
     
-    = get_cases_order_option_url(request.fullpath, cookies[:search_result_order])
-
 
     .grid-row
       .column-full
-        .button-holder
-          = submit_tag "Further review needed", class: 'button-secondary', form: 'retention_schedules_form' 
-          = submit_tag "Retain", class: 'button-secondary', form: 'retention_schedules_form' 
-          = submit_tag "Mark for destruction", class: 'button-secondary', form: 'retention_schedules_form' 
-          = submit_tag "Destroy cases", class: 'button-secondary button-destroy', form: 'retention_schedules_form' 
         nav.section-tabs
           ul
             - @global_nav_manager.current_page.tabs.each do |tab|
@@ -40,7 +33,25 @@ section#retention-cases.govuk-tabs__panel
                            count: tab.count),
                           tab.fullpath_with_query
     - if @cases.present?
+        - cases_count = @global_nav_manager.current_page_or_tab.cases.count
+
         .grid-row
+          .search-results-summary.column-one-third
+            span
+              strong
+                = cases_count
+              = " #{ 'case'.pluralize(cases_count)} found"
+
+          .search-results-order.column-one-third
+            = get_cases_order_option_url(request.fullpath, cookies[:search_result_order])
+
+          .column-full
+            .button-holder
+              = submit_tag "Further review needed", class: 'button-secondary', form: 'retention_schedules_form' 
+              = submit_tag "Retain", class: 'button-secondary', form: 'retention_schedules_form' 
+              = submit_tag "Mark for destruction", class: 'button-secondary', form: 'retention_schedules_form' 
+              - if @global_nav_manager.current_page_or_tab.name == :ready_for_removal
+                = submit_tag "Destroy cases", class: 'button-secondary button-destroy', form: 'retention_schedules_form' 
           .column-full.table-container.container.cases-table-container tabindex="0"
             table.report.table-font-xsmall
               thead
@@ -82,4 +93,6 @@ section#retention-cases.govuk-tabs__panel
                         = "TODO" 
                       td 
                         = kase.retention_schedule.status
+
+        = paginate @cases
 

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -89,6 +89,7 @@ feature 'Case retention schedules for GDPR', :js do
     expect(page).to have_content 'Pending removal'
     expect(page).to have_content 'Ready for removal'
 
+    expect(page).to have_content '2 cases found'
 
     expect(page).to have_content erasable_timely_kase.number
     expect(page).to have_content erasable_timely_kase_two.number
@@ -96,6 +97,9 @@ feature 'Case retention schedules for GDPR', :js do
     expect(page).to_not have_content erasable_untimely_kase.number
 
     click_on 'Pending removal'
+
+    expect(page).to have_content '3 cases found'
+    expect(page).to_not have_content 'Destroy cases'
 
     expect(page).to have_content not_set_timely_kase.number
     expect(page).to have_content reviewable_timely_kase.number
@@ -118,6 +122,10 @@ feature 'Case retention schedules for GDPR', :js do
 
     expect(page).to have_content not_set_timely_kase.number
     expect(page).to have_content retain_timely_kase.number
+
+    click_on 'Show newest cases first'
+    expect(page).to have_content 'Show oldest cases first'
+    click_on 'Show oldest cases first'
 
     Capybara.find(:css, "#retention-checkbox-#{not_set_timely_kase.id}", visible: false).set(true)
 

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -124,8 +124,19 @@ feature 'Case retention schedules for GDPR', :js do
     expect(page).to have_content retain_timely_kase.number
 
     click_on 'Show newest cases first'
+
+    page_order_correct?(
+      not_set_timely_kase.number.to_s, 
+      retain_timely_kase.number.to_s
+    )
+
     expect(page).to have_content 'Show oldest cases first'
+
     click_on 'Show oldest cases first'
+    page_order_correct?(
+      retain_timely_kase.number.to_s,
+      not_set_timely_kase.number.to_s
+    )
 
     Capybara.find(:css, "#retention-checkbox-#{not_set_timely_kase.id}", visible: false).set(true)
 
@@ -156,6 +167,12 @@ feature 'Case retention schedules for GDPR', :js do
 
     cases_page.load
     expect(page).to_not have_content 'Case Retention'
+  end
+
+  def page_order_correct?(before_text, after_text)
+    before = page.text.index(before_text)
+    after = page.text.index(after_text)
+    before < after
   end
 
   def case_with_retention_schedule(case_type:, status:, date:)


### PR DESCRIPTION
## Description
PR adds:
- pagination for the Retention tabs
- case counts for the retention tabs
- moves buttons below the sub tabs as per the designs
- makes the case ordering work
- removes the filters (this is the way it should be as they are not defined at the moment) Will add as separate PR.
- also removes the destroy button unless the user is on the "Ready for removal tab"

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
Before:
![Screenshot 2022-04-13 at 13 21 52](https://user-images.githubusercontent.com/13377553/163178760-23b009b9-4808-4d23-a881-a852b19ebdea.png)

After:
![Screenshot 2022-04-13 at 13 19 49](https://user-images.githubusercontent.com/13377553/163178431-0a5f3dd9-9ca4-46ff-b917-be4b3d70dd25.png)

Pagination:

First page
![Screenshot 2022-04-13 at 13 20 24](https://user-images.githubusercontent.com/13377553/163178545-8969728d-5ba2-446b-931c-b0409426abae.png)

Subsequent pages:
![Screenshot 2022-04-13 at 13 21 04](https://user-images.githubusercontent.com/13377553/163178639-80a9801e-5d96-4021-ba13-da9b7b76ef7a.png)


### Related JIRA tickets
[CT-4142](https://dsdmoj.atlassian.net/browse/CT-4142)
[CT-4143](https://dsdmoj.atlassian.net/browse/CT-4143)

### Manual testing instructions
Test on the Case Retention tab by clicking around etc.
