### PR TITLE
Ct 4165 work out enum states correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'acts_as_tree', '~> 2.9'
 gem 'rubyzip', '>= 1.2.4'
 gem 'caxlsx'
 gem 'caxlsx_rails'
+gem 'aasm', '~> 5.2'
 # AXLSX styler - easy styling of cells based on cell references
 gem 'axlsx_styler'
 gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.2.0)
+      concurrent-ruby (~> 1.0)
     actioncable (6.1.5.1)
       actionpack (= 6.1.5.1)
       activesupport (= 6.1.5.1)
@@ -632,6 +634,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm (~> 5.2)
   activerecord-session_store
   acts_as_tree (~> 2.9)
   annotate (~> 3.2.0)

--- a/app/controllers/retention_schedules_controller.rb
+++ b/app/controllers/retention_schedules_controller.rb
@@ -2,15 +2,16 @@ class RetentionSchedulesController < ApplicationController
   def bulk_update
     service = RetentionSchedulesUpdateService.new(
       retention_schedules_params: retention_schedules_params,
-      action_text: params[:commit]
+      event_text: params[:commit]
     )
 
     service.call
 
     if service.result == :error
       flash[:alert] = service.error_message
+      redirect_to '/cases/retention'
     else
-      success_message = "#{service.case_count} cases retention statuses updated to #{service.status_action}"
+      success_message = "#{service.case_count} cases have been #{service.post_update_message}"
       flash[:notice] = success_message
       redirect_to '/cases/retention'
     end

--- a/app/models/retention_schedule.rb
+++ b/app/models/retention_schedule.rb
@@ -15,19 +15,19 @@ class RetentionSchedule < ApplicationRecord
     state :not_set, initial: true, display: 'Not set'
     state :retain, display: 'Retain'
     state :review, display: 'Review'
-    state :destroy, display: 'Destroy'
+    state :to_be_destroyed, display: 'Destroy'
     state :destroyed, display: 'Anonymised'
     
     event :mark_for_retention do
-      transitions from: [:not_set, :review, :destroy], to: :retain
+      transitions from: [:not_set, :review, :to_be_destroyed], to: :retain
     end
 
     event :mark_for_review do
-      transitions from: [:not_set, :retain, :destroy], to: :review
+      transitions from: [:not_set, :retain, :to_be_destroyed], to: :review
     end
 
     event :mark_for_destruction do
-      transitions from: [:not_set, :retain, :review], to: :destroy
+      transitions from: [:not_set, :retain, :review], to: :to_be_destroyed
     end
 
     event :unlist do
@@ -35,7 +35,7 @@ class RetentionSchedule < ApplicationRecord
     end
 
     event :final_destruction do
-      transitions from: [:destroy], to: :destroyed
+      transitions from: [:to_be_destroyed], to: :destroyed
     end
   end
 

--- a/app/models/retention_schedule.rb
+++ b/app/models/retention_schedule.rb
@@ -12,11 +12,11 @@ class RetentionSchedule < ApplicationRecord
              class_name: 'Case::SAR::Offender'
 
   aasm column: 'state', logger: Rails.logger do
-    state :not_set, initial: true
-    state :retain
-    state :review
-    state :destroy
-    state :destroyed
+    state :not_set, initial: true, display: 'Not set'
+    state :retain, display: 'Retain'
+    state :review, display: 'Review'
+    state :destroy, display: 'Destroy'
+    state :destroyed, display: 'Anonymised'
     
     event :mark_for_retention do
       transitions from: [:not_set, :review, :destroy], to: :retain
@@ -38,7 +38,6 @@ class RetentionSchedule < ApplicationRecord
       transitions from: [:destroy], to: :destroyed
     end
   end
-
 
   class << self
     def common_date_viewable_from_range

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -111,15 +111,15 @@ class CaseFinderService
   def erasable_cases_scope
     retention_cases_scope.where(
       retention_schedule: { 
-        status: ['erasable']
+        state: [:destroy]
       })
   end
 
   def triagable_cases_scope
-    triagable_statuses = ['review', 'retain', 'not_set']
+    triagable_states = [:review, :retain, :not_set]
     retention_cases_scope.where(
       retention_schedule: { 
-        status: triagable_statuses
+        state: triagable_states
       })
   end
 

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -111,7 +111,7 @@ class CaseFinderService
   def erasable_cases_scope
     retention_cases_scope.where(
       retention_schedule: { 
-        state: [:destroy]
+        state: [:to_be_destroyed]
       })
   end
 

