### PR TITLE
CT-2206 Enable Style/MutableConstant rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -407,6 +407,11 @@ Style/AsciiComments:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-comments'
   Enabled: true
 
+Style/MutableConstant:
+  Description: 'Ensure all constants are frozen. Use .freeze'
+  EnforcedStyle: 'literals'
+  Enabled: true
+
 Naming/AsciiIdentifiers:
   Description: 'Use only ascii symbols in identifiers.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#english-identifiers'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,8 @@ class ApplicationController < ActionController::Base
 
   include Pundit::Authorization
 
-  GLOBAL_NAV_EXCLUSION_PATHS    = %w{ /cases/filter }
-  CSV_REQUEST_REGEX             = /\.csv$/
+  GLOBAL_NAV_EXCLUSION_PATHS    = %w{ /cases/filter }.freeze
+  CSV_REQUEST_REGEX             = /\.csv$/.freeze
 
   before_action do
     unless self.class.to_s =~ /^Devise::/

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -127,19 +127,19 @@ class StatsController < ApplicationController
   end
 
   # The plan here is/was to colour the spreadsheet titles just like the existing reports from ITG
-  LIGHT_BLUE = 'c1d1f0'
-  LIGHT_GREY = 'd1d1e0'
+  LIGHT_BLUE = 'c1d1f0'.freeze
+  LIGHT_GREY = 'd1d1e0'.freeze
 
-  BRIGHT_RED = 'FF0000'
-  BRIGHT_YELLOW = 'FFFF00'
-  BRIGHT_LIME_GREEN = '00FF00'
+  BRIGHT_RED = 'FF0000'.freeze
+  BRIGHT_YELLOW = 'FFFF00'.freeze
+  BRIGHT_LIME_GREEN = '00FF00'.freeze
 
   # mapping of RAG ratings to spreadsheet cell colours
   RAG_RATING_COLOURS = { red: BRIGHT_RED,
                          amber: BRIGHT_YELLOW,
                          green: BRIGHT_LIME_GREEN,
                          grey: LIGHT_GREY,
-                         blue: LIGHT_BLUE }
+                         blue: LIGHT_BLUE }.freeze
 
   # Assumes no report spans more than 26 columns
   SPREADSHEET_COLUMN_NAMES = ('A'..'Z').to_a

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -4,9 +4,9 @@ module SearchHelper
     :search_result_order_by_oldest_first => { "order" => "cases.id ASC"},
     :search_result_order_by_newest_first => {"order" => "cases.received_date DESC, cases.id DESC"},
     :search => {"order" => nil}
-  }
+  }.freeze
 
-  DEFAULT_SEARCH_RESULT_ORDER_FLAG = "search_result_order_by_oldest_first"
+  DEFAULT_SEARCH_RESULT_ORDER_FLAG = "search_result_order_by_oldest_first".freeze
 
   def self.get_order_option(search_order_choice)
     if SEARCH_SCOPE_SET[search_order_choice.to_sym].present?

--- a/app/models/case/sar/internal_review.rb
+++ b/app/models/case/sar/internal_review.rb
@@ -26,7 +26,7 @@ class Case::SAR::InternalReview < Case::SAR::Standard
     subject: 'Case summary',
     message: 'Full case details',
     original_case: 'The original case'
-  }
+  }.freeze
 
   before_save do
     self.workflow = 'trigger'

--- a/app/models/case_attachment.rb
+++ b/app/models/case_attachment.rb
@@ -16,7 +16,7 @@
 
 class CaseAttachment < ApplicationRecord
 
-  UNCONVERTIBLE_EXTENSIONS = %w( .pdf .jpg .jpeg .bmp .gif .png )
+  UNCONVERTIBLE_EXTENSIONS = %w( .pdf .jpg .jpeg .bmp .gif .png ).freeze
 
   self.inheritance_column = :_type_not_used
   belongs_to :case,

--- a/app/models/case_transition.rb
+++ b/app/models/case_transition.rb
@@ -21,7 +21,7 @@
 class CaseTransition < ApplicationRecord
   include Warehousable
 
-  ASSIGN_RESPONDER_EVENT = 'assign_responder'
+  ASSIGN_RESPONDER_EVENT = 'assign_responder'.freeze
 
   belongs_to :case,
              inverse_of: :transitions,
