### PR TITLE
Update retention information in case details page

### DIFF
--- a/app/decorators/case/base_decorator.rb
+++ b/app/decorators/case/base_decorator.rb
@@ -148,11 +148,6 @@ class Case::BaseDecorator < Draper::Decorator
     I18n.l(object.date_responded, format: :default)
   end
 
-  def planned_destruction_date
-    date = object.retention_schedule.planned_destruction_date
-    I18n.l(date, format: :default)
-  end
-
   def self.collection_decorator_class
     PaginatingDecorator
   end

--- a/app/views/cases/offender_sar/_case_details.html.slim
+++ b/app/views/cases/offender_sar/_case_details.html.slim
@@ -39,3 +39,4 @@
 
         - if case_details.closed?
           = render partial: 'cases/shared/closed_case_details', locals: { case_details: case_details, allow_editing: allow_editing }
+          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details, allow_editing: allow_editing }

--- a/app/views/cases/offender_sar_complaint/_case_deadlines.html.slim
+++ b/app/views/cases/offender_sar_complaint/_case_deadlines.html.slim
@@ -1,4 +1,4 @@
- - if case_details.external_deadline.present?
+- if case_details.external_deadline.present?
   tr.section.case-external-deadline.section-external-deadline
     th = t('common.case.external_deadline')
     td = case_details.external_deadline

--- a/app/views/cases/offender_sar_complaint/_case_details.html.slim
+++ b/app/views/cases/offender_sar_complaint/_case_details.html.slim
@@ -38,6 +38,7 @@
 
         - if case_details.closed?
           = render partial: 'cases/shared/closed_case_details', locals: { case_details: case_details }
+          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details, allow_editing: allow_editing }
 
         = render partial: 'cases/offender_sar_complaint/approval_flags_details', locals: { case_details: case_details }
         = render partial: 'cases/offender_sar_complaint/appeal_outcome_details', locals: { case_details: case_details }

--- a/app/views/cases/shared/_closed_case_details.html.slim
+++ b/app/views/cases/shared/_closed_case_details.html.slim
@@ -66,9 +66,3 @@ tbody.response-details
     tr.outcome
       th = t('common.case.outcome')
       td = case_details.pretty_ico_decision
-
-  - if case_details.retention_schedule.present? && FeatureSet.branston_retention_scheduling.enabled?
-    tr.planned-erasure-date
-      th = t('common.case.planned_destruction_date')
-      td = case_details.planned_destruction_date
-

--- a/app/views/cases/shared/_retention_details.html.slim
+++ b/app/views/cases/shared/_retention_details.html.slim
@@ -1,0 +1,10 @@
+- if case_details.retention_schedule.present? && FeatureSet.branston_retention_scheduling.enabled?
+  tbody.retention-details
+    tr.section.planned-destruction-date
+      th = t('common.case.retention_details.destruction_date')
+      td = l(case_details.retention_schedule.planned_destruction_date)
+      td = (allow_editing ? link_to(t('common.links.change'), '#') : ' ')
+    tr.retention-schedule-state
+      th = t('common.case.retention_details.status')
+      td = case_details.retention_schedule.human_state
+      td = ' '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -970,7 +970,9 @@ en:
       pages_exempt: Exempt pages
       pages_final_count: Final page count
       pages_received: Pages received
-      planned_destruction_date: Planned destruction date
+      retention_details:
+        destruction_date: Destruction date
+        status: Retention status
       pnc_acronym_html: '<abbr title="Police national computer">PNC</abbr> number'
       postal_address: "Requester’s postal address"
       previous_case_numbers: Previous SAR cases

--- a/spec/features/cases/offender_sar_complaint/case_closing_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_closing_spec.rb
@@ -39,7 +39,7 @@ feature 'Closing a case' do
       original_case.save
     end
 
-    scenario 'adds retention schedule to case and related cases on closure', js: true do
+    scenario 'adds retention schedule details to case and related cases on closure', js: true do
       open_cases_page.load
       close_case(case_ready_to_close)
 
