### PR TITLE
CT-4132 Add filter for retention state to the UI

### DIFF
--- a/app/assets/stylesheets/moj/_govuk_overrides.scss
+++ b/app/assets/stylesheets/moj/_govuk_overrides.scss
@@ -142,7 +142,7 @@ td {
     float: right;
   }
 
-  .multiple-choice {
+  .cases-table-container .multiple-choice {
     padding: 9px 0 0 13px;
 
     label {

--- a/app/controllers/cases/filters_controller.rb
+++ b/app/controllers/cases/filters_controller.rb
@@ -148,6 +148,9 @@ module Cases
         prepare_open_cases_collection(service)
       end
 
+      @filter_crumbs = @query.filter_crumbs
+      @current_tab_name = "retention_#{@global_nav_manager.current_page_or_tab.name}"
+
       respond_to do |format|
         format.html { render :retention }
       end

--- a/app/models/case_attachment.rb
+++ b/app/models/case_attachment.rb
@@ -123,11 +123,11 @@ class CaseAttachment < ApplicationRecord
   def validate_file_extension
     mime_type = Rack::Mime.mime_type(File.extname filename)
     unless Settings.case_uploads_accepted_types.include? mime_type
-      errors[:url] << I18n.t(
+      errors.add(:url, I18n.t(
         'activerecord.errors.models.case_attachment.attributes.url.bad_file_type',
         type: mime_type,
         filename: filename
-      )
+      ))
     end
   end
 end

--- a/app/models/retention_schedule.rb
+++ b/app/models/retention_schedule.rb
@@ -48,5 +48,9 @@ class RetentionSchedule < ApplicationRecord
       viewable_from = Settings.retention_timings.common.viewable_from
       viewable_from.months.ago..Date.today
     end
+
+    def states_map
+      aasm.states.to_h { |state| [state.name, state.display_name] }
+    end
   end
 end

--- a/app/models/search_query.rb
+++ b/app/models/search_query.rb
@@ -60,7 +60,10 @@ class SearchQuery < ApplicationRecord
       CaseFilter::CaseComplaintTypeFilter,
       CaseFilter::CaseComplaintSubtypeFilter, 
       CaseFilter::CaseComplaintPriorityFilter, 
-      CaseFilter::CasePartialCaseFlagFilter]
+      CaseFilter::CasePartialCaseFlagFilter],
+    "retention_pending_removal" => [
+      CaseFilter::CaseRetentionStateFilter
+    ],
   }.freeze
 
   attr_accessor :business_unit_name_filter

--- a/app/services/case_filter/case_retention_state_filter.rb
+++ b/app/services/case_filter/case_retention_state_filter.rb
@@ -1,0 +1,38 @@
+module CaseFilter
+  class CaseRetentionStateFilter < CaseMultiChoicesFilterBase
+    class << self
+      def identifier
+        'filter_retention_state'
+      end
+
+      def filter_attributes
+        [:filter_retention_state]
+      end
+    end
+
+    def available_choices
+      { filter_retention_state: retention_states }
+    end
+
+    def call
+      @records.where(
+        retention_schedule: { state: @query.filter_retention_state }
+      )
+    end
+
+    private
+
+    def retention_states
+      RetentionSchedule.states_map.except(*excluded_states).stringify_keys
+    end
+
+    # No need to show checkboxes for `to_be_destroyed` and `destroyed`, as cases
+    # with these retention states will not show in the tab where this filter is applied.
+    def excluded_states
+      [
+        RetentionSchedule::STATE_TO_BE_DESTROYED,
+        RetentionSchedule::STATE_DESTROYED
+      ]
+    end
+  end
+end

--- a/app/views/cases/filters/retention.html.slim
+++ b/app/views/cases/filters/retention.html.slim
@@ -33,7 +33,7 @@ section#retention-cases.govuk-tabs__panel
                            count: tab.count),
                           tab.fullpath_with_query
     - if @cases.present?
-        - cases_count = @global_nav_manager.current_page_or_tab.cases.count
+        - cases_count = @cases.total_count
 
         .grid-row
           .search-results-summary.column-one-third

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -552,6 +552,7 @@ en:
         filter_status: Status
         filter_timeliness: Timeliness
         filter_high_profile: Flag as high profile?