@@ -29,12 +29,12 @@ class CaseTransition < ApplicationRecord
              foreign_key: :case_id
 
   # This list should be bigger, but don't have time or inclination to move all event names here (yet)
-  EXTEND_FOR_PIT_EVENT = 'extend_for_pit'
-  REMOVE_PIT_EXTENSION_EVENT = 'remove_pit_extension'
-  EXTEND_SAR_DEADLINE_EVENT = 'extend_sar_deadline'
-  REMOVE_SAR_EXTENSION_EVENT = 'remove_sar_deadline_extension'
-  ADD_MESSAGE_TO_CASE_EVENT = 'add_message_to_case'
-  ADD_NOTE_TO_CASE_EVENT = 'add_note_to_case'
+  EXTEND_FOR_PIT_EVENT = 'extend_for_pit'.freeze
+  REMOVE_PIT_EXTENSION_EVENT = 'remove_pit_extension'.freeze
+  EXTEND_SAR_DEADLINE_EVENT = 'extend_sar_deadline'.freeze
+  REMOVE_SAR_EXTENSION_EVENT = 'remove_sar_deadline_extension'.freeze
+  ADD_MESSAGE_TO_CASE_EVENT = 'add_message_to_case'.freeze
+  ADD_NOTE_TO_CASE_EVENT = 'add_note_to_case'.freeze
 
   after_destroy :update_most_recent, if: :most_recent?
 

--- a/app/models/report_type.rb
+++ b/app/models/report_type.rb
@@ -21,7 +21,7 @@ class ReportType < ApplicationRecord
                                         quarter_to_date
                                         last_quarter
                                         last_month
-                                      }
+                                      }.freeze
 
   has_many :reports
 

--- a/app/models/search_query.rb
+++ b/app/models/search_query.rb
@@ -85,11 +85,11 @@ class SearchQuery < ApplicationRecord
   },  _suffix: true
 
   # Add all those properties withn query jsonb fields
-  TYPED_FILTER_FIELDS = {search_text: [:string, default: nil], list_path: [:string, default: nil]}
+  @@typed_filter_fields = {search_text: [:string, default: nil], list_path: [:string, default: nil]}
   FILTER_CLASSES_MAP.to_hash.values.flatten.uniq.each do | filter_class |
-    filter_class.filter_fields(TYPED_FILTER_FIELDS)
+    filter_class.filter_fields(@@typed_filter_fields)
   end
-  jsonb_accessor(:query, **TYPED_FILTER_FIELDS)
+  jsonb_accessor(:query, **@@typed_filter_fields)
 
   # Define the list of date fields
   GOV_UK_DATE_FIELDS = CaseFilter::ReceivedDateFilter.date_fields + 

--- a/app/models/team_property.rb
+++ b/app/models/team_property.rb
@@ -18,8 +18,8 @@ class TeamProperty < ApplicationRecord
     lead
     can_allocate
     role
-  )
-  ROLES = %w[manager responder approver]
+  ).freeze
+  ROLES = %w[manager responder approver].freeze
 
   belongs_to :team
 

--- a/app/models/warehouse/case_report.rb
+++ b/app/models/warehouse/case_report.rb
@@ -11,7 +11,7 @@ module Warehouse
       "Case::SAR::OffenderComplaint" => ['process_offender_sar', 'process_offender_sar_complaint'], 
       "Case::ICO::FOI" => ['process_ico'],
       "Case::ICO::SAR" => ['process_ico']    
-    }
+    }.freeze
 
     # Class methods to allow this class to be used in async jobs
     class << self

--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -54,7 +54,7 @@ class Case::BasePolicy < ApplicationPolicy
         Case::ICO::SAR,
         Case::OverturnedICO::SAR,
         Case::OverturnedICO::FOI,
-    ]
+    ].freeze
 
     def initialize(user, scope, feature = nil)
       @user  = user

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -49,7 +49,7 @@ class CSVExporter
     'Original internal deadline',
     'Original external deadline',
     'Number of days late against original deadline'
-  ]
+  ].freeze
 
   CSV_COLUMN_FIELDS = [
     'number',
@@ -97,7 +97,7 @@ class CSVExporter
     'original_internal_deadline', 
     'original_external_deadline',
     'num_days_late_against_original_deadline'
-  ]
+  ].freeze
 
   def initialize(kase)
     @kase = kase

