### PR TITLE
CT-4132 Implement retention deadline filter

### DIFF
--- a/app/models/search_query.rb
+++ b/app/models/search_query.rb
@@ -62,7 +62,11 @@ class SearchQuery < ApplicationRecord
       CaseFilter::CaseComplaintPriorityFilter, 
       CaseFilter::CasePartialCaseFlagFilter],
     "retention_pending_removal" => [
-      CaseFilter::CaseRetentionStateFilter
+      CaseFilter::CaseRetentionDeadlineFilter,
+      CaseFilter::CaseRetentionStateFilter,
+    ],
+    "retention_ready_for_removal" => [
+      CaseFilter::CaseRetentionDeadlineFilter,
     ],
   }.freeze
 
@@ -91,7 +95,8 @@ class SearchQuery < ApplicationRecord
   GOV_UK_DATE_FIELDS = CaseFilter::ReceivedDateFilter.date_fields + 
                         CaseFilter::DateRespondedFilter.date_fields + 
                         CaseFilter::ExternalDeadlineFilter.date_fields +
-                        CaseFilter::InternalDeadlineFilter.date_fields
+                        CaseFilter::InternalDeadlineFilter.date_fields +
+                        CaseFilter::CaseRetentionDeadlineFilter.date_fields
 
   acts_as_gov_uk_date(*GOV_UK_DATE_FIELDS)
 

--- a/app/services/case_filter/case_retention_deadline_filter.rb
+++ b/app/services/case_filter/case_retention_deadline_filter.rb
@@ -1,0 +1,41 @@
+module CaseFilter
+  class CaseRetentionDeadlineFilter < CaseDateRangeFilterBase
+    def self.date_field_name
+      'planned_destruction_date'
+    end
+
+    def available_choices
+      {
+        today: {
+          name: 'Today', from: today, to: today,
+        },
+        one_month: {
+          name: '1 month', from: months_ago(1), to: today,
+        },
+        two_months: {
+          name: '2 months', from: months_ago(2), to: today,
+        },
+        three_months: {
+          name: '3 months', from: months_ago(3), to: today,
+        },
+        four_months: {
+          name: '4 months', from: months_ago(4), to: today,
+        },
+      }
+    end
+
+    private
+
+    def today
+      months_ago(0)
+    end
+
+    def months_ago(months)
+      {
+        day: months.months.ago.strftime("%d"),
+        month: months.months.ago.strftime("%m"),
+        year: months.months.ago.strftime("%Y")
+      }.to_json
+    end
+  end
+end

--- a/config/locales/filters.en.yml
+++ b/config/locales/filters.en.yml
@@ -21,6 +21,7 @@ en:
       internal_deadline: "Draft deadline %{from_date} - %{to_date}"
       received_date: "Received date %{from_date} - %{to_date}"
       date_responded: "Date responded %{from_date} - %{to_date}"
+      planned_destruction_date: "Destruction due %{from_date} - %{to_date}"
       filter_case_type:
         <<: *list_filter_type
       filter_open_case_status:
@@ -63,11 +64,13 @@ en:
       filter_high_profile: Filter by sensitivity
       filter_caseworker: Filter by complaint caseworker
       filter_retention_state: Filter by GDPR RRD status
+      filter_planned_destruction_date: Filter by GDPR destruction deadline
       date_headings:
         filter_received_date: 'Received between'
         filter_date_responded: 'Responded between'
         filter_external_deadline: 'Due'
         filter_internal_deadline: 'Due'
+        filter_planned_destruction_date: 'Due'
     filter_open_case_status:
       pending_dacu_clearance: 'Pending clearance - Disclosure'
       pending_press_office_clearance: 'Pending clearance - Press office'

--- a/spec/models/search_query_spec.rb
+++ b/spec/models/search_query_spec.rb
@@ -67,6 +67,8 @@ describe SearchQuery do
                                                  :external_deadline_to,
                                                  :internal_deadline_from,
                                                  :internal_deadline_to,
+                                                 :planned_destruction_date_from,
+                                                 :planned_destruction_date_to,
                                                  :filter_case_type,
                                                  :filter_open_case_status,
                                                  :filter_sensitivity,
@@ -120,6 +122,8 @@ describe SearchQuery do
           received_date_to:         nil,
           date_responded_from:      nil,
           date_responded_to:        nil,
