### PR TITLE
Remove lots of render deprecation warnings

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -131,7 +131,7 @@ class AssignmentsController < ApplicationController
       end
     end
     respond_to do |format|
-      format.js { render 'assignments/accept.js.erb' }
+      format.js { render 'assignments/accept' }
       format.html do
         if @success
           flash[:notice] = "#{ @message}. #{ get_undo_link }".html_safe
@@ -160,7 +160,7 @@ class AssignmentsController < ApplicationController
     end
 
     respond_to do |format|
-      format.js { render 'assignments/accept.js.erb' }
+      format.js { render 'assignments/accept' }
       format.html do
         if @success
           flash[:notice] = "#{ @message}. #{ get_undo_link }".html_safe
@@ -178,7 +178,7 @@ class AssignmentsController < ApplicationController
     unaccept_service.call
 
     respond_to do |format|
-      format.js { render 'assignments/unaccept.js.erb' }
+      format.js { render 'assignments/unaccept' }
       format.html { redirect_to case_path(@case) }
     end
   end

--- a/app/controllers/cases/clearances_controller.rb
+++ b/app/controllers/cases/clearances_controller.rb
@@ -33,7 +33,7 @@ module Cases
       service.call
 
       respond_to do |format|
-        format.js { render 'flag_for_clearance.js.erb' }
+        format.js { render 'flag_for_clearance' }
         format.html do
           redirect_to case_path(@case)
         end
@@ -67,7 +67,7 @@ module Cases
       service.call
 
       respond_to do |format|
-        format.js { render 'unflag_for_clearance.js.erb' }
+        format.js { render 'unflag_for_clearance' }
         format.html do
           flash[:notice] = "Case has been de-escalated. #{ get_de_escalated_undo_link }".html_safe
           if @case.type_abbreviation == 'SAR'

--- a/app/views/teams/edit.html.slim
+++ b/app/views/teams/edit.html.slim
@@ -14,4 +14,4 @@
         "#{pluralize(@team.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""
 
 = form_for @team, as: :team, url: team_path(@team) do |f|
-  = render partial: 'form.html.slim', locals: {form: f}
+  = render partial: 'form', locals: {form: f}

--- a/app/views/teams/new.html.slim
+++ b/app/views/teams/new.html.slim
@@ -18,4 +18,4 @@
 
   = hidden_field_tag :team_type, params[:team_type]
 
-  = render partial: 'form.html.slim', locals: {form: f, team_type: @team_type }
+  = render partial: 'form', locals: {form: f, team_type: @team_type }

--- a/spec/controllers/cases/clearances_controller_spec.rb
+++ b/spec/controllers/cases/clearances_controller_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Cases::ClearancesController, type: :controller do
 
         it 'renders the view' do
           patch :flag_for_clearance, params: params, xhr: true
-          expect(response).to have_rendered('flag_for_clearance.js.erb')
+          expect(response).to have_rendered('flag_for_clearance')
         end
 
         it 'returns a success code' do
@@ -133,7 +133,7 @@ RSpec.describe Cases::ClearancesController, type: :controller do
 
         it 'renders the view' do
           patch :flag_for_clearance, params: params, xhr: true
-          expect(response).to have_rendered('flag_for_clearance.js.erb')
+          expect(response).to have_rendered('flag_for_clearance')
         end
 
         it 'returns success' do
@@ -415,7 +415,7 @@ RSpec.describe Cases::ClearancesController, type: :controller do
 
           it 'renders the view' do
             patch :unflag_for_clearance, params: params, xhr: true
-            expect(response).to have_rendered(('unflag_for_clearance.js.erb'))
+            expect(response).to have_rendered(('unflag_for_clearance'))
           end
 
           it 'returns success' do

--- a/spec/features/cases/sar_internal_review/case_creating_spec.rb
+++ b/spec/features/cases/sar_internal_review/case_creating_spec.rb
@@ -79,6 +79,8 @@ feature 'SAR Internal Review Case creation by a manager' do
   def then_they_can_take_the_case_on_and_clear_the_response
     click_link 'New cases'
     click_link 'Take case on'
+
+    expect(page).to have_content(latest_sar_ir_number)
     click_link latest_sar_ir_number
 
     expect(page).not_to have_content('Close case')

--- a/spec/views/cases/_case_attachments_html_slim_spec.rb
+++ b/spec/views/cases/_case_attachments_html_slim_spec.rb
@@ -44,7 +44,7 @@ describe 'cases/case_attachments.html.slim', type: :view do
       disallow_case_policy(:can_remove_attachment?, ico_case)
 
 