+        filter_retention_state: Status
       team:
         role: What will the business unit be responsible for?
         correspondence_type_ids: Correspondence types

--- a/config/locales/filters.en.yml
+++ b/config/locales/filters.en.yml
@@ -43,6 +43,8 @@ en:
         <<: *list_filter_type
       filter_partial_case_flag:
         <<: *list_filter_type
+      filter_retention_state:
+        <<: *list_filter_type
     headings:
       filter_status: Filter by open/closed cases
       filter_cases: Filter cases
@@ -60,6 +62,7 @@ en:
       filter_complaint_priority: Filter by priority
       filter_high_profile: Filter by sensitivity
       filter_caseworker: Filter by complaint caseworker
+      filter_retention_state: Filter by GDPR RRD status
       date_headings:
         filter_received_date: 'Received between'
         filter_date_responded: 'Responded between'

--- a/config/locales/nav.en.yml
+++ b/config/locales/nav.en.yml
@@ -5,7 +5,7 @@ en:
       incoming_cases: New cases
       my_open_cases: My open cases
       open_cases: All open cases
-      case_retention: Case Retention
+      rrd_pending: RRD Pending
   nav:
     menu: Menu
     pages:
@@ -15,6 +15,7 @@ en:
       my_open_cases: My open cases
       open_cases: Cases
       search_cases: Search
+      rrd_pending: RRD Pending
       teams:
         one: Team
         other: Teams

--- a/spec/controllers/cases/filters_controller/filters_controller_spec.rb
+++ b/spec/controllers/cases/filters_controller/filters_controller_spec.rb
@@ -229,6 +229,78 @@ describe Cases::FiltersController, type: :controller do
     end
   end
 
+  describe '#retention' do
+    context 'tab ready_for_removal' do
+      context 'as an anonymous user' do
+        it 'be redirected to signin if trying to access the page' do
+          get :retention, params: { tab: 'ready_for_removal' }
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+
+      context 'as a manager' do
+        before do
+          sign_in manager
+
+          allow_any_instance_of(GlobalNavManager).to receive(:current_page_or_tab).and_return(page_double)
+          allow_any_instance_of(CaseSearchService).to receive(:call).and_return(true)
+        end
+
+        let(:page_double) { double('page', name: 'ready_for_removal').as_null_object }
+
+        it 'renders the retention cases page' do
+          get :retention, params: { tab: 'ready_for_removal' }
+          expect(response).to render_template :retention
+        end
+
+        it 'assigns the filter_crumbs' do
+          get :retention, params: { tab: 'ready_for_removal' }
+          expect(assigns(:filter_crumbs)).not_to be_nil
+        end
+
+        it 'assigns the current_tab_name' do
+          get :retention, params: { tab: 'ready_for_removal' }
+          expect(assigns(:current_tab_name)).to eq('retention_ready_for_removal')
+        end
+      end
+    end
+
+    context 'tab pending_removal' do
+      context 'as an anonymous user' do
+        it 'be redirected to signin if trying to access the page' do
+          get :retention, params: { tab: 'pending_removal' }
+          expect(response).to redirect_to(new_user_session_path)
+        end
+      end
+
+      context 'as a manager' do
+        before do
+          sign_in manager
+
+          allow_any_instance_of(GlobalNavManager).to receive(:current_page_or_tab).and_return(page_double)
+          allow_any_instance_of(CaseSearchService).to receive(:call).and_return(true)
+        end
+
+        let(:page_double) { double('page', name: 'pending_removal').as_null_object }
+
+        it 'renders the retention cases page' do
+          get :retention, params: { tab: 'pending_removal' }
+          expect(response).to render_template :retention
+        end
+
+        it 'assigns the filter_crumbs' do
+          get :retention, params: { tab: 'pending_removal' }
+          expect(assigns(:filter_crumbs)).not_to be_nil
+        end
+
+        it 'assigns the current_tab_name' do
+          get :retention, params: { tab: 'pending_removal' }
+          expect(assigns(:current_tab_name)).to eq('retention_pending_removal')
+        end
+      end
+    end
+  end
+
   # Utility methods
 
   def stub_current_case_finder_for_closed_cases_with(result)

