### PR TITLE
Ct 4223 restrict to team admins

### DIFF
--- a/app/views/cases/filters/retention.html.slim
+++ b/app/views/cases/filters/retention.html.slim
@@ -32,7 +32,8 @@ section#retention-cases.govuk-tabs__panel
                 = link_to t("nav.tabs.#{tab.name}",
                            count: tab.count),
                           tab.fullpath_with_query
-    - if @cases.present?
+
+    - if @cases.present? && @user.team_admin?
         - cases_count = @cases.total_count
 
         .grid-row

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -161,17 +161,6 @@ global_navigation:
       path: /cases/closed
       scope: closed_cases
 
-    rrd_pending:
-      path: /cases/retention
-      scope: retention_cases
-      visibility:
-        - BRANSTON
-      tabs:
-        ready_for_removal:
-          scope: erasable_cases
-        pending_removal:
-          scope: triagable_cases
-
     search_cases:
       path: /cases/search
     teams:
@@ -190,6 +179,17 @@ global_navigation:
       path: /contacts
       visibility:
         - BRANSTON
+
+    rrd_pending:
+      path: /cases/retention
+      scope: retention_cases
+      visibility:
+        - BRANSTON
+      tabs:
+        ready_for_removal:
+          scope: erasable_cases
+        pending_removal:
+          scope: triagable_cases
 
   tabs:
     in_time:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -109,7 +109,7 @@ homepage_navigation:
       path: /cases/retention
       scope: retention_cases
       visibility:
-        - BRANSTON
+        - team_admin
       tabs:
         ready_for_removal:
           scope: erasable_cases
@@ -184,7 +184,7 @@ global_navigation:
       path: /cases/retention
       scope: retention_cases
       visibility:
-        - BRANSTON
+        - team_admin
       tabs:
         ready_for_removal:
           scope: erasable_cases

--- a/spec/features/cases/retention_schedules/anonymisation_spec.rb
+++ b/spec/features/cases/retention_schedules/anonymisation_spec.rb
@@ -1,11 +1,18 @@
 require 'rails_helper'
 
 feature 'Case retention schedules for GDPR', :js do
-  given(:branston_user)         { find_or_create :branston_user }
-  given(:branston_team)   { create :managing_team, managers: [branston_user] }
+  given(:branston_team_admin_user)         { find_or_create :branston_user }
+  given(:admin_team)          { find_or_create :team_for_admin_users }
 
-  given(:non_branston_user)         { find_or_create :disclosure_bmt_user }
-  given(:non_branston_team)   { create :managing_team, managers: [non_branston_user] }
+  before do
+    tur = TeamsUsersRole.new(
+      team_id: admin_team.id, 
+      user_id: branston_team_admin_user.id, 
+      role: 'team_admin'
+    )
+
+    branston_team_admin_user.team_roles << tur
+  end
 
   # erasable
   let!(:erasable_timely_kase) {
@@ -35,8 +42,8 @@ feature 'Case retention schedules for GDPR', :js do
     ) 
   }
 
-  scenario 'branston users can see the GDPR tab with correct cases' do
-    login_as branston_user
+  scenario 'branston team admin users can see the GDPR tab with correct cases' do
+    login_as branston_team_admin_user
     
     cases_page.load
 

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -1,12 +1,23 @@
 require 'rails_helper'
 
 feature 'Case retention schedules for GDPR', :js do
-  given(:branston_user)         { find_or_create :branston_user }
-  given(:branston_team)   { create :managing_team, managers: [branston_user] }
+  let(:branston_team_admin_user)   { find_or_create :branston_user }
+  let(:branston_user)         { create :branston_user, email: 'non.team.admin@test.com' }
 
-  given(:non_branston_user)         { find_or_create :disclosure_bmt_user }
+  given(:admin_team)          { find_or_create :team_for_admin_users }
+
+  given(:non_branston_user)   { find_or_create :disclosure_bmt_user }
   given(:non_branston_team)   { create :managing_team, managers: [non_branston_user] }
 
+  before do
+    tur = TeamsUsersRole.new(
+      team_id: admin_team.id, 
+      user_id: branston_team_admin_user.id, 
+      role: 'team_admin'
+    )
+
+    branston_team_admin_user.team_roles << tur
+  end
 
   ## Dates > 8 years
   # not set
@@ -85,9 +96,17 @@ feature 'Case retention schedules for GDPR', :js do
     ) 
   }
 
-  scenario 'branston users can see the GDPR tab with correct cases' do
+  scenario 'non admin branston users cannot manage RRD schedules of cases' do
     login_as branston_user
-    
+
+    cases_page.load
+
+    expect(page).to_not have_content 'RRD Pending'
+  end
+
+  scenario 'branston team admin users can managers RRD schedules of cases' do
+    login_as branston_team_admin_user
+
     cases_page.load
 
     expect(page).to have_content 'RRD Pending'


### PR DESCRIPTION
## Description
Restricts RRD tabs to branston team admins. 

NOTE: Team admins only exist in the context of Branston so relying on 'team_admin' will work for this. All team admins are also general Branston users, which sets the scope of cases.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
Non team admins (i.e. regular branston users):
<img width="987" alt="Screenshot 2022-06-13 at 17 20 14" src="https://user-images.githubusercontent.com/13377553/173399277-5d0733fa-3252-4551-a13b-dade483382e7.png">

Team admins:
<img width="983" alt="Screenshot 2022-06-13 at 17 21 49" src="https://user-images.githubusercontent.com/13377553/173399595-903491c6-c8b1-418c-b19b-08fd52bc0740.png">

### Related JIRA tickets
[CT-4102](https://dsdmoj.atlassian.net/browse/CT-4102)

### Manual testing instructions
- sign in as branston team admin to manage RRD retention schedules.
- log in as regular branston user to test that RRD does not show. 