-      render partial: 'cases/case_attachments.html.slim',
+      render partial: 'cases/case_attachments',
              locals:{ case_details: ico_case}
 
       partial =  case_attachments_section(rendered)
@@ -55,7 +55,7 @@ describe 'cases/case_attachments.html.slim', type: :view do
       disallow_case_policy(:can_remove_attachment?, @kase)
 
 
-      render partial: 'cases/case_attachments.html.slim',
+      render partial: 'cases/case_attachments',
              locals:{ case_details: @kase}
 
       partial =  case_attachments_section(rendered)
@@ -69,7 +69,7 @@ describe 'cases/case_attachments.html.slim', type: :view do
       disallow_case_policy(:can_remove_attachment?, @kase)
 
 
-      render partial: 'cases/case_attachments.html.slim',
+      render partial: 'cases/case_attachments',
              locals:{ case_details: @kase}
 
       partial =  case_attachments_section(rendered)
@@ -85,7 +85,7 @@ describe 'cases/case_attachments.html.slim', type: :view do
     it 'should have a preview and download link' do
       disallow_case_policy(:can_remove_attachment?, @kase)
 
-      render partial: 'cases/case_attachments.html.slim',
+      render partial: 'cases/case_attachments',
              locals:{ case_details: @kase}
 
       partial =  case_attachments_section(rendered)
@@ -101,7 +101,7 @@ describe 'cases/case_attachments.html.slim', type: :view do
       it 'should show a remove link if the user is authorised to do so' do
         allow_case_policy(:can_remove_attachment?, @kase)
 
-        render partial: 'cases/case_attachments.html.slim',
+        render partial: 'cases/case_attachments',
                locals:{ case_details: @kase}
 
         partial =  case_attachments_section(rendered)
@@ -114,7 +114,7 @@ describe 'cases/case_attachments.html.slim', type: :view do
       it 'should not show a remove link if the user is not allowed to' do
         disallow_case_policy(:can_remove_attachment?, @kase)
 
-        render partial: 'cases/case_attachments.html.slim',
+        render partial: 'cases/case_attachments',
                locals:{ case_details: @kase}
 
         partial =  case_attachments_section(rendered)

--- a/spec/views/cases/_case_history_html_slim_spec.rb
+++ b/spec/views/cases/_case_history_html_slim_spec.rb
@@ -12,7 +12,7 @@ describe 'cases/case_history.html.slim', type: :view do
     transitions = [first]
 
     assign(:case_transitions, transitions)
-    render partial: 'cases/case_history.html.slim',
+    render partial: 'cases/case_history',
               locals:{ case_details: first}
 
     partial = case_history_section(rendered)
@@ -30,7 +30,7 @@ describe 'cases/case_history.html.slim', type: :view do
     transitions = [first]
 
     assign(:case_transitions, transitions)
-    render partial: 'cases/case_history.html.slim',
+    render partial: 'cases/case_history',
               locals:{ case_details: first}
 
     partial = case_history_section(rendered)

--- a/spec/views/cases/_case_request_html_slim_spec.rb
+++ b/spec/views/cases/_case_request_html_slim_spec.rb
@@ -37,7 +37,7 @@ describe 'cases/case_request.html.slim', type: :view do
     let(:offender_sar_case) { create :offender_sar_case, message: '' }
   
     let(:partial) do
-      render partial: 'cases/case_request.html.slim',
+      render partial: 'cases/case_request',
              locals:{ case_details: offender_sar_case }
 
       case_request_section(rendered)
@@ -66,7 +66,7 @@ describe 'cases/case_request.html.slim', type: :view do
     end
 
     let(:partial) do
-      render partial: 'cases/case_request.html.slim',
+      render partial: 'cases/case_request',
              locals:{ case_details: decorated_case }
 
       case_request_section(rendered)
@@ -94,7 +94,7 @@ describe 'cases/case_request.html.slim', type: :view do
     end
 
     let(:partial) do
-      render partial: 'cases/case_request.html.slim',
+      render partial: 'cases/case_request',
              locals:{ case_details: decorated_case}
 
       case_request_section(rendered)
@@ -121,7 +121,7 @@ describe 'cases/case_request.html.slim', type: :view do
 
     let(:partial) do
       disallow_case_policies_in_view(decorated_case, :can_remove_attachment?, :can_upload_request_attachment?)