--- a/app/services/retention_schedules_update_service.rb
+++ b/app/services/retention_schedules_update_service.rb
@@ -5,10 +5,10 @@ class RetentionSchedulesUpdateService
               :status_action
 
   STATUS_ACTIONS = {
-    further_review_needed: 'review',
-    retain: 'retain',
-    mark_for_destruction: 'erasable',
-    destroy_cases: 'erased'
+    further_review_needed: :mark_for_review,
+    retain: :mark_for_retention,
+    mark_for_destruction: :mark_for_destruction,
+    destroy_cases: :final_destruction
   }.freeze
 
   def initialize(retention_schedules_params:, action_text:)
@@ -61,7 +61,7 @@ class RetentionSchedulesUpdateService
       kase = Case::Base.includes(:retention_schedule).find(case_id)
       if kase
         retention_schedule = kase.retention_schedule
-        retention_schedule.status = @status_action
+        retention_schedule.public_send(@status_action)
         retention_schedule.save if retention_schedule.valid? 
       end
     end

--- a/app/services/retention_schedules_update_service.rb
+++ b/app/services/retention_schedules_update_service.rb
@@ -2,7 +2,7 @@ class RetentionSchedulesUpdateService
 
   attr_reader :error_message, 
               :result,
-              :status_action
+              :post_update_message
 
   STATUS_ACTIONS = {
     further_review_needed: :mark_for_review,
@@ -11,17 +11,25 @@ class RetentionSchedulesUpdateService
     destroy_cases: :final_destruction
   }.freeze
 
-  def initialize(retention_schedules_params:, action_text:)
-    @action_text = action_text
+  POST_UPDATE_MESSAGES = {
+    further_review_needed: "marked for review",
+    retain: "marked for retention",
+    mark_for_destruction: "marked for destruction",
+    destroy_cases: "destroyed"
+  }
+
+  def initialize(retention_schedules_params:, event_text:)
+    @event_text = event_text
     @retention_schedules_params = retention_schedules_params
     @case_ids = prepare_case_ids
-    @status_action = lookup_status_action 
+    @state_change_event = lookup_status_action 
+    @post_update_message = lookup_post_update_message
     @result = :incomplete
     @error_message = nil
   end
 
   def call
-    if @status_action.nil?
+    if @state_change_event.nil?
       @error_message =  "Requested retention schedule status action is incorrect"
       @result = :error
     else
@@ -42,8 +50,12 @@ class RetentionSchedulesUpdateService
     STATUS_ACTIONS[parameterize_status_action]
   end
 
+  def lookup_post_update_message
+    POST_UPDATE_MESSAGES[parameterize_status_action]
+  end
+
   def parameterize_status_action
-    @action_text.parameterize(separator: "_").to_sym
+    @event_text.parameterize(separator: "_").to_sym
   end
 
   def prepare_case_ids
@@ -57,13 +69,13 @@ class RetentionSchedulesUpdateService
   private
 
   def update_retention_schedule_statuses
-    @case_ids.each do |case_id|
-      kase = Case::Base.includes(:retention_schedule).find(case_id)
-      if kase
-        retention_schedule = kase.retention_schedule
-        retention_schedule.public_send(@status_action)
-        retention_schedule.save if retention_schedule.valid? 
-      end
+    retention_schedules = RetentionSchedule
+                            .includes(:case)
+                            .where(case_id: @case_ids)
+
+    retention_schedules.each do |retention_schedule|
+      retention_schedule.public_send(@state_change_event)
+      retention_schedule.save if retention_schedule.valid? 
     end
   end
 end

--- a/app/views/cases/filters/retention.html.slim
+++ b/app/views/cases/filters/retention.html.slim
@@ -92,7 +92,7 @@ section#retention-cases.govuk-tabs__panel
                       td 
                         = "TODO" 
                       td 
-                        = kase.retention_schedule.status
+                        = kase.retention_schedule.aasm.human_state
 
         = paginate @cases
 

