### PR TITLE
CT-4134 Branston GDPR - Edit RRD state

### DIFF
--- a/app/forms/base_form_object.rb
+++ b/app/forms/base_form_object.rb
@@ -12,6 +12,16 @@ class BaseFormObject
     run_callbacks(:initialize) { super }
   end
 
+  # Initialize a new form object given an AR model, reading and setting
+  # the attributes declared in the form object.
+  def self.build(record)
+    attrs = record.slice(
+      attribute_names
+    ).merge!(record: record)
+
+    new(attrs)
+  end
+
   def save
     valid? && persist!
   end
@@ -37,30 +47,12 @@ class BaseFormObject
     instance_variable_set("@#{attr_name}".to_sym, value)
   end
 
-  class << self
-    # Initialize a new form object given an AR model, setting its attributes
-    def build(record)
-      attributes = attributes_map(record)
-
-      attributes.merge!(
-        record: record
-      )
-
-      new(attributes)
-    end
-
-    # Iterates through all declared attributes in the form object, retrieving
-    # their values from the `record` instance and generating a hash map.
-    def attributes_map(record)
-      attribute_names.to_h { |attr| [attr, record[attr]] }
-    end
-  end
-
   private
 
-  # :nocov:
+  # If the logic is any more complex than this, override in subclasses
   def persist!
-    raise 'Subclasses of BaseFormObject need to implement #persist!'
+    record.update(
+      attributes
+    )
   end
-  # :nocov:
 end

--- a/app/forms/retention_schedule_form.rb
+++ b/app/forms/retention_schedule_form.rb
@@ -2,13 +2,34 @@ class RetentionScheduleForm < BaseFormObject
   include GovUkDateFields::ActsAsGovUkDate
 
   attribute :planned_destruction_date, :date
+  attribute :state, :string
 
   acts_as_gov_uk_date :planned_destruction_date
 
   validates_presence_of :planned_destruction_date
   validate :destruction_date_after_close_date, if: :planned_destruction_date
 
+  validates_inclusion_of :state, in: :state_choices
+
+  def state_choices
+    allowed_states.map(&:to_s)
+  end
+
   private
+
+  # If the retention schedule has progressed already to any state other than the
+  # initial `not_set`, we don't allow reverting back to the initial state, so we
+  # remove this state from the available choices.
+  #
+  # Additionally, we don't handle the anonymisation through this form, so we also
+  # remove the final state.
+  #
+  def allowed_states
+    RetentionSchedule.state_names.tap do |states|
+      states.delete(RetentionSchedule::STATE_ANONYMISED)
+      states.delete(RetentionSchedule::STATE_NOT_SET) unless record.not_set?
+    end
+  end
 
   def destruction_date_after_close_date
     unless planned_destruction_date > record.case.date_responded
@@ -19,6 +40,7 @@ class RetentionScheduleForm < BaseFormObject
   def persist!
     record.update(
       planned_destruction_date: planned_destruction_date,
+      state: state,
     )
   end
 end

--- a/app/forms/retention_schedule_form.rb
+++ b/app/forms/retention_schedule_form.rb
@@ -36,11 +36,4 @@ class RetentionScheduleForm < BaseFormObject
       errors.add(:planned_destruction_date, :before_closure)
     end
   end
-
-  def persist!
-    record.update(
-      planned_destruction_date: planned_destruction_date,
-      state: state,
-    )
-  end
 end

--- a/app/models/retention_schedule.rb
+++ b/app/models/retention_schedule.rb
@@ -52,5 +52,9 @@ class RetentionSchedule < ApplicationRecord
     def states_map
       aasm.states.to_h { |state| [state.name, state.display_name] }
     end
+
+    def state_names
+      aasm.states.map(&:name)
+    end
   end
 end

--- a/app/views/retention_schedules/edit.html.slim
+++ b/app/views/retention_schedules/edit.html.slim
@@ -20,4 +20,7 @@
         legend_text: '', form_hint_text: t('cases.new.date_sar_received_copy') \
       }
   .form-group
+    = f.radio_button_fieldset :state, choices: @form_object.state_choices
+
+  .form-group
     = f.submit t('.submit'), class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -359,6 +359,7 @@ en:
     attributes:
       retention_schedule_form:
         planned_destruction_date: Destruction date
+        state: Status
     errors:
       models:
         retention_schedule_form:
@@ -366,6 +367,8 @@ en:
             planned_destruction_date:
               blank: cannot be blank
               before_closure: must be after case closed date
+            state:
+              inclusion: is not a valid status
 
   pundit:
     assignment_policy:
@@ -568,6 +571,8 @@ en:
       team:
         role: What will the business unit be responsible for?
         correspondence_type_ids: Correspondence types
+      retention_schedule_form:
+        state: What is the retention status?
     hint:
       case:
         linked_case_number: " For example 170131001"
@@ -882,6 +887,12 @@ en:
         ico: ICO
         overturned_sar: Overturned SAR
         overturned_foi: Overturned FOI
+      retention_schedule_form:
+        state:
+          not_set: Not set
+          retain: Retain
+          review: Review
+          to_be_anonymised: Destroy
     links:
       case_details:
         edit_case: 'Edit case details'
@@ -1630,7 +1641,7 @@ en:
       submit: Continue
     update:
       flash:
-        success: Retention details updated
+        success: Retention details successfully updated
 
   users:
     new:

