### PR TITLE
Add note to case history on RetentionSchedule status changes

### DIFF
--- a/app/controllers/retention_schedules_controller.rb
+++ b/app/controllers/retention_schedules_controller.rb
@@ -1,8 +1,10 @@
 class RetentionSchedulesController < ApplicationController
+
   def bulk_update
     service = RetentionSchedulesUpdateService.new(
       retention_schedules_params: retention_schedules_params,
-      event_text: params[:commit]
+      event_text: params[:commit],
+      current_user: current_user
     )
 
     service.call

--- a/app/models/retention_schedule.rb
+++ b/app/models/retention_schedule.rb
@@ -39,6 +39,10 @@ class RetentionSchedule < ApplicationRecord
     end
   end
 
+  def human_state
+    aasm.human_state
+  end
+
   class << self
     def common_date_viewable_from_range
       viewable_from = Settings.retention_timings.common.viewable_from

--- a/app/views/cases/filters/retention.html.slim
+++ b/app/views/cases/filters/retention.html.slim
@@ -92,7 +92,7 @@ section#retention-cases.govuk-tabs__panel
                       td 
                         = "TODO" 
                       td 
-                        = kase.retention_schedule.aasm.human_state
+                        = kase.retention_schedule.human_state
 
         = paginate @cases
 

--- a/spec/models/retention_schedule_spec.rb
+++ b/spec/models/retention_schedule_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe RetentionSchedule, type: :model do
     ) 
   }
 
+
   describe 'deplay values for states' do
     it 'has correct display values for its states' do
       retention_schedule = RetentionSchedule.new(


### PR DESCRIPTION
## Description
Adds a note to the case history to a case when as if the state changes on its associated retention schedule.

RRD = "Retention Review Destroy" this is the way Branston internally refer to things the process of assessing cases for destruction.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="998" alt="Screenshot 2022-05-13 at 16 10 47" src="https://user-images.githubusercontent.com/13377553/168313537-140c0ee1-9c33-41a5-970c-98ea57beb849.png">


### Related JIRA tickets
[CT-4193](https://dsdmoj.atlassian.net/browse/CT-4193)

### Manual testing instructions
- On the case retention page, update the statuses of some cases.
- Got to the show page for the updated case / cases.
- A note should be added to the case history section of the case in the form outlined in the picture above.
