### PR TITLE
Fix bug

### DIFF
--- a/app/services/retention_schedules/add_schedule_service.rb
+++ b/app/services/retention_schedules/add_schedule_service.rb
@@ -4,7 +4,6 @@ module RetentionSchedules
 
     def initialize(kase:)
       @kase = kase
-      @planned_destruction_date = planned_destruction_date
       @result = nil
     end
 
@@ -14,6 +13,7 @@ module RetentionSchedules
       ActiveRecord::Base.transaction do
         begin
           if @kase.offender_sar? || @kase.offender_sar_complaint?
+            @planned_destruction_date = planned_destruction_date
             add_retention_schedules
             @result = :success
           else
@@ -81,7 +81,7 @@ module RetentionSchedules
       end
     end
 
-    def planned_destruction_date
+    def planned_destruction_date 
       years = Settings.retention_timings.off_sars.erasure.years
       months = Settings.retention_timings.off_sars.erasure.months
       retention_period = years.years + months.months
@@ -90,7 +90,11 @@ module RetentionSchedules
     end
 
     def closure_date
-      @kase.last_transitioned_at.to_date 
+      if @kase.last_transitioned_at.nil?
+        @kase.transitions.most_recent.created_at.to_date
+      else
+        @kase.last_transitioned_at.to_date
+      end
     end
   end
 end

--- a/lib/tasks/retention_schedules.rake
+++ b/lib/tasks/retention_schedules.rake
@@ -39,7 +39,7 @@ namespace :retention_schedules do
       progressbar = ProgressBar.create
 
       
-      Case::SAR::Offender.where(current_state: :closed).find_each do | kase |
+      Case::SAR::Offender.where(current_state: :closed).includes(:transitions).find_each do | kase |
         if kase.retention_schedule.nil?
           percent_counter += 1
           begin 


### PR DESCRIPTION
## Description
There was an issue in calculating the planned destruction date as not all cases have a last_transitioned_at value.

This fixes that by accessing the latest transition for a case if there is no last_tansitioned_at value present.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
- Create some closed cases locally using FactoryBot:
```ruby
100.times { FactoryBot.create(:offender_sar_case, current_state: :closed, date_responded: Date.today) }
```
- these will not have RetentionSchedules by default
- Run the task:
```
rails rake:retention_schedules:add_rs_to_existing_branston_cases
```
- on the application you should see that these case now have "Planned Destruction Dates" visible on their show pages.