--- a/spec/factories/case/offender_sar_complaints.rb
+++ b/spec/factories/case/offender_sar_complaints.rb
@@ -231,11 +231,12 @@ FactoryBot.define do
     trait :with_retention_schedule do
       transient do
         planned_destruction_date { Date.today }
+        state { }
       end
 
       after(:create) do |kase, evaluator|
         kase.retention_schedule = RetentionSchedule.new(
-          planned_destruction_date: evaluator.planned_destruction_date
+          planned_destruction_date: evaluator.planned_destruction_date, state: evaluator.state
         )
         kase.save!
       end

--- a/spec/factories/case/offender_sars.rb
+++ b/spec/factories/case/offender_sars.rb
@@ -146,11 +146,12 @@ FactoryBot.define do
   trait :with_retention_schedule do
     transient do
       planned_destruction_date { Date.today }
+      state { }
     end
 
     after(:create) do |kase, evaluator|
       kase.retention_schedule = RetentionSchedule.new(
-        planned_destruction_date: evaluator.planned_destruction_date
+        planned_destruction_date: evaluator.planned_destruction_date, state: evaluator.state
       )
       kase.save!
     end

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -82,7 +82,7 @@ feature 'Case retention schedules for GDPR', :js do
     
     cases_page.load
 
-    expect(page).to have_content 'Rrd Pending'
+    expect(page).to have_content 'RRD Pending'
 
     cases_page.homepage_navigation.case_retention.click
     

--- a/spec/models/retention_schedule_spec.rb
+++ b/spec/models/retention_schedule_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe RetentionSchedule, type: :model do
   end
 
   describe 'class methods' do
-    describe '#common_date_viewable_from_range' do
+    describe '.common_date_viewable_from_range' do
       it 'returns a range that is correct' do
         class_range = RetentionSchedule.common_date_viewable_from_range
         expected_range = 4.months.ago..Date.today
@@ -134,6 +134,14 @@ RSpec.describe RetentionSchedule, type: :model do
         expect(class_range).to be_a(Range)
         expect(class_range.begin.day).to match(expected_range.begin.day)
         expect(class_range.end).to match(expected_range.end)
+      end
+    end
+
+    describe '.states_map' do
+      it 'returns a map of states and their corresponding display names' do
+        expect(
+          described_class.states_map
+        ).to eq({ not_set: 'Not set', retain: 'Retain', review: 'Review', to_be_destroyed: 'Destroy', destroyed: 'Anonymised' })
       end
     end
   end

--- a/spec/models/search_query_spec.rb
+++ b/spec/models/search_query_spec.rb
@@ -78,6 +78,7 @@ describe SearchQuery do
                                                  :filter_complaint_subtype, 
                                                  :filter_caseworker,
                                                  :filter_partial_case_flag,
+                                                 :filter_retention_state,
                                                  :date_responded_from, 
                                                  :date_responded_to, 
                                                  :received_date_from, 
@@ -234,6 +235,7 @@ describe SearchQuery do
                                                 :filter_complaint_subtype,
                                                 :filter_caseworker,
                                                 :filter_partial_case_flag,
+                                                :filter_retention_state,
                                                 :date_responded_from, 
                                                 :date_responded_to, 
                                                 :received_date_from, 
@@ -554,6 +556,11 @@ describe SearchQuery do
       search_query = create :search_query, filter_timeliness: ['in_time']
       expect(search_query.applied_filters).to eq [CaseFilter::TimelinessFilter]
     end
+
+    it 'includes retention state filter' do
+      search_query = create :search_query, filter_retention_state: ['review']
+      expect(search_query.applied_filters).to eq [CaseFilter::CaseRetentionStateFilter]
+    end
   end
 
   describe '#available_filters' do
@@ -642,6 +649,13 @@ describe SearchQuery do
           CaseFilter::CaseComplaintSubtypeFilter, 
           CaseFilter::CaseComplaintPriorityFilter,
         ]
+      end
+
+      it 'Pending removal tab' do
+        search_query = create :search_query
+        expect(
+          search_query.available_filters(user, 'retention_pending_removal'
+        ).map(&:class)).to eq [CaseFilter::CaseRetentionStateFilter]
       end
 
       it 'Search tab' do