--- a/db/migrate/20220506131034_add_state_to_retention_schedules.rb
+++ b/db/migrate/20220506131034_add_state_to_retention_schedules.rb
@@ -1,0 +1,20 @@
+class AddStateToRetentionSchedules < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :retention_schedules, :status
+
+    execute <<-SQL
+      DROP TYPE retention_status;
+    SQL
+
+    add_column :retention_schedules, :state, :string
+  end
+
+  def down
+    remove_column :retention_schedules, :state
+
+    execute <<-SQL
+      CREATE TYPE retention_status AS ENUM ('review', 'retain', 'erasable', 'erased', 'not_set');
+    SQL
+    add_column :retention_schedules, :status, :retention_status
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -82,19 +82,6 @@ CREATE TYPE public.requester_type AS ENUM (
 
 
 --
--- Name: retention_status; Type: TYPE; Schema: public; Owner: -
---
-
-CREATE TYPE public.retention_status AS ENUM (
-    'review',
-    'retain',
-    'erasable',
-    'erased',
-    'not_set'
-);
-
-
---
 -- Name: search_query_type; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -866,9 +853,9 @@ CREATE TABLE public.retention_schedules (
     case_id bigint NOT NULL,
     planned_erasure_date date,
     erasure_date date,
-    status public.retention_status,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    state character varying
 );
 
 
@@ -2301,6 +2288,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210917113753'),
 ('20220117091139'),
 ('20220319002602'),
-('20220401091216');
+('20220401091216'),
+('20220506131034');
 
 

--- a/lib/tasks/retention_schedules.rake
+++ b/lib/tasks/retention_schedules.rake
@@ -6,14 +6,14 @@ namespace :retention_schedules do
         puts "Cannot run this command on production environment!"
       else
         puts "Seeding some cases with retention_schedules"
-        statuses = ['erasable', 'erasable', 'review', 'retain', 'not_set', 'review'] * 3
+        states = ['destroy', 'destroy', 'review', 'retain', 'not_set', 'review'] * 3
 
         count = 0
-        statuses.each do |status|
+        states.each do |state|
 
           case_with_retention_schedule(
             case_type: :offender_sar_case,
-            status: status,
+            state: state,
             planned_erasure_date: (Date.today - (3.months + rand(1..10).days))
           )
 
@@ -23,12 +23,12 @@ namespace :retention_schedules do
       end
     end
 
-    def case_with_retention_schedule(case_type:, status:, planned_erasure_date:)
+    def case_with_retention_schedule(case_type:, state:, planned_erasure_date:)
       kase = FactoryBot::create(
         case_type, 
         retention_schedule: 
         RetentionSchedule.new( 
-          status: status, 
+          state: state, 
           planned_erasure_date: planned_erasure_date 
         ) 
       )

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -56,7 +56,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:erasable_timely_kase) {
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'destroy',
+      state: 'to_be_destroyed',
       date: Date.today - 4.months
     ) 
   }
@@ -64,7 +64,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:erasable_timely_kase_two) {
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'destroy',
+      state: 'to_be_destroyed',
       date: Date.today - (4.months - 7.days)
     ) 
   }
@@ -72,7 +72,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:erasable_untimely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'destroy',
+      state: 'to_be_destroyed',
       date: Date.today - (5.months)
     ) 
   }
@@ -152,7 +152,7 @@ feature 'Case retention schedules for GDPR', :js do
 
     not_set_timely_kase.reload
 
-    expect(not_set_timely_kase.retention_schedule.aasm.current_state).to eq(:destroy)
+    expect(not_set_timely_kase.retention_schedule.aasm.current_state).to eq(:to_be_destroyed)
   end
 
   scenario 'non branston users cannot see the GDPR tab' do

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -13,7 +13,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:not_set_timely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'not_set',
+      state: 'not_set',
       date: Date.today - 4.months
     ) 
   }
@@ -22,7 +22,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:reviewable_timely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'review',
+      state: 'review',
       date: Date.today - (4.months - 7.days)
     ) 
   }
@@ -30,7 +30,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:reviewable_untimely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'review',
+      state: 'review',
       date: Date.today - (5.months)
     ) 
   }
@@ -39,7 +39,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:retain_timely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'retain',
+      state: 'retain',
       date: Date.today - (4.months - 7.days)
     ) 
   }
@@ -47,7 +47,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:retain_untimely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'retain',
+      state: 'retain',
       date: Date.today - (5.months)
     ) 
   }
@@ -56,7 +56,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:erasable_timely_kase) {
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'erasable',
+      state: 'destroy',
       date: Date.today - 4.months
     ) 
   }
@@ -64,7 +64,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:erasable_timely_kase_two) {
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'erasable',
+      state: 'destroy',
       date: Date.today - (4.months - 7.days)
     ) 
   }
