### PR TITLE
Change tab name to rrd pending

### DIFF
--- a/app/services/global_nav_manager.rb
+++ b/app/services/global_nav_manager.rb
@@ -49,7 +49,7 @@ class GlobalNavManager
 
   def pages_for_user(pages)
     pages.map do |page_name, page_settings|
-      unless page_name == :case_retention && FeatureSet.branston_retention_scheduling.disabled?
+      unless page_name == :rrd_pending && FeatureSet.branston_retention_scheduling.disabled?
         Page.new(name: page_name, parent: self, attrs: page_settings)
       end
     end.compact.select(&:visible?)

--- a/app/views/cases/filters/retention.html.slim
+++ b/app/views/cases/filters/retention.html.slim
@@ -49,7 +49,8 @@ section#retention-cases.govuk-tabs__panel
             .button-holder
               = submit_tag "Further review needed", class: 'button-secondary', form: 'retention_schedules_form' 
               = submit_tag "Retain", class: 'button-secondary', form: 'retention_schedules_form' 
-              = submit_tag "Mark for destruction", class: 'button-secondary', form: 'retention_schedules_form' 
+              - if @global_nav_manager.current_page_or_tab.name == :pending_removal
+                = submit_tag "Mark for destruction", class: 'button-secondary', form: 'retention_schedules_form' 
               - if @global_nav_manager.current_page_or_tab.name == :ready_for_removal
                 = submit_tag "Destroy cases", class: 'button-secondary button-destroy', form: 'retention_schedules_form' 
           .column-full.table-container.container.cases-table-container tabindex="0"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1253,7 +1253,7 @@ en:
         request: Request
         actions: Actions
       retention:
-        heading: Case retention scheduling
+        heading: Retain, Review, or Destroy (RRD)
     fixed_details:
       requester: Requester
       email_address: Email address

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -105,7 +105,7 @@ homepage_navigation:
       path: /cases/closed
       scope: closed_cases
 
-    case_retention:
+    rrd_pending:
       path: /cases/retention
       scope: retention_cases
       visibility:
@@ -161,7 +161,7 @@ global_navigation:
       path: /cases/closed
       scope: closed_cases
 
-    case_retention:
+    rrd_pending:
       path: /cases/retention
       scope: retention_cases
       visibility:

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -82,7 +82,7 @@ feature 'Case retention schedules for GDPR', :js do
     
     cases_page.load
 
-    expect(page).to have_content 'Case Retention'
+    expect(page).to have_content 'Rrd Pending'
 
     cases_page.homepage_navigation.case_retention.click
     


### PR DESCRIPTION
## Description
Update some page copy so that it uses "Retention, Review, Destroy" / RRD which is how it is referenced by users.

This also removes the "Mark for destruction" button from the pending removal tab as per CT-4190

Note: 
The way the computation of tab headings work does not support non-sentance case capitalisation i.e RRD -> Rrd on the tabs. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
Before:
<img width="616" alt="Screenshot 2022-05-24 at 16 57 47" src="https://user-images.githubusercontent.com/13377553/170080129-ad47bd2c-355b-4bd4-b357-7821aab98fc1.png">

After:
<img width="723" alt="Screenshot 2022-05-24 at 16 57 08" src="https://user-images.githubusercontent.com/13377553/170079999-5120a5c4-7dc3-48e2-84d5-1bacb200a8d5.png">

Button removal:
<img width="1004" alt="Screenshot 2022-05-25 at 13 07 55" src="https://user-images.githubusercontent.com/13377553/170258394-e955f61d-ddbe-4309-b47d-2d7d725c1992.png">


### Related JIRA tickets
[CT-4130](https://dsdmoj.atlassian.net/browse/CT-4130)
[CT-4131](https://dsdmoj.atlassian.net/browse/CT-4131)
[CT-4190](https://dsdmoj.atlassian.net/browse/CT-4190)


### Manual testing instructions
See changes on page