@@ -48,19 +48,39 @@ feature 'Closing a case' do
 
       show_page = cases_show_page.case_details
 
-      expect(show_page.response_details.planned_erasure.date.first.text)
+      expect(show_page.retention_details.planned_destruction_date)
+        .to have_content('Destruction date')
+      expect(show_page.retention_details.planned_destruction_date.date.first.text)
         .to eq(formatted_planned_closure_date(case_ready_to_close))
+      expect(show_page.retention_details.retention_schedule_state)
+        .to have_content('Retention status')
+      expect(show_page.retention_details.retention_schedule_state.data.first.text)
+        .to eq('Not set')
 
       visit("cases/#{original_case.id}")
       show_page = cases_show_page.case_details
-      expect(show_page.response_details.planned_erasure.date.first.text)
+
+      expect(show_page.retention_details.planned_destruction_date)
+        .to have_content('Destruction date')
+      expect(show_page.retention_details.planned_destruction_date.date.first.text)
         .to eq(formatted_planned_closure_date(case_ready_to_close))
+      expect(show_page.retention_details.retention_schedule_state)
+        .to have_content('Retention status')
+      expect(show_page.retention_details.retention_schedule_state.data.first.text)
+        .to eq('Not set')
 
       other_related_complaints.each do |kase|
         visit("cases/#{kase.id}")
         show_page = cases_show_page.case_details
-        expect(show_page.response_details.planned_erasure.date.first.text)
+
+        expect(show_page.retention_details.planned_destruction_date)
+          .to have_content('Destruction date')
+        expect(show_page.retention_details.planned_destruction_date.date.first.text)
           .to eq(formatted_planned_closure_date(case_ready_to_close))
+        expect(show_page.retention_details.retention_schedule_state)
+          .to have_content('Retention status')
+        expect(show_page.retention_details.retention_schedule_state.data.first.text)
+          .to eq('Not set')
       end
     end
   end

--- a/spec/site_prism/page_objects/sections/cases/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/case_details_section.rb
@@ -103,7 +103,6 @@ module PageObjects
         end
 
         section :response_details, '.response-details' do
-
           section :date_responded, '.date-responded' do
             element :data, 'td'
           end
@@ -130,13 +129,17 @@ module PageObjects
           section :exemptions, '.exemptions' do
             elements :list, 'td ul li'
           end
-
-          section :planned_erasure, '.planned-erasure-date' do
-            elements :date, 'td'
-          end
         end
 
+        section :retention_details, 'tbody.retention-details' do
+          section :planned_destruction_date, '.planned-destruction-date' do
+            elements :date, 'td'
+          end
 
+          section :retention_schedule_state, '.retention-schedule-state' do
+            elements :data, 'td'
+          end
+        end
 
         element :edit_case, :xpath, '//a[contains(.,"Edit case details")]'
         element :edit_case_link, :xpath, '//a[contains(.,"Edit case details")]'


### PR DESCRIPTION
## Description

Preparation for ticket CT-4134 (Edit RRD Case Details).

Show in the case details page the retention information. I'm not adding the "Indicative SAR count" row because I believe this is the fuzzy search that has been descoped.

Also, the "Change" link is a placeholder, this will be implemented in another PR (as well as making sure it shows/hide depending on current user permissions).

Note: it looks like a lot of changes because I refactored a bit the retention details into its own little partial and call the render only in those cases that will have retention schedules anyways (SAR and SAR complaints) and not in the other case types.
I had to also refactor a bit the page objects for the feature tests...

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots

<img width="1054" alt="Screenshot 2022-06-09 at 11 40 57" src="https://user-images.githubusercontent.com/687910/172828684-521b2a47-ad58-474c-adf9-6c95dea52ee8.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4134

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to a case having retention schedule and check the details show. The Change link is a placeholder with no functionality yet.