--- a/app/services/global_nav_manager/page.rb
+++ b/app/services/global_nav_manager/page.rb
@@ -2,7 +2,7 @@ class GlobalNavManager
   class Page
     attr_reader :name, :path, :tabs
 
-    IGNORE_QUERY_PARAMS = ['page']
+    IGNORE_QUERY_PARAMS = ['page'].freeze
 
     # 'parent' here is actually a GlobalNavManager instance
     def initialize(name:, parent:, attrs:)

--- a/app/services/retention_schedules/anonymise_case_service.rb
+++ b/app/services/retention_schedules/anonymise_case_service.rb
@@ -54,11 +54,11 @@ module RetentionSchedules
       ico_contact_name: 'XXXX XXXX',
       ico_contact_phone: 'XXXX XXXX',
       ico_reference: 'XXXX XXXX',
-    }
+    }.freeze
 
-    ANON_NOTE_MESSAGE_VALUE = 'Note details have been anonymised'
+    ANON_NOTE_MESSAGE_VALUE = 'Note details have been anonymised'.freeze
 
-    ANON_DATA_REQUEST_NOTE_VALUE = 'Information has been anonymised'
+    ANON_DATA_REQUEST_NOTE_VALUE = 'Information has been anonymised'.freeze
 
     def initialize(kase:)
       # whole case and links will need to be loaded

--- a/app/services/retention_schedules_update_service.rb
+++ b/app/services/retention_schedules_update_service.rb
@@ -16,7 +16,7 @@ class RetentionSchedulesUpdateService
     retain: "marked for retention",
     mark_for_destruction: "marked for destruction",
     destroy_cases: "destroyed"
-  }
+  }.freeze
 
   def initialize(retention_schedules_params:, event_text:, current_user:)
     @event_text = event_text

--- a/app/services/stats/audit.rb
+++ b/app/services/stats/audit.rb
@@ -17,7 +17,7 @@ module Stats
       info_held
       granted
       exemptions
-    }
+    }.freeze
 
     attr_reader :filename
 

--- a/app/services/stats/base_appeals_performance_report.rb
+++ b/app/services/stats/base_appeals_performance_report.rb
@@ -6,14 +6,14 @@ module Stats
         directorate:                     'Directorate',
         business_unit:                   'Business unit',
         responsible:                     'Responsible'
-    }
+    }.freeze
 
     R002_SPECIFIC_SUPERHEADINGS = {
         business_group:                  '',
         directorate:                     '',
         business_unit:                   '',
         responsible:                     ''
-    }
+    }.freeze
 
     class << self
       def report_format
@@ -37,7 +37,7 @@ module Stats
       @stats.finalise
     end
 
-    INDEXES_FOR_PERCENTAGE_COLUMNS = [4, 10]
+    INDEXES_FOR_PERCENTAGE_COLUMNS = [4, 10].freeze
 
     def to_csv
       csv = @stats.to_csv(row_names_as_first_column: false, superheadings: superheadings)

--- a/app/services/stats/base_business_unit_performance_report.rb
+++ b/app/services/stats/base_business_unit_performance_report.rb
@@ -10,7 +10,7 @@ module Stats
       responsible:                     'Responsible',
       deactivated:                     'Deactivated',
       moved:                           'Moved to',
-    }
+    }.freeze
 
     R003_BU_PERFORMANCE_COLUMNS = {
       bu_performance:             'Performance %',
@@ -19,7 +19,7 @@ module Stats
       bu_responded_late:          'Responded - late',
       bu_open_in_time:            'Open - in time',
       bu_open_late:               'Open - late',
-    }
+    }.freeze
 
     R003_SPECIFIC_SUPERHEADINGS = {
       business_group:                  '',
@@ -30,7 +30,7 @@ module Stats
       responsible:                     '',
       deactivated:                     '',
       moved:                           '',
-    }
+    }.freeze
 
     R003_BU_PERFORMANCE_SUPERHEADINGS = {
       bu_performance:             'Business unit',
@@ -39,7 +39,7 @@ module Stats
       bu_responded_late:          'Business unit',
       bu_open_in_time:            'Business unit',
       bu_open_late:               'Business unit',
-    }
+    }.freeze
 
     class << self
       def report_format
@@ -91,7 +91,7 @@ module Stats
       @stats.finalise
     end
 
