### PR TITLE
CT-4134 Branston GDPR - Edit RRD details

### DIFF
--- a/app/controllers/concerns/form_object_updatable.rb
+++ b/app/controllers/concerns/form_object_updatable.rb
@@ -1,0 +1,35 @@
+module FormObjectUpdatable
+  extend ActiveSupport::Concern
+
+  private
+
+  def update_and_advance(form_class, opts = {}, &block)
+    hash = permitted_params(form_class).to_h
+
+    @form_object = form_class.new(
+      hash.merge(record: opts[:record])
+    )
+
+    if @form_object.save
+      block.call
+    else
+      render opts.fetch(:render, :edit)
+    end
+  end
+
+  def permitted_params(form_class)
+    params
+      .fetch(form_class.model_name.singular, {})
+      .permit(form_attribute_names(form_class))
+  end
+
+  def form_attribute_names(form_class)
+    form_class.attribute_types.map do |(attr_name, primitive)|
+      primitive.is_a?(ActiveModel::Type::Date) ? date_params(attr_name) : attr_name
+    end.flatten
+  end
+
+  def date_params(attr_name)
+    %W[#{attr_name}_dd #{attr_name}_mm #{attr_name}_yyyy]
+  end
+end

--- a/app/controllers/retention_schedules_controller.rb
+++ b/app/controllers/retention_schedules_controller.rb
@@ -1,4 +1,7 @@
 class RetentionSchedulesController < ApplicationController
+  include FormObjectUpdatable
+
+  before_action :set_case, only: [:edit, :update]
 
   def bulk_update
     service = RetentionSchedulesUpdateService.new(
@@ -19,8 +22,29 @@ class RetentionSchedulesController < ApplicationController
     end
   end
 
+  def edit
+    @form_object = RetentionScheduleForm.build(
+      current_retention_schedule
+    )
+  end
+
+  def update
+    update_and_advance(RetentionScheduleForm, record: current_retention_schedule) do
+      redirect_to case_path(@case), flash: { notice: t('.flash.success') }
+    end
+  end
 
   private
+
+  def set_case
+    @case = current_retention_schedule.case
+  end
+
+  def current_retention_schedule
+    @_current_retention_schedule ||= RetentionSchedule.find(
+      params.require(:id)
+    )
+  end
 
   def retention_schedules_params
     params.require(:retention_schedules).require(:case_ids).permit!

--- a/app/forms/base_form_object.rb
+++ b/app/forms/base_form_object.rb
@@ -1,0 +1,67 @@
+class BaseFormObject
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :record
+
+  # This will allow subclasses to define after_initialize callbacks
+  # and is needed for some functionality to work, i.e. acts_as_gov_uk_date
+  define_model_callbacks :initialize
+
+  def initialize(*)
+    run_callbacks(:initialize) { super }
+  end
+
+  # Initialize a new form object given an AR model, setting its attributes
+  def self.build(record)
+    attributes = attributes_map(record)
+
+    attributes.merge!(
+      record: record
+    )
+
+    new(attributes)
+  end
+
+  def save
+    valid? && persist!
+  end
+
+  def to_key
+    # Intentionally returns nil so the form builder picks up _only_
+    # the class name to generate the HTML attributes.
+    nil
+  end
+
+  def new_record?
+    true
+  end
+
+  # Add the ability to read/write attributes without calling their accessor methods.
+  # Needed to behave more like an ActiveRecord model, where you can manipulate the
+  # database attributes making use of `self[:attribute]`
+  def [](attr_name)
+    instance_variable_get("@#{attr_name}".to_sym)
+  end
+
+  def []=(attr_name, value)
+    instance_variable_set("@#{attr_name}".to_sym, value)
+  end
+
+  def attributes_map
+    self.class.attributes_map(self)
+  end
+
+  # Iterates through all declared attributes in the form object, mapping its values
+  def self.attributes_map(origin)
+    attribute_names.to_h { |attr| [attr, origin[attr]] }
+  end
+
+  private
+
+  # :nocov:
+  def persist!
+    raise 'Subclasses of BaseForm need to implement #persist!'
+  end
+  # :nocov:
+end

--- a/app/forms/retention_schedule_form.rb
+++ b/app/forms/retention_schedule_form.rb
@@ -1,0 +1,24 @@
+class RetentionScheduleForm < BaseFormObject
+  include GovUkDateFields::ActsAsGovUkDate
+
+  attribute :planned_destruction_date, :date
+
+  acts_as_gov_uk_date :planned_destruction_date
+
+  validates_presence_of :planned_destruction_date
+  validate :destruction_date_after_close_date, if: :planned_destruction_date
+
+  private
+
+  def destruction_date_after_close_date
+    unless planned_destruction_date > record.case.date_responded
+      errors.add(:planned_destruction_date, :before_closure)
+    end
+  end
+
+  def persist!
+    record.update(
+      planned_destruction_date: planned_destruction_date,
+    )
+  end
+end

--- a/app/views/cases/filters/retention.html.slim
+++ b/app/views/cases/filters/retention.html.slim
@@ -88,7 +88,7 @@ section#retention-cases.govuk-tabs__panel
                 th 
                   = t('retention_schedules.table_headings.status')
               tbody
-                = form_with url: "/retention_schedules", method: :patch, id: 'retention_schedules_form' do |f|
+                = form_with url: bulk_update_retention_schedules_path, method: :patch, id: 'retention_schedules_form' do |f|
                   - @cases.each do |kase|
                     tr.case_row
                       td

--- a/app/views/cases/shared/_retention_details.html.slim
+++ b/app/views/cases/shared/_retention_details.html.slim
@@ -3,7 +3,7 @@
     tr.section.planned-destruction-date
       th = t('common.case.retention_details.destruction_date')
       td = l(case_details.retention_schedule.planned_destruction_date)
-      td = (allow_editing ? link_to(t('common.links.change'), '#') : ' ')
+      td = (allow_editing ? link_to(t('common.links.change'), edit_retention_schedule_path(case_details.retention_schedule)) : ' ')
     tr.retention-schedule-state
       th = t('common.case.retention_details.status')
       td = case_details.retention_schedule.human_state

--- a/app/views/retention_schedules/edit.html.slim
+++ b/app/views/retention_schedules/edit.html.slim
@@ -1,0 +1,23 @@
+- content_for :page_title do
+  = t('page_title.edit_case_page', case_number: @case.number)
+
+- content_for :heading
+  = t('.heading')
+
+- content_for :sub_heading
+  = t('.subheading')
+
+= link_to 'Back', case_path(@case), class: 'govuk-back-link'
+
+= render partial: 'layouts/header'
+
+= GovukElementsErrorsHelper.error_summary @form_object,
+    "#{pluralize(@form_object.errors.count, t('common.error'))} #{t('common.summary_error')}", ""
+
+= form_for @form_object, url: retention_schedule_path(@form_object.record), method: :put do |f|
+  .form-group
+    = f.gov_uk_date_field :planned_destruction_date, { \
+        legend_text: '', form_hint_text: t('cases.new.date_sar_received_copy') \
+      }
+  .form-group
+    = f.submit t('.submit'), class: 'button'

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -92,9 +92,10 @@ ignore_unused:
   # Default date/time format used
   - '{date,time}.formats.default'
   - 'time.formats.default_date'
-  # ActiveRecord Model error messages
-  - 'activerecord.errors.models.*'
-  - 'activerecord.attributes.*'
+  # ActiveRecord errors and attributes
+  - 'activerecord.{errors.models,attributes}.*'
+  # ActiveModel errors and attributes
+  - 'activemodel.{errors.models,attributes}.*'
   - 'nav.tabs.{in_time,late}_html'
   - 'pundit.nil_class'
   - 'event.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -355,6 +355,18 @@ en:
             message:
               blank: cannot be blank            
 
+  activemodel:
+    attributes:
+      retention_schedule_form:
+        planned_destruction_date: Destruction date
+    errors:
+      models:
+        retention_schedule_form:
+          attributes:
+            planned_destruction_date:
+              blank: cannot be blank
+              before_closure: must be after case closed date
+
   pundit:
     assignment_policy:
       can_assign_to_new_team?: You are not authorised to assign this case to another team

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1624,6 +1624,13 @@ en:
       status: Retention status
     misc:
       destroy_alert_message: Are you sure you want to permanently destroy these cases?
+    edit:
+      heading: What are the retention details?
+      subheading: Edit retention details
+      submit: Continue
+    update:
+      flash:
+        success: Retention details updated
 
   users:
     new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -169,7 +169,9 @@ Rails.application.routes.draw do
     end
   end
 
-  patch '/retention_schedules', to: "retention_schedules#bulk_update"
+  resources :retention_schedules, only: [:edit, :update] do
+    patch :bulk_update, on: :collection
+  end
 
   # Case Actions (general)
   resources :cases, only: [:new, :show, :destroy] do

--- a/spec/controllers/retention_schedules_controller_spec.rb
+++ b/spec/controllers/retention_schedules_controller_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe RetentionSchedulesController, type: :controller do
+  let(:team_admin) { find_or_create :team_admin }
+
+  let(:case_with_rrd) {
+    create(
+      :offender_sar_case, :closed, :with_retention_schedule,
+      planned_destruction_date: Date.tomorrow
+    )
+  }
+
+  let(:retention_schedule) { case_with_rrd.retention_schedule }
+
+  # TODO: implement proper access control and add tests here when ready.
+
+  describe '#edit' do
+    context 'when user has access' do
+      before do
+        sign_in team_admin
+      end
+
+      it 'builds the form object and renders the view' do
+        get :edit, params: { id: retention_schedule.id }
+
+        expect(assigns(:case)).to eq(case_with_rrd)
+        expect(assigns(:form_object).record).to eq(retention_schedule)
+
+        expect(response).to render_template(:edit)
+      end
+
+      context 'when the retention schedule does not exist' do
+        it 'raises an exception' do
+          expect {
+            get :edit, params: { id: 12345 }
+          }.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+
+  describe '#update' do
+    context 'when user has access' do
+      before do
+        sign_in team_admin
+      end
+
+      context 'when the update was successful' do
+        it 'redirects back to the case details page, showing a flash notice' do
+          patch :update, params: {
+            id: retention_schedule.id,
+            retention_schedule_form: {
+              planned_destruction_date_yyyy: 2050,
+              planned_destruction_date_mm: 12,
+              planned_destruction_date_dd: 31
+            }
+          }
+
+          expect(retention_schedule.reload.planned_destruction_date).to eq(Date.new(2050, 12, 31))
+
+          expect(flash[:notice]).to eq('Retention details updated')
+          expect(response).to redirect_to(case_path(case_with_rrd))
+        end
+      end
+
+      context 'when the update failed' do
+        it 'renders the `edit` action showing errors' do
+          patch :update, params: { id: retention_schedule.id }
+
+          expect(assigns(:case)).to eq(case_with_rrd)
+          expect(assigns(:form_object).errors.added?(:planned_destruction_date, :blank)).to eq(true)
+
+          expect(response).to render_template(:edit)
+        end
+      end
+
+      context 'when the retention schedule does not exist' do
+        it 'raises an exception' do
+          expect {
+            patch :update, params: { id: 12345 }
+          }.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/base_form_object_spec.rb
+++ b/spec/forms/base_form_object_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+RSpec.describe BaseFormObject do
+  describe '#save' do
+    before do
+      allow(subject).to receive(:valid?).and_return(is_valid)
+    end
+
+    context 'for a valid form' do
+      let(:is_valid) { true }
+
+      it 'calls persist!' do
+        expect(subject).to receive(:persist!)
+        subject.save
+      end
+    end
+
+    context 'for an invalid form' do
+      let(:is_valid) { false }
+
+      it 'does not call persist!' do
+        expect(subject).not_to receive(:persist!)
+        subject.save
+      end
+
+      it 'returns false' do
+        expect(subject.save).to eq(false)
+      end
+    end
+  end
+
+  describe '#persisted?' do
+    it 'always returns false' do
+      expect(subject.persisted?).to eq(false)
+    end
+  end
+
+  describe '#new_record?' do
+    it 'always returns true' do
+      expect(subject.new_record?).to eq(true)
+    end
+  end
+
+  describe '#to_key' do
+    it 'always returns nil' do
+      expect(subject.to_key).to be_nil
+    end
+  end
+
+  describe '[]' do
+    let(:record) { double('Record') }
+
+    before do
+      subject.record = record
+    end
+
+    it 'read the attribute directly without using the method' do
+      expect(subject).not_to receive(:record)
+      expect(subject[:record]).to eq(record)
+    end
+  end
+
+  describe '[]=' do
+    let(:record) { double('Record') }
+
+    it 'assigns the attribute directly without using the method' do
+      expect(subject).not_to receive(:record=)
+      subject[:record] = record
+      expect(subject.record).to eq(record)
+    end
+  end
+end

--- a/spec/forms/retention_schedule_form_spec.rb
+++ b/spec/forms/retention_schedule_form_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require_relative '../support/forms/form_validation_shared_examples'
+
+RSpec.describe RetentionScheduleForm do
+  it_behaves_like 'a date question form', attribute_name: :planned_destruction_date do
+    before do
+      allow(subject).to receive(:destruction_date_after_close_date).and_return(true)
+    end
+  end
+
+  describe 'logic specific to this form' do
+    let(:record) { double('Record', case: case_double) }
+    let(:case_double) { double(Case::Base, date_responded: Date.today) }
+
+    let(:planned_destruction_date) { Date.tomorrow }
+
+    let(:arguments) { {
+      record: record,
+      planned_destruction_date: planned_destruction_date,
+    } }
+
+    subject { described_class.new(arguments) }
+
+    context 'destruction_date_after_close_date validation' do
+      context 'when the `planned_destruction_date` is before the `date_responded`' do
+        let(:planned_destruction_date) { Date.yesterday }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(:planned_destruction_date, :before_closure)).to eq(true)
+        end
+      end
+
+      context 'when the `planned_destruction_date` is after the `date_responded`' do
+        it 'has no validation errors on the field' do
+          expect(subject).to be_valid
+          expect(subject.errors.added?(:planned_destruction_date)).to eq(false)
+        end
+      end
+    end
+
+    describe '#save' do
+      context 'when form is valid' do
+        it 'saves the record' do
+          expect(record).to receive(:update).with(
+            planned_destruction_date: planned_destruction_date,
+          ).and_return(true)
+
+          expect(subject.save).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/retention_schedules_spec.rb
+++ b/spec/requests/retention_schedules_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "RetentionSchedules", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end

--- a/spec/support/forms/form_validation_shared_examples.rb
+++ b/spec/support/forms/form_validation_shared_examples.rb
@@ -1,0 +1,74 @@
+RSpec.shared_examples 'a date question form' do |options|
+  let(:question_attribute) { options[:attribute_name] }
+
+  let(:arguments) { {
+    record: record,
+    "#{question_attribute}_yyyy" => date_value[0],
+    "#{question_attribute}_mm"   => date_value[1],
+    "#{question_attribute}_dd"   => date_value[2],
+  } }
+
+  let(:record) { double('Record') }
+  let(:date_value) { %w(2018 12 31) }
+
+  subject { described_class.new(arguments) }
+
+  describe '#save' do
+    context 'date validation' do
+      context 'when date is not given' do
+        let(:date_value) { [] }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(question_attribute, :blank)).to eq(true)
+        end
+      end
+
+      context 'when day part of the date is missing' do
+        let(:date_value) { %w(2018 12 nil) }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        # ActsAsGovUkDate gem will not set an error symbol but instead an error message
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(question_attribute, 'Invalid date')).to eq(true)
+        end
+      end
+
+      context 'when month part of the date is missing' do
+        let(:date_value) { %w(2018 nil 31) }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        # ActsAsGovUkDate gem will not set an error symbol but instead an error message
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(question_attribute, 'Invalid date')).to eq(true)
+        end
+      end
+
+      context 'when date is invalid' do
+        let(:date_value) { %w(2018 15 31) } # Month 15
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        # ActsAsGovUkDate gem will not set an error symbol but instead an error message
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.added?(question_attribute, 'Invalid date')).to eq(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Note: this PR was too big so I'm going to implement this in more than one PR, this is the first one that includes the editing of the destruction date. This does not include yet the editing of the retention status (review, retain...)

**Individual commits with more detail.**

A new edit page has been implemented, to edit the retention details of a case. To access this page, select a closed case that has already some retention schedule assigned and click the "Change" link in the case details.

As this is editing a relationship table (`has_one :retention_schedule`) the existing "framework" to edit case details wasn't ideal and I think it is best to just do this in a clean way with a form object. Also this setup will work fine with other pages in the future, or we can migrate some of the existing ones if we consider.

Most of this code is a streamlined version, with just the absolute minimum, of the form objects / steps mechanism I've implemented and iterated in many of my previous apps like C100, Disclosure Checker or Tax Tribunals, and it has proved robust and easy to work with, but happy to have a chat/demo/walkthrough if necessary.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="1011" alt="Screenshot 2022-06-13 at 15 08 35" src="https://user-images.githubusercontent.com/687910/173372587-02598c29-397d-4ce4-933c-ba30623fcb16.png">

<img width="746" alt="Screenshot 2022-06-13 at 15 09 33" src="https://user-images.githubusercontent.com/687910/173372670-bd853c0c-0603-4bda-842b-9383f2dee58f.png">

<img width="1050" alt="Screenshot 2022-06-13 at 15 10 02" src="https://user-images.githubusercontent.com/687910/173372749-753501a0-1fc1-41a0-8fce-80e3136a31c6.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4134

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to the details of a closed case with retention schedule, and click the Change link, it will open the retention details page where you can edit the date (only the date for now) and there is validation as well.
Note at the moment permissions are not being checked (it is enough you are signed in).
