### PR TITLE
Add rake task to add retention schedules to existing closed cases

### DIFF
--- a/lib/tasks/retention_schedules.rake
+++ b/lib/tasks/retention_schedules.rake
@@ -1,44 +1,97 @@
+require 'pry'
+
 namespace :retention_schedules do
-  namespace :branston do
-    desc 'create a dummy Offender Sar with retention schedules case'
-    task :create => :environment do
-      if is_on_production?
-        puts "Cannot run this command on production environment!"
-      else
-        puts "Seeding some cases with retention_schedules"
-        states = ['destroy', 'destroy', 'review', 'retain', 'not_set', 'review'] * 3
+  desc 'create a dummy Offender Sar with retention schedules case'
+  task :create => :environment do
+    if is_on_production?
+      puts "Cannot run this command on production environment!"
+    else
+      puts "Seeding some cases with retention_schedules"
+      states = ['destroy', 'destroy', 'review', 'retain', 'not_set', 'review'] * 3
 
-        count = 0
-        states.each do |state|
+      count = 0
+      states.each do |state|
 
-          case_with_retention_schedule(
-            case_type: :offender_sar_case,
-            state: state,
-            planned_erasure_date: (Date.today - (3.months + rand(1..10).days))
-          )
+        case_with_retention_schedule(
+          case_type: :offender_sar_case,
+          state: state,
+          planned_destruction_date: (Date.today - (3.months + rand(1..10).days))
+        )
 
-          count += 1
-        end
-        puts "Number of cases seeded: #{count}"
+        count += 1
       end
-    end
-
-    def case_with_retention_schedule(case_type:, state:, planned_erasure_date:)
-      kase = FactoryBot::create(
-        case_type, 
-        retention_schedule: 
-        RetentionSchedule.new( 
-          state: state, 
-          planned_erasure_date: planned_erasure_date 
-        ) 
-      )
-      kase.save
-      kase
-    end
-
-    def is_on_production?
-      ENV['ENV'].present? && ENV['ENV'] == 'prod'
+      puts "Number of cases seeded: #{count}"
     end
   end
-end
+  
+  desc 'Adds retention_schedules to existing closed cases'
+  task :add_rs_to_existing_branston_cases => [:environment] do
+    if FeatureSet.branston_retention_scheduling.enabled?
+      puts "\n*** Adding Retention Schedules to existing closed Branston cases ***"
 
+      errors = []
+      off_sar_count = 0
+      off_sar_complaint_count = 0
+      already_had_rs = 0
+
+      percent = (Case::SAR::Offender.where(current_state: :closed).count / 100).round
+      percent_counter = 0
+      progressbar = ProgressBar.create
+
+      
+      Case::SAR::Offender.where(current_state: :closed).find_each do | kase |
+        if kase.retention_schedule.nil?
+          percent_counter += 1
+          begin 
+            service = RetentionSchedules::AddScheduleService.new(
+              kase: kase
+            )
+            service.call
+            
+            off_sar_count += 1 if kase.offender_sar?
+            off_sar_complaint_count += 1 if kase.offender_sar_complaint?
+
+          rescue => e
+            errors << "Case #{kase.id} errored when adding retention_schedule\n" +
+                      "Error details: #{e.message}"
+          ensure
+            if percent_counter == percent
+              progressbar.increment
+              percent_counter = 0
+            end
+          end
+        else
+          already_had_rs += 1 
+        end
+      end
+    else
+      puts "Cannot run task as feature unavailable on this environment"
+    end
+    puts "\nTotal updated cases: #{off_sar_count + off_sar_complaint_count}"
+    puts "-------------------------"
+    puts "Offender SAR total: #{off_sar_count}"
+    puts "Offender SAR complaint total: #{off_sar_complaint_count}"
+    puts "-------------------------"
+    puts "#{already_had_rs} cases already had retention schedules"
+
+    puts "\n Case errors: \n--------------\n\n" if errors.any?
+    errors.each { |error| puts error }
+  end
+
+  def case_with_retention_schedule(case_type:, state:, planned_destruction_date:)
+    kase = FactoryBot::create(
+      case_type, 
+      retention_schedule: 
+      RetentionSchedule.new( 
+        state: state, 
+        planned_destruction_date: planned_destruction_date 
+      ) 
+    )
+    kase.save
+    kase
+  end
+
+  def is_on_production?
+    ENV['ENV'].present? && ENV['ENV'] == 'prod'
+  end
+end


### PR DESCRIPTION
## Description
Rake task to add RetentionSchdules to existing closed branston cases.

Task has progress bar and some stats after running so it is easier to see what is happening. Tested on 5000 cases locally and takes about 15 seconds to run.

Output should look like the following:
<img width="1919" alt="Screenshot 2022-05-24 at 15 11 32" src="https://user-images.githubusercontent.com/13377553/170056430-43856153-0cb3-486d-9622-4e56a283b85d.png">


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Manual testing instructions
- Create some closed cases locally using FactoryBot:
```ruby
100.times { FactoryBot.create(:offender_sar_case, current_state: :closed, date_responded: Date.today) }
```
- these will not have RetentionSchedules by default
- Run the task:
```
rails rake:retention_schedules:add_rs_to_existing_branston_cases
```
- on the application you should see that these case now have "Planned Destruction Dates" visible on their show pages.


