### PR TITLE
Allow users to order by cases planned destruction dates

### DIFF
--- a/app/controllers/cases/filters_controller.rb
+++ b/app/controllers/cases/filters_controller.rb
@@ -8,8 +8,8 @@ module Cases
     before_action :set_url, only: [:open, :closed, :my_open, :retention]
     before_action :set_state_selector, only: [:open, :my_open]
     before_action :set_retention_schedule_order_flag, only: [:retention]
-    before_action :set_cookie_order_flag_from_param, only: [:open, :my_open]
-    before_action :reset_default_order_from_retention_schedule_order_flag, only: [:open, :my_open]
+    before_action :set_cookie_order_flag, only: [:open, :my_open]
+    after_action :reset_default_order_from_retention_schedule_order_flag, only: [:retention]
     before_action :set_non_current_tab_counts, only: [:my_open]
 
     def show
@@ -183,7 +183,7 @@ module Cases
       service
     end
 
-    def set_cookie_order_flag_from_param
+    def set_cookie_order_flag
       if params["order"].present?
         set_order_cookie(params["order"]) 
       end

--- a/app/controllers/cases/filters_controller.rb
+++ b/app/controllers/cases/filters_controller.rb
@@ -3,6 +3,7 @@ module Cases
     include SetupCase
     include SearchParams
     include AvailableCaseReports
+    include RetentionSchedulePageOrdering
 
     before_action :set_url, only: [:open, :closed, :my_open, :retention]
     before_action :set_state_selector, only: [:open, :my_open]
@@ -193,43 +194,6 @@ module Cases
         :value => order,
         :secure => true 
       }
-    end
-
-    def set_initial_retention_shedule_order_flag
-      if cookies[:search_result_order] == nil
-        set_order_cookie(
-          SearchHelper::RETENTION_SCHEDULE_DEFAULT_SEARCH_RESULT_ORDER_FLAG
-        )
-      end
-    end
-
-    def set_retention_schedule_order_flag
-      set_initial_retention_shedule_order_flag
-      if order_flag_is_not_applicable_to_retention_schedules
-        set_order_cookie(
-          SearchHelper::RETENTION_SCHEDULE_DEFAULT_SEARCH_RESULT_ORDER_FLAG
-        )
-      else
-        set_cookie_order_flag_from_param
-      end
-    end
-
-    def reset_default_order_from_retention_schedule_order_flag
-      if order_flag_is_not_applicable_to_retention_schedules
-        set_cookie_order_flag_from_param
-      else
-        set_order_cookie(
-          SearchHelper::DEFAULT_SEARCH_RESULT_ORDER_FLAG
-        )
-      end
-    end
-
-    def order_flag_is_not_applicable_to_retention_schedules
-      # 'destruction_date' is the common part of the SEARCH_SCOPE_SET
-      # for the RetentionSchedule page. See the SearchHelper module
-      if cookies[:search_result_order]
-        cookies[:search_result_order].exclude?('destruction_date')
-      end
     end
 
     def set_state_selector

--- a/app/controllers/concerns/retention_schedule_page_ordering.rb
+++ b/app/controllers/concerns/retention_schedule_page_ordering.rb
@@ -1,0 +1,41 @@
+module RetentionSchedulePageOrdering
+  extend ActiveSupport::Concern
+
+  def set_retention_schedule_order_flag
+    set_initial_retention_shedule_order_flag
+    if order_flag_is_not_applicable_to_retention_schedules
+      set_order_cookie(
+        SearchHelper::RETENTION_SCHEDULE_DEFAULT_SEARCH_RESULT_ORDER_FLAG
+      )
+    else
+      set_cookie_order_flag_from_param
+    end
+  end
+
+  def set_initial_retention_shedule_order_flag
+    if cookies[:search_result_order] == nil
+      set_order_cookie(
+        SearchHelper::RETENTION_SCHEDULE_DEFAULT_SEARCH_RESULT_ORDER_FLAG
+      )
+    end
+  end
+
+
+  def reset_default_order_from_retention_schedule_order_flag
+    if order_flag_is_not_applicable_to_retention_schedules
+      set_cookie_order_flag_from_param
+    else
+      set_order_cookie(
+        SearchHelper::DEFAULT_SEARCH_RESULT_ORDER_FLAG
+      )
+    end
+  end
+
+  def order_flag_is_not_applicable_to_retention_schedules
+    # 'destruction_date' is the common part of the SEARCH_SCOPE_SET
+    # for the RetentionSchedule page. See the SearchHelper module.
+    if cookies[:search_result_order]
+      cookies[:search_result_order].exclude?('destruction_date')
+    end
+  end
+end

--- a/app/controllers/concerns/retention_schedule_page_ordering.rb
+++ b/app/controllers/concerns/retention_schedule_page_ordering.rb
@@ -8,12 +8,12 @@ module RetentionSchedulePageOrdering
         SearchHelper::RETENTION_SCHEDULE_DEFAULT_SEARCH_RESULT_ORDER_FLAG
       )
     else
-      set_cookie_order_flag_from_param
+      set_cookie_order_flag
     end
   end
 
   def set_initial_retention_shedule_order_flag
-    if cookies[:search_result_order] == nil
+    if cookies[:search_result_order].nil? || order_flag_is_not_applicable_to_retention_schedules
       set_order_cookie(
         SearchHelper::RETENTION_SCHEDULE_DEFAULT_SEARCH_RESULT_ORDER_FLAG
       )