-      render partial: 'cases/case_request.html.slim',
+      render partial: 'cases/case_request',
              locals:{ case_details: decorated_case }
 
       case_request_section(rendered)

--- a/spec/views/cases/_case_status_html_slim_spec.rb
+++ b/spec/views/cases/_case_status_html_slim_spec.rb
@@ -15,7 +15,7 @@ describe 'cases/case_status.html.slim', type: :view do
       offender_sar?: false
 
 
-    render partial: 'cases/case_status.html.slim',
+    render partial: 'cases/case_status',
            locals:{ case_details: unassigned_case}
 
     partial = case_status_section(rendered)
@@ -47,7 +47,7 @@ describe 'cases/case_status.html.slim', type: :view do
       type_of_offender_sar?: false,
       offender_sar?: false
 
-    render partial: 'cases/case_status.html.slim',
+    render partial: 'cases/case_status',
            locals:{ case_details: closed_case}
 
     partial = case_status_section(rendered)
@@ -73,7 +73,7 @@ describe 'cases/case_status.html.slim', type: :view do
       type_of_offender_sar?: false,
       offender_sar?: false
 
-    render partial: 'cases/case_status.html.slim',
+    render partial: 'cases/case_status',
            locals:{ case_details: non_trigger_case}
 
     partial = case_status_section(rendered)
@@ -100,7 +100,7 @@ describe 'cases/case_status.html.slim', type: :view do
         type_of_offender_sar?: false,
         offender_sar?: false
 
-      render partial: 'cases/case_status.html.slim',
+      render partial: 'cases/case_status',
              locals:{ case_details: non_trigger_case}
 
       partial = case_status_section(rendered)
@@ -131,7 +131,7 @@ describe 'cases/case_status.html.slim', type: :view do
         offender_sar?: false
 
 
-      render partial: 'cases/case_status.html.slim',
+      render partial: 'cases/case_status',
              locals:{ case_details: ico_case}
 
       partial = case_status_section(rendered)
@@ -171,7 +171,7 @@ describe 'cases/case_status.html.slim', type: :view do
                             params.merge({ offender_sar_complaint?: true })
 
       [offender_sar_case, offender_sar_complaint].each do |kase|
-        render partial: 'cases/case_status.html.slim',
+        render partial: 'cases/case_status',
                locals:{ case_details: kase}
         partial = case_status_section(rendered)
 
@@ -198,7 +198,7 @@ describe 'cases/case_status.html.slim', type: :view do
         offender_sar?: false
 
 
-      render partial: 'cases/case_status.html.slim',
+      render partial: 'cases/case_status',
              locals:{ case_details: ico_case}
 
       partial = case_status_section(rendered)
@@ -221,7 +221,7 @@ describe 'cases/case_status.html.slim', type: :view do
     }
 
     it 'displays ICO case reference number for ICO overturned SAR cases' do
-      render partial: 'cases/case_status.html.slim',
+      render partial: 'cases/case_status',
              locals: { case_details: ico_overturned_sar }
       partial = case_status_section(rendered)
 

--- a/spec/views/cases/_linked_cases_html_slim_spec.rb
+++ b/spec/views/cases/_linked_cases_html_slim_spec.rb
@@ -52,7 +52,7 @@ describe 'cases/linked_cases.html.slim', type: :view do
 
         disallow_case_policy main_case, :new_case_link?, :destroy_case_link?
 
-        render partial: 'cases/linked_cases.html.slim',
+        render partial: 'cases/linked_cases',
                locals:{ case_details: main_case}
 
         partial = linked_cases_section(rendered)
@@ -76,7 +76,7 @@ describe 'cases/linked_cases.html.slim', type: :view do
 
         allow_case_policy main_case, :new_case_link?, :destroy_case_link?
 
-        render partial: 'cases/linked_cases.html.slim',
+        render partial: 'cases/linked_cases',
                locals:{ case_details: main_case}
 
         partial = linked_cases_section(rendered)
@@ -107,7 +107,7 @@ describe 'cases/linked_cases.html.slim', type: :view do
 
       disallow_case_policy unlinked_case, :new_case_link?, :destroy_case_link?
 
-      render partial: 'cases/linked_cases.html.slim',
+      render partial: 'cases/linked_cases',
              locals:{ case_details: unlinked_case}
 
       partial = linked_cases_section(rendered)
@@ -132,7 +132,7 @@ describe 'cases/linked_cases.html.slim', type: :view do
     it 'hides the link if user is not authorised to link cases' do
       disallow_case_policy main_case, :new_case_link?, :destroy_case_link?
 