+          planned_destruction_date_from: nil,
+          planned_destruction_date_to: nil,
         )
       }
       let(:query_params) {
@@ -187,6 +191,8 @@ describe SearchQuery do
           date_responded_from:      nil,
           date_responded_to:        nil,
           filter_status:            [],
+          planned_destruction_date_from: nil,
+          planned_destruction_date_to: nil,
         )
       }
       let(:query_params) {
@@ -224,6 +230,8 @@ describe SearchQuery do
                                                 :external_deadline_to,
                                                 :internal_deadline_from,
                                                 :internal_deadline_to,
+                                                :planned_destruction_date_from,
+                                                :planned_destruction_date_to,
                                                 :filter_case_type,
                                                 :filter_open_case_status,
                                                 :filter_sensitivity,
@@ -561,6 +569,11 @@ describe SearchQuery do
       search_query = create :search_query, filter_retention_state: ['review']
       expect(search_query.applied_filters).to eq [CaseFilter::CaseRetentionStateFilter]
     end
+
+    it 'includes retention deadline filter' do
+      search_query = create :search_query, planned_destruction_date_from: Date.today, planned_destruction_date_to: Date.today
+      expect(search_query.applied_filters).to eq [CaseFilter::CaseRetentionDeadlineFilter]
+    end
   end
 
   describe '#available_filters' do
@@ -655,7 +668,17 @@ describe SearchQuery do
         search_query = create :search_query
         expect(
           search_query.available_filters(user, 'retention_pending_removal'
-        ).map(&:class)).to eq [CaseFilter::CaseRetentionStateFilter]
+        ).map(&:class)).to eq [
+          CaseFilter::CaseRetentionDeadlineFilter,
+          CaseFilter::CaseRetentionStateFilter,
+        ]
+      end
+
+      it 'Ready for removal tab' do
+        search_query = create :search_query
+        expect(
+          search_query.available_filters(user, 'retention_ready_for_removal'
+        ).map(&:class)).to eq [CaseFilter::CaseRetentionDeadlineFilter]
       end
 
       it 'Search tab' do