@@ -23,7 +23,7 @@ module RetentionSchedulePageOrdering
 
   def reset_default_order_from_retention_schedule_order_flag
     if order_flag_is_not_applicable_to_retention_schedules
-      set_cookie_order_flag_from_param
+      set_cookie_order_flag
     else
       set_order_cookie(
         SearchHelper::DEFAULT_SEARCH_RESULT_ORDER_FLAG

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -467,7 +467,7 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
     elsif current_order_option == default_oldest
       default_newest
     else
-      default_oldest
+      default_newest
     end
   end
 end

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -28,17 +28,15 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
   end
 
   def get_cases_order_option_url(original_uri, current_order_option)
-    if current_order_option == 'search_result_order_by_newest_first'
-      new_option = 'search_result_order_by_oldest_first'
-    else
-      new_option = 'search_result_order_by_newest_first'
-    end
+    new_option = get_new_option(current_order_option)
+
     uri = URI.parse(original_uri)
     hash_params = Hash[URI.decode_www_form(uri.query || '')]
     hash_params["order"] = new_option
     uri.query = URI.encode_www_form(hash_params)
     link_to t("common.show_#{new_option}"), uri.to_s
   end
+
 
   def accepted_case_attachment_types
     Settings.case_uploads_accepted_types.join ','
@@ -451,5 +449,25 @@ module CasesHelper #rubocop:disable Metrics/ModuleLength
   def get_first_number_in_string(number_string)
     return number_string.split(",").first&.upcase if number_string&.include?(",")
     number_string&.upcase
+  end
+
+  def get_new_option(current_order_option)
+    default_oldest = 'search_result_order_by_oldest_first'
+    default_newest = 'search_result_order_by_newest_first'
+    destruction_oldest = 'search_result_order_by_oldest_destruction_date'
+    destruction_newest = 'search_result_order_by_newest_destruction_date'
+
+      
+    if current_order_option == destruction_newest
+      destruction_oldest
+    elsif current_order_option == destruction_oldest
+      destruction_newest
+    elsif current_order_option == default_newest
+      default_oldest
+    elsif current_order_option == default_oldest
+      default_newest
+    else
+      default_oldest
+    end
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -3,10 +3,14 @@ module SearchHelper
   SEARCH_SCOPE_SET = {
     :search_result_order_by_oldest_first => { "order" => "cases.id ASC"},
     :search_result_order_by_newest_first => {"order" => "cases.received_date DESC, cases.id DESC"},
-    :search => {"order" => nil}
+    :search_result_order_by_oldest_destruction_date => {"order" => 'retention_schedule.planned_destruction_date DESC'},
+    :search_result_order_by_newest_destruction_date => {"order" => 'retention_schedule.planned_destruction_date ASC'},
+    :search => {"order" => nil},
   }.freeze
 
   DEFAULT_SEARCH_RESULT_ORDER_FLAG = "search_result_order_by_oldest_first".freeze
+
+  RETENTION_SCHEDULE_DEFAULT_SEARCH_RESULT_ORDER_FLAG = "search_result_order_by_oldest_destruction_date".freeze
 
   def self.get_order_option(search_order_choice)
     if SEARCH_SCOPE_SET[search_order_choice.to_sym].present?

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -129,6 +129,8 @@ ignore_unused:
   - stats.download_custom*
   - common.show_search_result_order_by_newest_first
   - common.show_search_result_order_by_oldest_first
+  - common.show_search_result_order_by_newest_destruction_date
+  - common.show_search_result_order_by_oldest_destruction_date
 
 
 ## Consider these keys used:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1081,6 +1081,8 @@ en:
     new_case_button: Create case
     show_search_result_order_by_newest_first: Show newest cases first
     show_search_result_order_by_oldest_first: Show oldest cases first
+    show_search_result_order_by_newest_destruction_date: Show newest destruction date first
+    show_search_result_order_by_oldest_destruction_date: Show oldest destruction date first
     phase_banner: |
       This is a new service.
     service_name: Track a query

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -136,16 +136,16 @@ feature 'Case retention schedules for GDPR', :js do
     expect(page).to have_content not_set_timely_kase.number
     expect(page).to have_content retain_timely_kase.number
 
-    click_on 'Show newest cases first'
+    click_on 'Show newest destruction date first'
 
     page_order_correct?(
       not_set_timely_kase.number.to_s, 
       retain_timely_kase.number.to_s
     )
 
-    expect(page).to have_content 'Show oldest cases first'
+    expect(page).to have_content 'Show oldest destruction date first'
 
-    click_on 'Show oldest cases first'
+    click_on 'Show oldest destruction date first'
     page_order_correct?(
       retain_timely_kase.number.to_s,
       not_set_timely_kase.number.to_s


### PR DESCRIPTION
## Description
Allows users to order retention schedules on the RRD tab by destruction date.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
Before:
<img width="1020" alt="Screenshot 2022-06-13 at 14 06 30" src="https://user-images.githubusercontent.com/13377553/173360391-c7187c1a-122b-4c5c-a5ce-d7e75ed194b7.png">

After:
<img width="1002" alt="Screenshot 2022-06-13 at 14 05 43" src="https://user-images.githubusercontent.com/13377553/173360278-6c1f807f-5152-46f1-978d-10b3b3cf6f44.png">


### Related JIRA tickets
[CT-4102](https://dsdmoj.atlassian.net/browse/CT-4102)

### Manual testing instructions
Click the ordering link on the RRD page - the cases should reorder by destruction date.