-      render partial: 'cases/linked_cases.html.slim',
+      render partial: 'cases/linked_cases',
              locals:{ case_details: main_case}
 
       partial = linked_cases_section(rendered)
@@ -143,7 +143,7 @@ describe 'cases/linked_cases.html.slim', type: :view do
     it 'shows the link if user is authorised to link cases' do
       allow_case_policy main_case, :new_case_link?, :destroy_case_link?
 
-      render partial: 'cases/linked_cases.html.slim',
+      render partial: 'cases/linked_cases',
              locals:{ case_details: main_case}
 
       partial = linked_cases_section(rendered)

--- a/spec/views/cases/clearances/_clearance_levels_html_slim_spec.rb
+++ b/spec/views/cases/clearances/_clearance_levels_html_slim_spec.rb
@@ -46,7 +46,7 @@ describe 'cases/clearance_details.html.slim', type: :view do
 
       allow_case_policies_in_view kase.decorate, :request_further_clearance?
 
-      render partial: 'cases/clearance_levels.html.slim',
+      render partial: 'cases/clearance_levels',
              locals:{ case_details: kase }
 
       partial = clearance_levels_section(rendered)
@@ -61,7 +61,7 @@ describe 'cases/clearance_details.html.slim', type: :view do
 
         allow_case_policies_in_view accepted_case.decorate, :request_further_clearance?
 
-        render partial: 'cases/clearance_levels.html.slim',
+        render partial: 'cases/clearance_levels',
                locals:{ case_details: accepted_case.decorate }
         partial = clearance_levels_section(rendered)
 
@@ -79,7 +79,7 @@ describe 'cases/clearance_details.html.slim', type: :view do
           :request_further_clearance?
         )
 
-        render partial: 'cases/clearance_levels.html.slim',
+        render partial: 'cases/clearance_levels',
                locals:{ case_details:unaccepted_pending_dacu_clearance_case.decorate }
         partial = clearance_levels_section(rendered)
 
@@ -99,7 +99,7 @@ describe 'cases/clearance_details.html.slim', type: :view do
         )
 
 
-        render partial: 'cases/clearance_levels.html.slim',
+        render partial: 'cases/clearance_levels',
                locals:{ case_details: accepted_pending_dacu_clearance_case.decorate }
         partial = clearance_levels_section(rendered)
 
@@ -118,7 +118,7 @@ describe 'cases/clearance_details.html.slim', type: :view do
         allow(policy).to receive(:request_further_clearance?).and_return(true)
         allow(view).to receive(:policy).with(triple_flagged_case).and_return(policy)
 
-        render partial: 'cases/clearance_levels.html.slim',
+        render partial: 'cases/clearance_levels',
                locals:{ case_details: triple_flagged_case.decorate }
         partial = clearance_levels_section(rendered)
 
@@ -147,7 +147,7 @@ describe 'cases/clearance_details.html.slim', type: :view do
         )
 
 
-        render partial: 'cases/clearance_levels.html.slim',
+        render partial: 'cases/clearance_levels',
                locals:{ case_details: flagged_overturned_sar.decorate }
         partial = clearance_levels_section(rendered)
 