@@ -72,7 +72,7 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:erasable_untimely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'erasable',
+      state: 'destroy',
       date: Date.today - (5.months)
     ) 
   }
@@ -101,6 +101,7 @@ feature 'Case retention schedules for GDPR', :js do
     expect(page).to have_content '3 cases found'
     expect(page).to_not have_content 'Destroy cases'
 
+
     expect(page).to have_content not_set_timely_kase.number
     expect(page).to have_content reviewable_timely_kase.number
     expect(page).to have_content retain_timely_kase.number
@@ -111,12 +112,13 @@ feature 'Case retention schedules for GDPR', :js do
     Capybara.find(:css, "#retention-checkbox-#{not_set_timely_kase.id}", visible: false).set(true)
     Capybara.find(:css, "#retention-checkbox-#{retain_timely_kase.id}", visible: false).set(true)
 
+
     click_on "Mark for destruction"
 
     expect(page).to_not have_content not_set_timely_kase.number
     expect(page).to_not have_content retain_timely_kase.number
 
-    expect(page).to have_content("2 cases retention statuses updated to erasable")
+    expect(page).to have_content("2 cases have been marked for destruction")
     
     click_on 'Ready for removal'
 
@@ -150,7 +152,7 @@ feature 'Case retention schedules for GDPR', :js do
 
     not_set_timely_kase.reload
 
-    expect(not_set_timely_kase.retention_schedule.status).to eq('erased')
+    expect(not_set_timely_kase.retention_schedule.aasm.current_state).to eq(:destroy)
   end
 
   scenario 'non branston users cannot see the GDPR tab' do
@@ -175,12 +177,12 @@ feature 'Case retention schedules for GDPR', :js do
     before < after
   end
 
-  def case_with_retention_schedule(case_type:, status:, date:)
+  def case_with_retention_schedule(case_type:, state:, date:)
     kase = create(
       case_type, 
       retention_schedule: 
         RetentionSchedule.new( 
-         status: status, 
+         state: state, 
          planned_erasure_date: date 
       ) 
     )

--- a/spec/models/retention_schedule_spec.rb
+++ b/spec/models/retention_schedule_spec.rb
@@ -29,9 +29,6 @@ RSpec.describe RetentionSchedule, type: :model do
   }
 
   describe 'deplay values for states' do
-    # TODO
-    # retention_schedule.aasm.human_state
-
     it 'has correct display values for its states' do
       retention_schedule = RetentionSchedule.new(
         case: kase, 

--- a/spec/models/retention_schedule_spec.rb
+++ b/spec/models/retention_schedule_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'aasm/rspec'
 
 RSpec.describe RetentionSchedule, type: :model do
 
@@ -27,15 +28,42 @@ RSpec.describe RetentionSchedule, type: :model do
     ) 
   }
 
-  describe '#status' do
-    it 'defaults to "not_set"'do
-      expect(retention_schedule.status).to eq('not_set')
+  describe 'state transitions' do
+    it 'has an initial state of "not_set"' do
+      expect(retention_schedule).to have_state(:not_set)
     end
 
-    it 'cannot have a status outside of enum definition' do
-      expect { 
-        retention_schedule.status = 'incorrect_status' 
-      }.to raise_error(ArgumentError)
+    it 'allows the correct transitions' do
+      expect(retention_schedule).to transition_from(:not_set, :review, :retain)
+        .to(:retain).on_event(:mark_for_retention)
+
+      expect(retention_schedule).to transition_from(:not_set, :retain, :destroy)
+        .to(:review).on_event(:mark_for_review)
+
+      expect(retention_schedule).to transition_from(:not_set, :retain, :review)
+        .to(:destroy).on_event(:mark_for_destruction)
+
+      expect(retention_schedule).to transition_from(:destroy)
+        .to(:destroyed).on_event(:final_destruction)
+
+      expect(retention_schedule).to transition_from(:retain)
+        .to(:not_set).on_event(:unlist)
+    end
+
+    it 'disallows incorrect transitions' do
+      expect(retention_schedule).to_not transition_from(:not_set, :retain, :review)
+        .to(:destroyed).on_event(:final_destruction)
+
+      expect(retention_schedule).to_not transition_from(:review, :destroy)
+        .to(:unlist).on_event(:unlist)
+
+      retention_schedule.mark_for_destruction
+      retention_schedule.final_destruction
+
+      expect(retention_schedule).to have_state(:destroyed)
+      expect(retention_schedule).to_not allow_transition_to(
+        :not_set, :retain, :review, :destroy
+      )
     end
   end
 