-    INDEXES_FOR_PERCENTAGE_COLUMNS = [8, 14, 20]
+    INDEXES_FOR_PERCENTAGE_COLUMNS = [8, 14, 20].freeze
 
     # This method needs to return a grid of 'cells' with value and rag_rating properties
     def to_csv

--- a/app/services/stats/base_report.rb
+++ b/app/services/stats/base_report.rb
@@ -3,8 +3,8 @@ module Stats
 
     # These are the current RAG (red-amber-green) thresholds for each report type
     # obviously anything above the 'amber' threshold is 'green'
-    RAG_THRESHOLDS_FOI = { red: 85, amber: 90 }
-    RAG_THRESHOLDS_SAR = { red: 80, amber: 85 }
+    RAG_THRESHOLDS_FOI = { red: 85, amber: 90 }.freeze
+    RAG_THRESHOLDS_SAR = { red: 80, amber: 85 }.freeze
 
     # Status names for ETL generated reports
     COMPLETE = 'complete'.freeze

--- a/app/services/stats/etl/offender_sar_closed_cases.rb
+++ b/app/services/stats/etl/offender_sar_closed_cases.rb
@@ -19,7 +19,7 @@ module Stats
         'Pages for dispatch',
         'Exempt pages',
         'Final page count'
-      ]
+      ].freeze
 
       FIELD_COLUMNS = [
         'number', 
@@ -34,7 +34,7 @@ module Stats
         'number_of_final_pages::integer - number_of_exempt_pages::integer', 
         'number_of_exempt_pages', 
         'number_of_final_pages'
-      ]
+      ].freeze
 
       def result_name
         RESULT_NAME

--- a/app/services/stats/etl/offender_sar_complaint_closed_cases.rb
+++ b/app/services/stats/etl/offender_sar_complaint_closed_cases.rb
@@ -26,7 +26,7 @@ module Stats
         'Outcome of litigation complaint', 
         'Cost paid', 
         'Settlement paid'
-      ]
+      ].freeze
 
       FIELD_COLUMNS = [
         'number',
@@ -48,7 +48,7 @@ module Stats
         'outcome', 
         'total_cost', 
         'settlement_cost'
-      ]
+      ].freeze
 
       def result_name
         RESULT_NAME

--- a/app/services/stats/r004_cabinet_office_report.rb
+++ b/app/services/stats/r004_cabinet_office_report.rb
@@ -5,7 +5,7 @@ module Stats
     COLUMNS = {
       desc:   "Description",
       value:  "Value"
-    }
+    }.freeze
 
     # The Cabinet Office report is one of the few to remain purely
     # in CSV format

--- a/app/services/stats/r006_kilo_map.rb
+++ b/app/services/stats/r006_kilo_map.rb
@@ -12,7 +12,7 @@ module Stats
         'Group email',
         'Team member name',
         'Team member email'
-    ]
+    ].freeze
 
     def self.description
       'Includes a list of all teams and users that respond to requests for information'

--- a/app/services/stats/r900_audit_report.rb
+++ b/app/services/stats/r900_audit_report.rb
@@ -26,7 +26,7 @@ module Stats
       refusal_reason
       appeal_outcome
       deleted
-    }
+    }.freeze
 
     # Note: Does not run parent constructor
     def initialize(**)

--- a/app/services/stats/r901_offender_sar_cases_report.rb
+++ b/app/services/stats/r901_offender_sar_cases_report.rb
@@ -20,7 +20,7 @@ module Stats
         'Case status',
         'Days open',
         'Data requests completed?'
-    ]
+    ].freeze
 
     def self.title
       'Cases report for Offender SAR and Complaint'

--- a/app/validators/closed_case_validator.rb
+++ b/app/validators/closed_case_validator.rb
@@ -26,7 +26,7 @@ class ClosedCaseValidator < ActiveModel::Validator
                              :validate_late_team_id ],
     'OFFENDER_SAR' =>       [:validate_date_responded],
     'OFFENDER_SAR_COMPLAINT' =>   [:validate_date_responded],
-  }
+  }.freeze
   # Validations applicable to cases that are being processed for closure.
   #
   # e.g. missing_info is a virtual attribute which is only used when submitting
@@ -42,7 +42,7 @@ class ClosedCaseValidator < ActiveModel::Validator
     'OVERTURNED_FOI'=>      [],
     'OFFENDER_SAR'  =>      [],
     'OFFENDER_SAR_COMPLAINT'  =>    [],