--- a/spec/views/cases/foi/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/foi/_case_details_html_slim_spec.rb
@@ -22,7 +22,7 @@ describe 'cases/foi/case_details.html.slim', type: :view do
   describe 'foi_basic_details' do
     it 'displays the initial case details' do
       assign(:case, unassigned_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals: { case_details: unassigned_case,
                        link_type: nil }
 
@@ -59,7 +59,7 @@ describe 'cases/foi/case_details.html.slim', type: :view do
     it 'displays a trigger badge if the case has been triggered' do
       trigger_case
       assign(:case, trigger_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals: { case_details: trigger_case,
                        link_type: nil }
 
@@ -75,7 +75,7 @@ describe 'cases/foi/case_details.html.slim', type: :view do
     it 'does not display the email address if one is not provided' do
       unassigned_case.email = nil
       assign(:case, unassigned_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals: { case_details: unassigned_case,
                        link_type: nil }
 
@@ -88,7 +88,7 @@ describe 'cases/foi/case_details.html.slim', type: :view do
     it 'does not display the postal address if one is not provided' do
       unassigned_case.postal_address = nil
       assign(:case, unassigned_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals: { case_details: unassigned_case,
                        link_type: nil }
 
@@ -102,7 +102,7 @@ describe 'cases/foi/case_details.html.slim', type: :view do
   describe 'responders details' do
     it 'displays the responders team name' do
       assign(:case, accepted_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals:{ case_details: accepted_case,
                       link_type: nil }
 
@@ -117,7 +117,7 @@ describe 'cases/foi/case_details.html.slim', type: :view do
   describe 'draft compliance details' do
     it 'displays the date compliant' do
       assign(:case, approved_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals:{ case_details: approved_case,
                       link_type: nil }
 
@@ -133,7 +133,7 @@ describe 'cases/foi/case_details.html.slim', type: :view do
     it 'displays all the case closure details' do
       closed_case
       assign(:case, closed_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals: { case_details: closed_case,
                        link_type: nil }
 
@@ -150,7 +150,7 @@ describe 'cases/foi/case_details.html.slim', type: :view do
 
     it 'displays as original case' do
       assign(:case, ico_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals:{ case_details: ico_case.original_case.decorate,
                       link_type: 'original' }
 
@@ -160,7 +160,7 @@ describe 'cases/foi/case_details.html.slim', type: :view do
 
     it 'displays a link to original case' do
       assign(:case, ico_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals:{ case_details: ico_case.original_case.decorate,
                       link_type: 'original' }
 

--- a/spec/views/cases/ico/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/ico/_case_details_html_slim_spec.rb
@@ -15,7 +15,7 @@ describe 'cases/ico/case_details.html.slim', type: :view do
       before do
         assign(:case, ico_foi_case)
         login_as create(:manager)
-        render partial: 'cases/ico/case_details.html.slim',
+        render partial: 'cases/ico/case_details',
                locals: { case_details: ico_foi_case,
                          link_type: nil }
       end
@@ -30,7 +30,7 @@ describe 'cases/ico/case_details.html.slim', type: :view do
       it 'displays the initial case details' do
         assign(:case, ico_foi_case)
         login_as create(:manager)
-        render partial: 'cases/ico/case_details.html.slim',
+        render partial: 'cases/ico/case_details',
                locals: { case_details: ico_foi_case,
                          link_type: nil }
 
@@ -52,7 +52,7 @@ describe 'cases/ico/case_details.html.slim', type: :view do
       it 'displays the responders team name' do
         assign(:case, accepted_case)
         login_as create(:manager)
-        render partial: 'cases/ico/case_details.html.slim',
+        render partial: 'cases/ico/case_details',
                locals: { case_details: accepted_case,
                          link_type: nil }
 
@@ -68,7 +68,7 @@ describe 'cases/ico/case_details.html.slim', type: :view do
       it 'displays the date,time taken, timeliness and final outcome' do
         assign(:case, closed_foi_appeal)
         login_as create(:manager)
-        render partial: 'cases/ico/case_details.html.slim',
+        render partial: 'cases/ico/case_details',
                locals: { case_details: closed_foi_appeal,
                          link_type: nil }
 
@@ -86,7 +86,7 @@ describe 'cases/ico/case_details.html.slim', type: :view do
         login_as create(:manager)
         assign(:case, responded_case)
 
-        render partial: 'cases/ico/case_details.html.slim',
+        render partial: 'cases/ico/case_details',
                locals:{ case_details: responded_case,
                         link_type: nil }
 
@@ -104,7 +104,7 @@ describe 'cases/ico/case_details.html.slim', type: :view do
       before do
         assign(:case, ico_sar_case)
         login_as create(:manager)
-        render partial: 'cases/ico/case_details.html.slim',
+        render partial: 'cases/ico/case_details',
                locals: { case_details: ico_sar_case,
                          link_type: nil }
       end
@@ -119,7 +119,7 @@ describe 'cases/ico/case_details.html.slim', type: :view do
       it 'displays the initial case details' do
         assign(:case, ico_sar_case)
         login_as create(:manager)
-        render partial: 'cases/ico/case_details.html.slim',
+        render partial: 'cases/ico/case_details',
                locals: { case_details: ico_sar_case,
                          link_type: nil }
 
@@ -141,7 +141,7 @@ describe 'cases/ico/case_details.html.slim', type: :view do
       it 'displays the responders team name' do
         assign(:case, accepted_sar_case)
         login_as create(:manager)
-        render partial: 'cases/ico/case_details.html.slim',
+        render partial: 'cases/ico/case_details',
                locals: { case_details: accepted_sar_case,
                          link_type: nil }
 
@@ -157,7 +157,7 @@ describe 'cases/ico/case_details.html.slim', type: :view do
       it 'displays the date,time taken, timeliness and final outcome' do
         assign(:case, closed_sar_appeal)
         login_as create(:manager)
-        render partial: 'cases/ico/case_details.html.slim',
+        render partial: 'cases/ico/case_details',
                locals: { case_details: closed_sar_appeal,
                          link_type: nil }
 

--- a/spec/views/cases/ico/_ico_final_decision_html_slim_spec.rb
+++ b/spec/views/cases/ico/_ico_final_decision_html_slim_spec.rb
@@ -10,7 +10,7 @@ describe 'cases/ico/_ico_final_decision.html.slim', type: :view do
       login_as create(:manager)
       disallow_case_policies_in_view upheld_closed_sar_ico_appeal,
                                      :can_remove_attachment?
-      render partial: 'cases/ico/ico_final_decision.html.slim',
+      render partial: 'cases/ico/ico_final_decision',
              locals: { case_details: upheld_closed_sar_ico_appeal }
     end
 
@@ -32,7 +32,7 @@ describe 'cases/ico/_ico_final_decision.html.slim', type: :view do
 
       disallow_case_policies_in_view upheld_closed_sar_ico_appeal,
                                      :can_remove_attachment?
-      render partial: 'cases/ico/ico_final_decision.html.slim',
+      render partial: 'cases/ico/ico_final_decision',
              locals: { case_details: upheld_closed_sar_ico_appeal }
 
       partial = ico_decision_section(rendered)
@@ -54,7 +54,7 @@ describe 'cases/ico/_ico_final_decision.html.slim', type: :view do
     def render_partial(kase)
       assign(:case, kase)
       disallow_case_policies_in_view kase, :can_remove_attachment?
-      render partial: 'cases/ico/ico_final_decision.html.slim',
+      render partial: 'cases/ico/ico_final_decision',
              locals: { case_details: kase }
 
       ico_decision_section(rendered)

--- a/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
@@ -19,7 +19,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
   describe 'basic_details' do
     it 'displays the initial case details (non third party case)' do
       assign(:case, offender_sar_case)
-      render partial: 'cases/offender_sar/case_details.html.slim',
+      render partial: 'cases/offender_sar/case_details',
              locals: { case_details: offender_sar_case,
                        link_type: nil, allow_editing: true}
 
@@ -49,7 +49,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
     it 'displays third party details if present' do
       third_party_case = (create :offender_sar_case, :third_party, third_party_name: 'Rick Westor').decorate
       assign(:case, third_party_case)
-      render partial: 'cases/offender_sar/case_details.html.slim', locals: {
+      render partial: 'cases/offender_sar/case_details', locals: {
         case_details: third_party_case,
         link_type: nil, 
         allow_editing: true
@@ -70,7 +70,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
         date_responded: 1.days.ago,
         external_deadline: 40.days.ago).decorate
       assign(:case, late_closed_case)
-      render partial: 'cases/offender_sar/case_details.html.slim', locals: {
+      render partial: 'cases/offender_sar/case_details', locals: {
         case_details: late_closed_case,
         link_type: nil,
         allow_editing: true

--- a/spec/views/cases/overturned_foi/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/overturned_foi/_case_details_html_slim_spec.rb
@@ -7,7 +7,7 @@ describe 'cases/overturned_foi/case_details.html.slim', type: :view do
   let(:bmt_manager)     { find_or_create(:disclosure_bmt_user) }
 
   def render_partial(kase)
-    render partial: 'cases/overturned_foi/case_details.html.slim',
+    render partial: 'cases/overturned_foi/case_details',
            locals: { case_details: kase.decorate,
                      link_type: nil }
     overturned_foi_case_details_section(rendered)
@@ -94,7 +94,7 @@ describe 'cases/overturned_foi/case_details.html.slim', type: :view do
     it 'displays the date compliant' do
       assign(:case, approved_case)
 
-      render partial: 'cases/overturned_foi/case_details.html.slim',
+      render partial: 'cases/overturned_foi/case_details',
              locals:{ case_details: approved_case,
                       link_type: nil }
 
@@ -110,7 +110,7 @@ describe 'cases/overturned_foi/case_details.html.slim', type: :view do
 
     it 'displays as original case' do
       assign(:case, ico_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals: { case_details: ico_case.original_case.decorate,
                        link_type: 'original' }
 
@@ -120,7 +120,7 @@ describe 'cases/overturned_foi/case_details.html.slim', type: :view do
 
     it 'displays a link to original case' do
       assign(:case, ico_case)
-      render partial: 'cases/foi/case_details.html.slim',
+      render partial: 'cases/foi/case_details',
              locals: { case_details: ico_case.original_case.decorate,
                        link_type: 'original' }
 

--- a/spec/views/cases/overturned_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/overturned_sar/_case_details_html_slim_spec.rb
@@ -8,7 +8,7 @@ describe 'cases/overturned_sar/case_details.html.slim', type: :view do
   let(:flagged_case)    { create(:overturned_ico_sar, :flagged ) }
 
   def render_partial(kase)
-    render partial: 'cases/overturned_sar/case_details.html.slim',
+    render partial: 'cases/overturned_sar/case_details',
            locals: { case_details: kase.decorate,
                      link_type: nil }
     overturned_sar_case_details_section(rendered)
@@ -123,7 +123,7 @@ describe 'cases/overturned_sar/case_details.html.slim', type: :view do
     it 'displays the date compliant' do
       assign(:case, approved_case)
 
-      render partial: 'cases/overturned_foi/case_details.html.slim',
+      render partial: 'cases/overturned_foi/case_details',
              locals:{ case_details: approved_case,
                       link_type: nil }
 
@@ -139,7 +139,7 @@ describe 'cases/overturned_sar/case_details.html.slim', type: :view do
 
     it 'displays as original case' do
       assign(:case, ico_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals: { case_details: ico_case.original_case.decorate,
                        link_type: 'original' }
 
@@ -149,7 +149,7 @@ describe 'cases/overturned_sar/case_details.html.slim', type: :view do
 
     it 'displays a link to original case' do
       assign(:case, ico_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals: { case_details: ico_case.original_case.decorate,
                        link_type: 'original' }
 

--- a/spec/views/cases/overturned_shared/new_html_slim_spec.rb
+++ b/spec/views/cases/overturned_shared/new_html_slim_spec.rb
@@ -47,7 +47,7 @@ describe 'cases/overturned_shared/_new.html.slim' do
     subject { partial.ico_appeal_info }
 
     it { should be_visible }
-    it { should have_text(overturned_foi.number) }
+    it { should have_text(overturned_foi.original_ico_appeal.number) }
     it { should have_text(overturned_foi.subject) }
     it { should have_text('(opens in a new tab)') }
 

--- a/spec/views/cases/sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/sar/_case_details_html_slim_spec.rb
@@ -17,7 +17,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
   describe 'basic_details' do
     it 'displays the initial case details (non third party case' do
       assign(:case, unassigned_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals: { case_details: unassigned_case,
                        link_type: nil }
 
@@ -37,7 +37,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
     it 'displays third party details if present' do
       third_party_case = (create :sar_case, :third_party, name: 'Rick Westor').decorate
       assign(:case, third_party_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals: { case_details: third_party_case,
                        link_type: nil }
       partial = case_details_section(rendered).sar_basic_details
@@ -52,7 +52,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
       unassigned_case.reply_method = 'send_by_post'
 
       assign(:case, unassigned_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals: { case_details: unassigned_case,
                        link_type: nil }
 
@@ -67,7 +67,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
       unassigned_case.email = 'john.doe@moj.com'
 
       assign(:case, unassigned_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals:{ case_details: unassigned_case,
                       link_type: nil }
 
@@ -81,7 +81,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
   describe 'responders details' do
     it 'displays the responders team name' do
       assign(:case, accepted_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals:{ case_details: accepted_case,
                       link_type: nil }
 
@@ -97,7 +97,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
     it 'displays the date compliant' do
       assign(:case, approved_case)
 
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals:{ case_details: approved_case,
                       link_type: nil }
 
@@ -114,7 +114,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
 
     it 'displays as original case' do
       assign(:case, ico_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals: { case_details: ico_case.original_case.decorate,
                        link_type: 'original' }
 
@@ -124,7 +124,7 @@ describe 'cases/sar/case_details.html.slim', type: :view do
 
     it 'displays a link to original case' do
       assign(:case, ico_case)
-      render partial: 'cases/sar/case_details.html.slim',
+      render partial: 'cases/sar/case_details',
              locals: { case_details: ico_case.original_case.decorate,
                        link_type: nil }
 

--- a/spec/views/cases/sar/_close_form_html_slim_spec.rb
+++ b/spec/views/cases/sar/_close_form_html_slim_spec.rb
@@ -5,7 +5,7 @@ describe 'cases/sar/_date_responded_form.html.slim' do
 
   it 'renders the close_form partial' do
     assign(:case, closed_sar)
-    render(partial: 'cases/sar/close_form.html.slim',
+    render(partial: 'cases/sar/close_form',
            locals: { kase: closed_sar.decorate,
                      submit_button: 'Save changes' })
     cases_close_page.load(rendered)

--- a/spec/views/cases/sar/_new_html_slim_spec.rb
+++ b/spec/views/cases/sar/_new_html_slim_spec.rb
@@ -13,7 +13,7 @@ describe 'cases/sar/new.html.slim', type: :view do
 
   xdescribe 'sar form' do
     it 'asks for data subjects info' do
-      render partial: 'cases/sar/new_form_common.html.slim',
+      render partial: 'cases/sar/new_form_common',
              locals:{ kase: sar_case}
 
     end
@@ -25,7 +25,7 @@ describe 'cases/sar/new.html.slim', type: :view do
 
   # describe 'basic_details' do
   #   it 'displays the initial case details' do
-  #     render partial: 'cases/case_details.html.slim',
+  #     render partial: 'cases/case_details',
   #            locals:{ case_details: unassigned_case}
   #
   #     partial = case_details_section(rendered).basic_details
@@ -59,7 +59,7 @@ describe 'cases/sar/new.html.slim', type: :view do
   #   it 'displays a trigger badge if the case has been triggered' do
   #     trigger_case
   #
-  #     render partial: 'cases/case_details.html.slim',
+  #     render partial: 'cases/case_details',
   #            locals:{ case_details: trigger_case}
   #
   #     partial = case_details_section(rendered).basic_details
@@ -74,7 +74,7 @@ describe 'cases/sar/new.html.slim', type: :view do
   #   it 'does not display the email address if one is not provided' do
   #     unassigned_case.email = nil
   #
-  #     render partial: 'cases/case_details.html.slim',
+  #     render partial: 'cases/case_details',
   #            locals:{ case_details: unassigned_case}
   #
   #     partial = case_details_section(rendered).basic_details
@@ -86,7 +86,7 @@ describe 'cases/sar/new.html.slim', type: :view do
   #   it 'does not display the postal address if one is not provided' do
   #     unassigned_case.postal_address = nil
   #
-  #     render partial: 'cases/case_details.html.slim',
+  #     render partial: 'cases/case_details',
   #            locals:{ case_details: unassigned_case}
   #
   #     partial = case_details_section(rendered).basic_details
@@ -97,7 +97,7 @@ describe 'cases/sar/new.html.slim', type: :view do
   # end
   # describe 'responders details' do
   #   it 'displays the responders team name' do
-  #     render partial: 'cases/case_details.html.slim',
+  #     render partial: 'cases/case_details',
   #            locals:{ case_details: accepted_case}
   #
   #     partial = case_details_section(rendered).responders_details
@@ -112,7 +112,7 @@ describe 'cases/sar/new.html.slim', type: :view do
   #
   #   it 'displays all the case closure details' do
   #     closed_case
-  #     render partial: 'cases/case_details.html.slim',
+  #     render partial: 'cases/case_details',
   #            locals:{ case_details: closed_case}
   #
   #     partial = case_details_section(rendered).response_details

--- a/spec/views/shared/_dropzone_js_html_slim_spec.rb
+++ b/spec/views/shared/_dropzone_js_html_slim_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 describe 'shared/dropzone_js.html.slim', type: :view do
   describe 'Preview template' do
-
-
     it 'displays a filename' do
       partial =  render_partial
       expect(partial).to have_filename
@@ -32,7 +30,7 @@ describe 'shared/dropzone_js.html.slim', type: :view do
 
 
   def render_partial
-    render partial: 'shared/dropzone_js.html.slim'
+    render partial: 'shared/dropzone_js'
     dropzonejs_preview_template_section(rendered)
   end
 


### PR DESCRIPTION
## Description

Code tweaks to eliminate all (as far as I can tell) deprecation warnings like this one:

```
DEPRECATION WARNING: Rendering actions with '.' in the name is deprecated: cases/ico/_ico_final_decision.html.slim (called from block (3 levels) in <main> at /projects/correspondence_tool_staff/spec/views/cases/ico/_ico_final_decision_html_slim_spec.rb:13)
```

This should not have any impact on the application but a bit of sanity check on dev/staging is recommended.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
