### PR TITLE
Ct 4102 implement anon orchestration logic

### DIFF
--- a/app/services/retention_schedules/anonymise_case_service.rb
+++ b/app/services/retention_schedules/anonymise_case_service.rb
@@ -1,7 +1,7 @@
 module RetentionSchedules
   class CaseNotClosedError < StandardError
     def message
-      "Case cannoted be destroyed as it is still open"
+      "Case cannot be destroyed as it is still open"
     end
   end
 

--- a/spec/features/cases/retention_schedules/anonymisation_spec.rb
+++ b/spec/features/cases/retention_schedules/anonymisation_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+feature 'Case retention schedules for GDPR', :js do
+  given(:branston_user)         { find_or_create :branston_user }
+  given(:branston_team)   { create :managing_team, managers: [branston_user] }
+
+  given(:non_branston_user)         { find_or_create :disclosure_bmt_user }
+  given(:non_branston_team)   { create :managing_team, managers: [non_branston_user] }
+
+  # erasable
+  let!(:erasable_timely_kase) {
+    case_with_retention_schedule(
+      case_type: :offender_sar_case, 
+      state: 'to_be_anonymised',
+      date: Date.today - 4.months
+    ) 
+  }
+
+  let!(:erasable_timely_kase_two) {
+    case_with_retention_schedule(
+      case_type: :offender_sar_case, 
+      state: 'to_be_anonymised',
+      date: Date.today - (4.months - 7.days)
+    ) 
+  }
+
+  let!(:erasable_untimely_kase) { 
+    case_with_retention_schedule(
+      case_type: :offender_sar_case, 
+      state: 'to_be_anonymised',
+      date: Date.today - (5.months)
+    ) 
+  }
+
+  scenario 'branston users can see the GDPR tab with correct cases' do
+    login_as branston_user
+    
+    cases_page.load
+
+    expect(page).to have_content 'RRD Pending'
+
+    cases_page.homepage_navigation.case_retention.click
+    
+    click_on 'Ready for removal'
+
+    expect(page).to have_content erasable_timely_kase.number
+    expect(page).to have_content erasable_timely_kase_two.number
+
+    Capybara.find(:css, "#retention-checkbox-#{erasable_timely_kase.id}", visible: false).set(true)
+    Capybara.find(:css, "#retention-checkbox-#{erasable_timely_kase_two.id}", visible: false).set(true)
+
+    click_on "Destroy cases"
+
+    expect(page).to have_content '2 cases have been destroyed'
+
+    expect(page).to_not have_content erasable_timely_kase.number
+    expect(page).to_not have_content erasable_timely_kase_two.number
+
+    cases_show_page.load(id: erasable_timely_kase.id)
+
+    expect(page).to have_content erasable_timely_kase.number
+    expect(page).to have_content 'XXXX XXXX'
+    expect(page).to have_content 'Information has been anonymised'
+    
+    cases_show_page.load(id: erasable_timely_kase.id)
+
+    expect(page).to have_content erasable_timely_kase_two.number
+    expect(page).to have_content 'XXXX XXXX'
+    expect(page).to have_content 'Information has been anonymised'
+
+    erasable_timely_kase.reload
+    erasable_timely_kase_two.reload
+
+    expect(erasable_timely_kase.retention_schedule.aasm.current_state).to eq(:anonymised)
+    expect(erasable_timely_kase_two.retention_schedule.aasm.current_state).to eq(:anonymised)
+  end
+
+  def case_with_retention_schedule(case_type:, state:, date:)
+    kase = create(
+      case_type, 
+      retention_schedule: 
+        RetentionSchedule.new( 
+         state: state, 
+         planned_destruction_date: date 
+      ) 
+    )
+    kase.save
+    kase
+  end
+end

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -13,7 +13,8 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:not_set_timely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'not_set',
+      case_state: :closed,
+      rs_state: 'not_set',
       date: Date.today - 4.months
     ) 
   }
@@ -22,7 +23,8 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:reviewable_timely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'review',
+      case_state: :closed,
+      rs_state: 'review',
       date: Date.today - (4.months - 7.days)
     ) 
   }
@@ -30,7 +32,8 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:reviewable_untimely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'review',
+      case_state: :closed,
+      rs_state: 'review',
       date: Date.today - (5.months)
     ) 
   }
@@ -39,7 +42,8 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:retain_timely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'retain',
+      case_state: :closed,
+      rs_state: 'retain',
       date: Date.today - (4.months - 7.days)
     ) 
   }
@@ -47,7 +51,8 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:retain_untimely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'retain',
+      case_state: :closed,
+      rs_state: 'retain',
       date: Date.today - (5.months)
     ) 
   }
@@ -56,7 +61,8 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:erasable_timely_kase) {
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'to_be_anonymised',
+      case_state: :closed,
+      rs_state: 'to_be_anonymised',
       date: Date.today - 4.months
     ) 
   }
@@ -64,7 +70,8 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:erasable_timely_kase_two) {
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'to_be_anonymised',
+      case_state: :closed,
+      rs_state: 'to_be_anonymised',
       date: Date.today - (4.months - 7.days)
     ) 
   }
@@ -72,7 +79,8 @@ feature 'Case retention schedules for GDPR', :js do
   let!(:erasable_untimely_kase) { 
     case_with_retention_schedule(
       case_type: :offender_sar_case, 
-      state: 'to_be_anonymised',
+      case_state: :closed,
+      rs_state: 'to_be_anonymised',
       date: Date.today - (5.months)
     ) 
   }
@@ -84,10 +92,10 @@ feature 'Case retention schedules for GDPR', :js do
 
     expect(page).to have_content 'RRD Pending'
 
+    cases_page.homepage_navigation.case_retention.click
+    #
     # simple check to see Linked Case column has data
     expect(page).to have_content 'No'
-
-    cases_page.homepage_navigation.case_retention.click
     
     expect(page).to have_content 'Pending removal'
     expect(page).to have_content 'Ready for removal'
@@ -180,15 +188,18 @@ feature 'Case retention schedules for GDPR', :js do
     before < after
   end
 
-  def case_with_retention_schedule(case_type:, state:, date:)
-    kase = create(
-      case_type, 
-      retention_schedule: 
-        RetentionSchedule.new( 
-         state: state, 
-         planned_destruction_date: date 
-      ) 
-    )
+  def case_with_retention_schedule(case_type:, case_state:, rs_state:, date:)
+      kase = create(
+        case_type, 
+        current_state: case_state,
+        date_responded: Date.today,
+        retention_schedule: 
+          RetentionSchedule.new( 
+           state: rs_state,
+           planned_destruction_date: date 
+        ) 
+      )
+
     kase.save
     kase
   end


### PR DESCRIPTION
## Description
Amends the `RetentionScheduleUpdateService` so that it calls the retention schedules `AnonymiseCaseService` to allow the user to anonymise multiple cases.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
UI is essentially the same, should see a message "x cases have been destroyed" once case has been anonymised 

### Related JIRA tickets
[CT-4102](https://dsdmoj.atlassian.net/browse/CT-4102)

### Manual testing instructions
- go to the RRD page
- Click Ready for removal tab
- Select cases for anonymisation
- Click Destroy cases
- You should see a success message
- Those cases should no longer be visible
- If you then go to the show page for those cases (search case number in closed case tab) You should see that the details of the case have been anonymised.