@@ -43,7 +71,6 @@ RSpec.describe RetentionSchedule, type: :model do
     it { should belong_to(:case).class_name('Case::SAR::Offender') }
     it { should validate_presence_of(:case) }
     it { should validate_presence_of(:planned_erasure_date) }
-    it { should validate_presence_of(:status) }
     
     it 'should be valid' do
       expect(retention_schedule).to be_valid

--- a/spec/models/retention_schedule_spec.rb
+++ b/spec/models/retention_schedule_spec.rb
@@ -60,13 +60,13 @@ RSpec.describe RetentionSchedule, type: :model do
       expect(retention_schedule).to transition_from(:not_set, :review, :retain)
         .to(:retain).on_event(:mark_for_retention)
 
-      expect(retention_schedule).to transition_from(:not_set, :retain, :destroy)
+      expect(retention_schedule).to transition_from(:not_set, :retain, :to_be_destroyed)
         .to(:review).on_event(:mark_for_review)
 
       expect(retention_schedule).to transition_from(:not_set, :retain, :review)
-        .to(:destroy).on_event(:mark_for_destruction)
+        .to(:to_be_destroyed).on_event(:mark_for_destruction)
 
-      expect(retention_schedule).to transition_from(:destroy)
+      expect(retention_schedule).to transition_from(:to_be_destroyed)
         .to(:destroyed).on_event(:final_destruction)
 
       expect(retention_schedule).to transition_from(:retain)
@@ -77,7 +77,7 @@ RSpec.describe RetentionSchedule, type: :model do
       expect(retention_schedule).to_not transition_from(:not_set, :retain, :review)
         .to(:destroyed).on_event(:final_destruction)
 
-      expect(retention_schedule).to_not transition_from(:review, :destroy)
+      expect(retention_schedule).to_not transition_from(:review, :to_be_destroyed)
         .to(:unlist).on_event(:unlist)
 
       retention_schedule.mark_for_destruction
@@ -85,7 +85,7 @@ RSpec.describe RetentionSchedule, type: :model do
 
       expect(retention_schedule).to have_state(:destroyed)
       expect(retention_schedule).to_not allow_transition_to(
-        :not_set, :retain, :review, :destroy
+        :not_set, :retain, :review, :to_be_destroyed
       )
     end
   end

--- a/spec/models/retention_schedule_spec.rb
+++ b/spec/models/retention_schedule_spec.rb
@@ -28,6 +28,32 @@ RSpec.describe RetentionSchedule, type: :model do
     ) 
   }
 
+  describe 'deplay values for states' do
+    # TODO
+    # retention_schedule.aasm.human_state
+
+    it 'has correct display values for its states' do
+      retention_schedule = RetentionSchedule.new(
+        case: kase, 
+        planned_erasure_date: Date.today
+      ) 
+
+      expect(retention_schedule.aasm.human_state).to match('Not set')
+
+      retention_schedule.mark_for_retention
+      expect(retention_schedule.aasm.human_state).to match('Retain')
+
+      retention_schedule.mark_for_review
+      expect(retention_schedule.aasm.human_state).to match('Review')
+
+      retention_schedule.mark_for_destruction
+      expect(retention_schedule.aasm.human_state).to match('Destroy')
+
+      retention_schedule.final_destruction
+      expect(retention_schedule.aasm.human_state).to match('Anonymised')
+    end
+  end
+
   describe 'state transitions' do
     it 'has an initial state of "not_set"' do
       expect(retention_schedule).to have_state(:not_set)

--- a/spec/services/retention_schedules_update_service_spec.rb
+++ b/spec/services/retention_schedules_update_service_spec.rb
@@ -56,8 +56,8 @@ describe RetentionSchedulesUpdateService do
       not_set_timely_kase.reload
       reviewable_timely_kase.reload
 
-      expect(not_set_timely_kase.retention_schedule.state).to eq 'destroy'
-      expect(reviewable_timely_kase.retention_schedule.state).to eq 'destroy'
+      expect(not_set_timely_kase.retention_schedule.state).to eq 'to_be_destroyed'
+      expect(reviewable_timely_kase.retention_schedule.state).to eq 'to_be_destroyed'
       expect(retain_timely_kase.retention_schedule.state).to eq 'retain'
     end
   end