--- a/spec/services/case_filter/case_retention_state_filter_spec.rb
+++ b/spec/services/case_filter/case_retention_state_filter_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+describe CaseFilter::CaseRetentionStateFilter do
+  before(:all) do
+    DbHousekeeping.clean
+
+    @offender_sar_complaint = create(:offender_sar_complaint)
+    @offender_sar_retention_not_set = create(:offender_sar_case, :closed, :with_retention_schedule)
+    @offender_sar_retention_review = create(:offender_sar_complaint, :closed, :with_retention_schedule, state: :review)
+  end
+
+  after(:all) do
+    DbHousekeeping.clean
+  end
+
+  let(:user) { find_or_create(:branston_user) }
+  let(:filter) { described_class.new search_query, user, Case::Base.joins(:retention_schedule) }
+
+  describe '#available_choices' do
+    let(:search_query) { create :search_query }
+
+    it 'contains the choices for the filter' do
+      expect(
+        filter.available_choices
+      ).to eq({ filter_retention_state: {'not_set' => 'Not set', 'retain' => 'Retain', 'review' => 'Review'} })
+    end
+  end
+
+  describe '#applied?' do
+    subject { filter }
+
+    context 'filter_retention_state not present' do
+      let(:search_query) { create :search_query }
+      it { should_not be_applied }
+    end
+
+    context 'filter_retention_state present' do
+      let(:search_query) { create :search_query, filter_retention_state: ['review'] }
+      it { should be_applied }
+    end
+  end
+
+  describe '#call' do
+    context 'filtering for not_set retention cases' do
+      let(:search_query) { create :search_query, filter_retention_state: ['not_set'] }
+
+      it 'returns the correct list of cases' do
+        results = filter.call
+        expect(results.records).to match_array([@offender_sar_retention_not_set])
+      end
+    end
+
+    context 'filtering for more than one state' do
+      let(:search_query) { create :search_query, filter_retention_state: %w(not_set review) }
+
+      it 'returns the correct list of cases' do
+        results = filter.call
+        expect(results.records).to match_array([@offender_sar_retention_not_set, @offender_sar_retention_review])
+      end
+    end
+  end
+
+  describe '#crumbs' do
+    context 'filter not enabled' do
+      let(:search_query) { create :search_query, filter_retention_state: [] }
+
+      it 'returns no crumbs' do
+        expect(filter.crumbs).to be_empty
+      end
+    end
+
+    context 'filtering for one retention state' do
+      let(:search_query) { create :search_query, filter_retention_state: ['not_set'] }
+
+      it 'returns a single crumb' do
+        expect(filter.crumbs).to have(1).items
+      end
+
+      it 'has the state in the crumb text' do
+        expect(filter.crumbs[0].first).to eq('Not set')
+      end
+
+      describe 'params that will be submitted when clicking on the crumb' do
+        subject { filter.crumbs[0].second }
+
+        it { should eq('filter_retention_state' => [''], 'parent_id' => search_query.id) }
+      end
+    end
+
+    context 'filtering for more than one state' do
+      let(:search_query) { create :search_query, filter_retention_state: %w(not_set review) }
+
+      it 'uses "Not set + 1 more" text for the crumb text' do
+        expect(filter.crumbs[0].first).to eq('Not set + 1 more')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

This PR adds a new filter to the RRD pending -> Pending removal tab, to filter by retention state, showing as options `Not set`, `Retain` and `Review` as these are the only states that will be applicable in this tab.

In another PR I will develop the other filter defined in this ticket. Didn't want to add all to this PR as it is quite big already.

I also figured out how to fix the capitalisation of RRD in the menu/tabs. And fixed a few deprecation warnings for `errors.add` as I saw them when running the tests.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="782" alt="Screenshot 2022-05-27 at 12 11 04" src="https://user-images.githubusercontent.com/687910/170688913-6bdccf51-45cc-4143-a5a3-71cd1e890500.png">

----

<img width="779" alt="Screenshot 2022-05-27 at 12 11 51" src="https://user-images.githubusercontent.com/687910/170688919-cfb73b38-6406-4bb5-aaa3-6b0575805e81.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4132

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions

Have some cases with retention schedules falling in the next 4 months, and with different states (not_set, review, retain...), and you can use the filter and test the behaviour.