--- a/spec/controllers/retention_schedules_controller_spec.rb
+++ b/spec/controllers/retention_schedules_controller_spec.rb
@@ -52,13 +52,15 @@ RSpec.describe RetentionSchedulesController, type: :controller do
             retention_schedule_form: {
               planned_destruction_date_yyyy: 2050,
               planned_destruction_date_mm: 12,
-              planned_destruction_date_dd: 31
+              planned_destruction_date_dd: 31,
+              state: RetentionSchedule::STATE_REVIEW
             }
           }
 
+          expect(retention_schedule.reload.review?).to eq(true)
           expect(retention_schedule.reload.planned_destruction_date).to eq(Date.new(2050, 12, 31))
 
-          expect(flash[:notice]).to eq('Retention details updated')
+          expect(flash[:notice]).to eq('Retention details successfully updated')
           expect(response).to redirect_to(case_path(case_with_rrd))
         end
       end

--- a/spec/forms/retention_schedule_form_spec.rb
+++ b/spec/forms/retention_schedule_form_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe RetentionScheduleForm do
       context 'when form is valid' do
         it 'saves the record' do
           expect(record).to receive(:update).with(
-            planned_destruction_date: planned_destruction_date,
-            state: state,
+            'planned_destruction_date' => planned_destruction_date,
+            'state' => state,
           ).and_return(true)
 
           expect(subject.save).to be(true)

--- a/spec/forms/retention_schedule_form_spec.rb
+++ b/spec/forms/retention_schedule_form_spec.rb
@@ -4,22 +4,43 @@ require_relative '../support/forms/form_validation_shared_examples'
 RSpec.describe RetentionScheduleForm do
   it_behaves_like 'a date question form', attribute_name: :planned_destruction_date do
     before do
+      # We stub these as we will test more thoroughly in separate scenarios
       allow(subject).to receive(:destruction_date_after_close_date).and_return(true)
+      allow(subject).to receive(:state_choices).and_return([])
     end
   end
 
   describe 'logic specific to this form' do
-    let(:record) { double('Record', case: case_double) }
+    let(:record) { double('Record', case: case_double, not_set?: schedule_not_set) }
     let(:case_double) { double(Case::Base, date_responded: Date.today) }
 
     let(:planned_destruction_date) { Date.tomorrow }
+    let(:state) { RetentionSchedule::STATE_NOT_SET.to_s }
+    let(:schedule_not_set) { true }
 
     let(:arguments) { {
       record: record,
       planned_destruction_date: planned_destruction_date,
+      state: state,
     } }
 
     subject { described_class.new(arguments) }
+
+    context '#state_choices' do
+      context 'when the schedule has not been set yet' do
+        it 'shows only the relevant values' do
+          expect(subject.state_choices).to eq(%w(not_set retain review to_be_anonymised))
+        end
+      end
+
+      context 'when the schedule has been set already' do
+        let(:schedule_not_set) { false }
+
+        it 'shows only the relevant values' do
+          expect(subject.state_choices).to eq(%w(retain review to_be_anonymised))
+        end
+      end
+    end
 
     context 'destruction_date_after_close_date validation' do
       context 'when the `planned_destruction_date` is before the `date_responded`' do
@@ -43,11 +64,53 @@ RSpec.describe RetentionScheduleForm do
       end
     end
 
+    context 'state validation' do
+      context 'when `state` is not present' do
+        let(:state) { nil }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.of_kind?(:state, :inclusion)).to eq(true)
+        end
+      end
+
+      context 'when `state` is not a valid value' do
+        let(:state) { 'foobar' }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.of_kind?(:state, :inclusion)).to eq(true)
+        end
+      end
+
+      context 'when `state` is `not_set` but the schedule has been already set' do
+        let(:schedule_not_set) { false }
+
+        it 'returns false' do
+          expect(subject.save).to be(false)
+        end
+
+        it 'has a validation error on the field' do
+          expect(subject).to_not be_valid
+          expect(subject.errors.of_kind?(:state, :inclusion)).to eq(true)
+        end
+      end
+    end
+
     describe '#save' do
       context 'when form is valid' do
         it 'saves the record' do
           expect(record).to receive(:update).with(
             planned_destruction_date: planned_destruction_date,
+            state: state,
           ).and_return(true)
 
           expect(subject.save).to be(true)

--- a/spec/models/retention_schedule_spec.rb
+++ b/spec/models/retention_schedule_spec.rb
@@ -152,5 +152,15 @@ RSpec.describe RetentionSchedule, type: :model do
         )
       end
     end
+
+    describe '.state_names' do
+      it 'returns an array of symbols of all possible states' do
+        expect(
+          described_class.state_names
+        ).to match_array(
+          [:not_set, :retain, :review, :to_be_anonymised, :anonymised]
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
Follow-up to PR #2021.

This adds the functionality to the edit page to change the retention state/status and completes the basic work for this ticket.

There is some validation involved to not allow to revert a schedule back to `not_set`, as per acceptance criteria.

In a separate ticket the permissions logic and the case history log will be implemented along with some view tests.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="778" alt="Screenshot 2022-06-15 at 09 52 08" src="https://user-images.githubusercontent.com/687910/173785802-2ff31cbc-0f90-4b1a-996b-f8a167b23b16.png">


### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to a case with retention schedule and click Change link. The state radios should show all possible options if the schedule is yet in a `not_set` state. If the schedule has been progressed already to any further state, then `not_set` radio will not show.
Upon clicking `continue` the state along any change to the date will be updated.