-  }
+  }.freeze
 
   class << self
     # Predicates to check what closure information is necessary for a case.

--- a/db/archived_migrations/20190609165906_warehouse_case_report.rb
+++ b/db/archived_migrations/20190609165906_warehouse_case_report.rb
@@ -45,7 +45,7 @@ class WarehouseCaseReport < ActiveRecord::Migration[5.0]
     'Draft in time' => :string,
     'In target' => :string,
     'Number of days late' => :integer,
-  }
+  }.freeze
 
   def up
     create_table :warehouse_case_reports, id: false do |t|

--- a/db/seeders/case_attachment_upload_group_seeder.rb
+++ b/db/seeders/case_attachment_upload_group_seeder.rb
@@ -4,7 +4,7 @@ class CaseAttachmentUploadGroupSeeder
     add_responses
     add_response_to_flagged_case
     upload_response_and_approve
-  )
+  ).freeze
 
   def initialize
     @transitions = CaseTransition.where(event: RESPONSE_EVENTS)

--- a/db/seeders/report_type_seeder.rb
+++ b/db/seeders/report_type_seeder.rb
@@ -107,7 +107,7 @@ class ReportTypeSeeder
                          default_reporting_period: 'year_to_date',
                          offender_sar_complaint: true,
                          etl: false},
-  ]
+  ].freeze
 
   def seed!(verbose: false)
     puts '----Seeding ReportTypes----' if verbose

--- a/lib/cts/cases/constants.rb
+++ b/lib/cts/cases/constants.rb
@@ -5,13 +5,13 @@ module CTS
       ICO_CASE_TYPES = %w{
           Case::ICO::FOI
           Case::ICO::SAR
-      }
+      }.freeze
 
       FOI_CASE_TYPES = %w{
           Case::FOI::Standard
           Case::FOI::ComplianceReview
           Case::FOI::TimelinessReview
-      }
+      }.freeze
 
       CASE_JOURNEYS = {
         foi:{
@@ -75,7 +75,7 @@ module CTS
             :closed,
           ]
         },
-      }
+      }.freeze
 
     end
   end

--- a/lib/db/database_dumper.rb
+++ b/lib/db/database_dumper.rb
@@ -10,8 +10,8 @@ class DatabaseDumper
   attr_reader :outcome_files, :bucket_key_id, :bucket_access_key, :bucket
 
   MAX_NUM_OF_RECORDS_PER_GROUP = 10000
-  TABLES_TO_BE_EXCLUDED = ["reports", "search_queries", "sessions", "versions"]
-  CLASSES_TO_ANONYMISE = [Team, TeamProperty, ::Warehouse::CaseReport, Case::Base, User, CaseTransition, CaseAttachment, Contact]
+  TABLES_TO_BE_EXCLUDED = ["reports", "search_queries", "sessions", "versions"].freeze
+  CLASSES_TO_ANONYMISE = [Team, TeamProperty, ::Warehouse::CaseReport, Case::Base, User, CaseTransition, CaseAttachment, Contact].freeze
 
 
   def initialize(tag, running_mode = 'tasks', is_store_to_s3_bucket = true, s3_bucket_setting = nil)

--- a/lib/db/users_settings_for_anonymizer.rb
+++ b/lib/db/users_settings_for_anonymizer.rb
@@ -16,7 +16,7 @@ require 'json'
 
 class UsersSettingsForAnonymizer
 
-  USER_SETTINGS_JSON_S3_PATH = "dumps/user_settings.json"
+  USER_SETTINGS_JSON_S3_PATH = "dumps/user_settings.json".freeze
 
   def initialize()
     @user_settings = []

--- a/spec/services/csv_generator_spec.rb
+++ b/spec/services/csv_generator_spec.rb
@@ -7,7 +7,7 @@ describe 'CSVGenerator' do
 
     CSV_COLUMN_HEADINGS = [
       'test column'
-    ]
+    ].freeze
 
     def initialize(**options)
     end


### PR DESCRIPTION
## Description

This was an old ticket, so we either do it or remove the ticket and forget about it.
I think it is not a bad idea to do it. There are a lot of modified files but the changes are very specific.

This includes converting a mutating constant `TYPED_FILTER_FIELDS` into a class variable which is ugly but better at least keeps the functionality intact as the constant could not be frozen after applying this rubocop rule.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
