### PR TITLE
Fix bullet warning about including linked_cases in query

### DIFF
--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -79,11 +79,11 @@ class Case::Base < ApplicationRecord
                       validate_if: :received_in_acceptable_range?
 
   scope :by_deadline, -> {
-    select("\"cases\".*, (properties ->> 'external_deadline')::timestamp with time zone, cases.id")
-      .order(Arel.sql("(properties ->> 'external_deadline')::timestamp with time zone ASC, cases.id"))
+    select("\"cases\".*, (cases.properties ->> 'external_deadline')::timestamp with time zone, cases.id")
+      .order(Arel.sql("(cases.properties ->> 'external_deadline')::timestamp with time zone ASC, cases.id"))
   }
   scope :by_last_transitioned_date, -> { reorder(last_transitioned_at: :desc) }
-  scope :most_recent_first, -> {reorder(Arel.sql("(properties ->> 'external_deadline')::timestamp with time zone DESC, cases.id")) }
+  scope :most_recent_first, -> {reorder(Arel.sql("(cases.properties ->> 'external_deadline')::timestamp with time zone DESC, cases.id")) }
 
   scope :opened, ->       { where.not(current_state: 'closed') }
   scope :not_icos, -> { where.not(type: ['Case::ICO::FOI', 'Case::ICO::SAR'] ) }

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -46,7 +46,7 @@ class CaseFinderService
 
   def retention_cases_scope
     get_root_scope('default')
-      .includes(:retention_schedule)
+      .includes([:retention_schedule, :case_links, :linked_cases])
       .where(retention_schedule: {
         planned_destruction_date: RetentionSchedule.common_date_viewable_from_range
       })

--- a/app/views/cases/filters/retention.html.slim
+++ b/app/views/cases/filters/retention.html.slim
@@ -91,7 +91,7 @@ section#retention-cases.govuk-tabs__panel
                       td 
                         = kase.retention_schedule.planned_destruction_date 
                       td 
-                        = "TODO" 
+                        = kase.linked_cases.present?.humanize
                       td 
                         = kase.retention_schedule.human_state
 

--- a/spec/controllers/cases/filters_controller/open_spec.rb
+++ b/spec/controllers/cases/filters_controller/open_spec.rb
@@ -92,7 +92,7 @@ describe Cases::FiltersController, type: :controller do
       it 'assigns the result set from the CaseFinderService' do
         get :open
         expect(assigns(:cases).object.to_sql)
-          .to include("ORDER BY (properties ->> 'external_deadline')")
+          .to include("ORDER BY (cases.properties ->> 'external_deadline')")
         expect(assigns(:cases).current_page).to eq 1
         expect(assigns(:cases)).to be_decorated
       end

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -84,6 +84,9 @@ feature 'Case retention schedules for GDPR', :js do
 
     expect(page).to have_content 'RRD Pending'
 
+    # simple check to see Linked Case column has data
+    expect(page).to have_content 'No'
+
     cases_page.homepage_navigation.case_retention.click
     
     expect(page).to have_content 'Pending removal'

--- a/spec/models/query/case_report_spec.rb
+++ b/spec/models/query/case_report_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Query::CaseReport do
 
   let(:default_retrieval_scope) { Case::Base.all }
   let(:external_deadline_retrieval_scope) { 
-    Case::Base.all.select(:id).order(Arel.sql("(properties ->> 'external_deadline')::timestamp with time zone")) 
+    Case::Base.all.select(:id).order(Arel.sql("(cases.properties ->> 'external_deadline')::timestamp with time zone")) 
   }
 
   describe '#initialize' do


### PR DESCRIPTION
## Description
Fixes issue where bullet was reporting an N+1 query, but includes with linked cases was still failing as 
the Arel the query was using was not specific on which record the 'queries' column belonged to.


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="500" alt="Screenshot 2022-05-31 at 17 00 13" src="https://user-images.githubusercontent.com/13377553/171218016-e2d25bc7-7d9a-430c-8c7f-12430917f1cf.png">

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->



### Manual testing instructions
- on the show page you should see either 'Yes' or 'No' if a case has linked cases or not.