--- a/spec/services/retention_schedules_update_service_spec.rb
+++ b/spec/services/retention_schedules_update_service_spec.rb
@@ -38,14 +38,14 @@ describe RetentionSchedulesUpdateService do
   let(:service) {
     RetentionSchedulesUpdateService.new(
       retention_schedules_params: selected_cases_params,
-      action_text: "Mark for destruction"
+      event_text: "Mark for destruction"
     )
   }
 
   let(:service_with_error) {
     RetentionSchedulesUpdateService.new(
       retention_schedules_params: selected_cases_params,
-      action_text: "non existant status"
+      event_text: "non existant status"
     )
   }
 

--- a/spec/services/retention_schedules_update_service_spec.rb
+++ b/spec/services/retention_schedules_update_service_spec.rb
@@ -4,7 +4,7 @@ describe RetentionSchedulesUpdateService do
   let!(:not_set_timely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'not_set',
+      state: 'not_set',
       date: Date.today - 4.months
     ) 
   }
@@ -12,7 +12,7 @@ describe RetentionSchedulesUpdateService do
   let!(:reviewable_timely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'review',
+      state: 'review',
       date: Date.today - (4.months - 7.days)
     ) 
   }
@@ -20,7 +20,7 @@ describe RetentionSchedulesUpdateService do
   let!(:retain_timely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      status: 'retain',
+      state: 'retain',
       date: Date.today - (4.months - 7.days)
     ) 
   }
@@ -56,9 +56,9 @@ describe RetentionSchedulesUpdateService do
       not_set_timely_kase.reload
       reviewable_timely_kase.reload
 
-      expect(not_set_timely_kase.retention_schedule.status).to eq 'erasable'
-      expect(reviewable_timely_kase.retention_schedule.status).to eq 'erasable'
-      expect(retain_timely_kase.retention_schedule.status).to eq 'retain'
+      expect(not_set_timely_kase.retention_schedule.state).to eq 'destroy'
+      expect(reviewable_timely_kase.retention_schedule.state).to eq 'destroy'
+      expect(retain_timely_kase.retention_schedule.state).to eq 'retain'
     end
   end
 
@@ -89,24 +89,23 @@ describe RetentionSchedulesUpdateService do
   end
 
   describe 'constants' do
-    it 'can resolve STATUS_ACTIONS to correct values' do
-      correct_statues = RetentionSchedule.statuses
+    it 'can resolve STATUS_ACTIONS to correct AASM event trigger method names' do
       statuses = RetentionSchedulesUpdateService::STATUS_ACTIONS
 
-      expect(statuses[:further_review_needed]).to eq correct_statues[:review]
-      expect(statuses[:retain]).to eq correct_statues[:retain]
-      expect(statuses[:mark_for_destruction]).to eq correct_statues[:erasable]
-      expect(statuses[:destroy_cases]).to eq correct_statues[:erased]
+      expect(statuses[:further_review_needed]).to eq :mark_for_review
+      expect(statuses[:retain]).to eq :mark_for_retention
+      expect(statuses[:mark_for_destruction]).to eq :mark_for_destruction
+      expect(statuses[:destroy_cases]).to eq :final_destruction
     end
   end
 
 
-  def case_with_retention_schedule(case_type:, status:, date:)
+  def case_with_retention_schedule(case_type:, state:, date:)
     kase = create(
       case_type, 
       retention_schedule: 
         RetentionSchedule.new( 
-         status: status, 
+         state: state,
          planned_erasure_date: date 
       ) 
     )


### PR DESCRIPTION
## Description
This PR refactors the use of enum for statuses for retention schedules to use an AASM state machine on the model instead.

More details on the features of [AASM here](https://github.com/aasm/aasm)

Note for reviewer - I think in the current implementation we may be overriding the ActiveRecord method `destroy!` or at least perhaps adding some confusion to the API. As we are now using a state machine that allows for human display values that differ from the DB state values, we can always change this if it becomes an issue. Or do you think its worth doing now?

Please also check the state flow declarations against the diagram that defines them [here](https://dsdmoj.atlassian.net/wiki/spaces/STSDD/pages/3895820507/Review+Retain+and+Destroy+case+records#Case-Transition-from-Closure-to-Destruction)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A

### Related JIRA tickets
[CT-4165](https://dsdmoj.atlassian.net/browse/CT-4165)

### Manual testing instructions
- you should be able to move cases between states in Dev as before on the Case Retention page.