--- a/spec/services/case_filter/case_retention_deadline_filter_spec.rb
+++ b/spec/services/case_filter/case_retention_deadline_filter_spec.rb
@@ -1,0 +1,122 @@
+require "rails_helper"
+
+describe CaseFilter::CaseRetentionDeadlineFilter do
+  before(:all) do
+    DbHousekeeping.clean
+      @offender_sar_retention_2018 = create(:offender_sar_complaint, :closed, :with_retention_schedule, planned_destruction_date: Time.new(2018, 5, 15))
+      @offender_sar_retention_2020 = create(:offender_sar_case, :closed, :with_retention_schedule, planned_destruction_date: Time.new(2020, 5, 15))
+  end
+
+  after(:all) do
+    DbHousekeeping.clean
+  end
+
+  let(:user) { find_or_create(:branston_user) }
+  let(:filter) { described_class.new search_query, user, Case::Base.joins(:retention_schedule) }
+
+  describe '#available_choices' do
+    let(:search_query) { create :search_query }
+
+    it 'contains the choices for the filter' do
+      available_choices = Timecop.freeze(Time.new(2018, 5, 15)) { filter.available_choices }
+
+      expect(
+        available_choices
+      ).to eq({
+        :today => {:name => "Today", :from => "{\"day\":\"15\",\"month\":\"05\",\"year\":\"2018\"}", :to => "{\"day\":\"15\",\"month\":\"05\",\"year\":\"2018\"}"},
+        :one_month => {:name => "1 month", :from => "{\"day\":\"15\",\"month\":\"04\",\"year\":\"2018\"}", :to => "{\"day\":\"15\",\"month\":\"05\",\"year\":\"2018\"}"},
+        :two_months => {:name => "2 months", :from => "{\"day\":\"15\",\"month\":\"03\",\"year\":\"2018\"}", :to => "{\"day\":\"15\",\"month\":\"05\",\"year\":\"2018\"}"},
+        :three_months => {:name => "3 months", :from => "{\"day\":\"15\",\"month\":\"02\",\"year\":\"2018\"}", :to => "{\"day\":\"15\",\"month\":\"05\",\"year\":\"2018\"}"},
+        :four_months => {:name => "4 months", :from => "{\"day\":\"15\",\"month\":\"01\",\"year\":\"2018\"}", :to => "{\"day\":\"15\",\"month\":\"05\",\"year\":\"2018\"}"}
+      })
+    end
+  end
+
+  describe '#applied?' do
+    subject { filter }
+
+    context 'no planned_destruction_date present' do
+      let(:search_query) { create :search_query }
+      it { should_not be_applied }
+    end
+
+    context 'both from and to planned_destruction_date present' do
+      let(:search_query) { create :search_query, planned_destruction_date_from: Date.today, planned_destruction_date_to: Date.today }
+      it { should be_applied }
+    end
+
+    context 'only planned_destruction_date_from present' do
+      let(:search_query) { create :search_query, planned_destruction_date_from: Date.today }
+      it { should_not be_applied }
+    end
+
+    context 'only planned_destruction_date_to present' do
+      let(:search_query) { create :search_query, planned_destruction_date_to: Date.today }
+      it { should_not be_applied }
+    end
+  end
+
+  describe '#call' do
+    context 'no cases with deadline in date range' do
+      let(:search_query) { create :search_query,
+                                  planned_destruction_date_from: Date.new(2017, 12, 4),
+                                  planned_destruction_date_to: Date.new(2018, 01, 15) }
+
+      it 'returns an empty collection' do
+        expect(filter.call).to eq([])
+      end
+    end
+
+    context 'there are cases within the deadline' do
+      let(:search_query) { create :search_query,
+                                  planned_destruction_date_from: Date.new(2018, 01, 01),
+                                  planned_destruction_date_to: Date.new(2021, 01, 01) }
+
+      it 'returns all the cases in the range' do
+        expect(filter.call).to eq([@offender_sar_retention_2018, @offender_sar_retention_2020])
+      end
+    end
+
+    context 'there are some cases within the deadline, not all' do
+      let(:search_query) { create :search_query,
+                                  planned_destruction_date_from: Date.new(2019, 01, 01),
+                                  planned_destruction_date_to: Date.new(2021, 01, 01) }
+
+      it 'returns only the cases in the range' do
+        expect(filter.call).to eq([@offender_sar_retention_2020])
+      end
+    end
+  end
+
+  describe '#crumbs' do
+    context 'filter not enabled' do
+      let(:search_query) { create :search_query, planned_destruction_date_from: nil, planned_destruction_date_to: nil }
+
+      it 'returns no crumbs' do
+        expect(filter.crumbs).to be_empty
+      end
+    end
+
+    context 'from and to date selected' do
+      let(:search_query)  { create :search_query,
+                                   planned_destruction_date_from: Date.new(2017, 12, 4),
+                                   planned_destruction_date_to: Date.new(2017, 12, 25) }
+
+      it 'returns a single crumb' do
+        expect(filter.crumbs).to have(1).items
+      end
+
+      it 'uses the from and to dates in the crumb text' do
+        expect(filter.crumbs[0].first).to eq 'Destruction due 4 Dec 2017 - 25 Dec 2017'
+      end
+
+      describe 'params that will be submitted when clicking on the crumb' do
+        subject { filter.crumbs[0].second }
+
+        it { should eq 'planned_destruction_date_from' => '',
+                       'planned_destruction_date_to' => '',
+                       'parent_id' => search_query.id }
+      end
+    end
+  end
+end

--- a/spec/services/case_search_service_spec.rb
+++ b/spec/services/case_search_service_spec.rb
@@ -236,6 +236,8 @@ describe CaseSearchService do
                                            filter_case_type: ['foi-standard'],
                                            external_deadline_from: external_deadline_from,
                                            external_deadline_to: external_deadline_to,
+                                           planned_destruction_date_from: nil,
+                                           planned_destruction_date_to:   nil,
                                            internal_deadline_from:       nil,
                                            internal_deadline_to:         nil,
                                            received_date_from:       nil,


### PR DESCRIPTION
## Description

This is a follow-up to PR #2005, to add a new filter to the RRD pending -> Pending removal and Ready for removal tabs, to filter by `planned_destruction_date`.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="768" alt="Screenshot 2022-05-31 at 11 44 11" src="https://user-images.githubusercontent.com/687910/171156117-cba9e619-aceb-4b3b-8e55-4c3f185efd27.png">

----

<img width="1025" alt="Screenshot 2022-05-31 at 11 44 24" src="https://user-images.githubusercontent.com/687910/171156125-62cd9720-6018-4654-b3bf-cda0f2d4a8fa.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4132

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Have some cases with retention schedules with different deadlines, and you can use the date filter and test the behaviour.
