### PR TITLE
Change scope of RRD pages

### DIFF
--- a/app/models/retention_schedule.rb
+++ b/app/models/retention_schedule.rb
@@ -46,7 +46,7 @@ class RetentionSchedule < ApplicationRecord
   class << self
     def common_date_viewable_from_range
       viewable_from = Settings.retention_timings.common.viewable_from
-      viewable_from.months.ago..Date.today
+      ..Date.today + viewable_from.months
     end
 
     def states_map

--- a/app/models/retention_schedule.rb
+++ b/app/models/retention_schedule.rb
@@ -49,6 +49,14 @@ class RetentionSchedule < ApplicationRecord
       ..Date.today + viewable_from.months
     end
 
+    def erasable_cases_viewable_range
+      (..Date.today)
+    end
+
+    def triagable_destory_cases_range
+      ((Date.today + 1)..)
+    end
+
     def states_map
       aasm.states.to_h { |state| [state.name, state.display_name] }
     end

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -111,29 +111,29 @@ class CaseFinderService
   def erasable_cases_scope
     retention_cases_scope.where(
       retention_schedule: { 
-        state: [:to_be_anonymised],
-        planned_destruction_date: ..Date.today
+        state: RetentionSchedule::STATE_TO_BE_ANONYMISED,
+        planned_destruction_date: RetentionSchedule.erasable_cases_viewable_range 
       })
   end
 
   def triagable_cases_scope
     triagable_statuses =  [
-      :review, 
-      :retain, 
-      :not_set
+      RetentionSchedule::STATE_REVIEW, 
+      RetentionSchedule::STATE_RETAIN, 
+      RetentionSchedule::STATE_NOT_SET
     ]
 
     retention_cases_scope.where(
       retention_schedule: { 
         state: triagable_statuses
-      }).or(traiagable_destroy_cases_scope)
+      }).or(triagable_destroy_cases_scope)
   end
 
-  def traiagable_destroy_cases_scope
+  def triagable_destroy_cases_scope
     retention_cases_scope.where(
       retention_schedule: { 
-        state: [:to_be_anonymised],
-        planned_destruction_date: (Date.today + 1)..
+        state: RetentionSchedule::STATE_TO_BE_ANONYMISED,
+        planned_destruction_date: RetentionSchedule.triagable_destory_cases_range
       })
   end
 

--- a/app/services/case_finder_service.rb
+++ b/app/services/case_finder_service.rb
@@ -111,15 +111,29 @@ class CaseFinderService
   def erasable_cases_scope
     retention_cases_scope.where(
       retention_schedule: { 
-        state: [:to_be_anonymised]
+        state: [:to_be_anonymised],
+        planned_destruction_date: ..Date.today
       })
   end
 
   def triagable_cases_scope
-    triagable_states = [:review, :retain, :not_set]
+    triagable_statuses =  [
+      :review, 
+      :retain, 
+      :not_set
+    ]
+
     retention_cases_scope.where(
       retention_schedule: { 
-        state: triagable_states
+        state: triagable_statuses
+      }).or(traiagable_destroy_cases_scope)
+  end
+
+  def traiagable_destroy_cases_scope
+    retention_cases_scope.where(
+      retention_schedule: { 
+        state: [:to_be_anonymised],
+        planned_destruction_date: (Date.today + 1)..
       })
   end
 

--- a/spec/features/cases/retention_schedules/anonymisation_spec.rb
+++ b/spec/features/cases/retention_schedules/anonymisation_spec.rb
@@ -29,7 +29,7 @@ feature 'Case retention schedules for GDPR', :js do
       case_type: :offender_sar_case, 
       case_state: :closed,
       rs_state: 'to_be_anonymised',
-      date: Date.today - (4.months - 7.days)
+      date: Date.today
     ) 
   }
 
@@ -38,7 +38,7 @@ feature 'Case retention schedules for GDPR', :js do
       case_type: :offender_sar_case, 
       case_state: :closed,
       rs_state: 'to_be_anonymised',
-      date: Date.today - (5.months)
+      date: Date.today + 5.months
     ) 
   }
 

--- a/spec/models/retention_schedule_spec.rb
+++ b/spec/models/retention_schedule_spec.rb
@@ -129,10 +129,10 @@ RSpec.describe RetentionSchedule, type: :model do
     describe '.common_date_viewable_from_range' do
       it 'returns a range that is correct' do
         class_range = RetentionSchedule.common_date_viewable_from_range
-        expected_range = 4.months.ago..Date.today
+        expected_range = ..Date.today + 4.months
 
-        expect(class_range).to be_a(Range)
-        expect(class_range.begin.day).to match(expected_range.begin.day)
+        expect(class_range.class).to be(Range)
+        expect(class_range.begin).to be(nil)
         expect(class_range.end).to match(expected_range.end)
       end
     end

--- a/spec/models/retention_schedule_spec.rb
+++ b/spec/models/retention_schedule_spec.rb
@@ -126,13 +126,31 @@ RSpec.describe RetentionSchedule, type: :model do
   end
 
   describe 'class methods' do
-    describe '.common_date_viewable_from_range' do
-      it 'returns a range that is correct' do
+    describe 'date ranges' do
+      it 'returns a range that is correct to view non "destroy" triagable cases' do
         class_range = RetentionSchedule.common_date_viewable_from_range
         expected_range = ..Date.today + 4.months
 
         expect(class_range.class).to be(Range)
         expect(class_range.begin).to be(nil)
+        expect(class_range.end).to match(expected_range.end)
+      end
+
+      it 'returns a range that is correct to erasable cases' do
+        class_range = RetentionSchedule.erasable_cases_viewable_range
+        expected_range = ..Date.today 
+
+        expect(class_range.class).to be(Range)
+        expect(class_range.begin).to be(nil)
+        expect(class_range.end).to match(expected_range.end)
+      end
+
+      it 'returns a range that is correct to view triagable "destroy" cases' do
+        class_range = RetentionSchedule.triagable_destory_cases_range
+        expected_range = ((Date.today + 1)..)
+
+        expect(class_range).to be_a(Range)
+        expect(class_range.begin).to match(expected_range.begin)
         expect(class_range.end).to match(expected_range.end)
       end
     end


### PR DESCRIPTION
- makes the Pending tab also have 'destroy' cases that are in the future. Those that have passed their destruction dates and have a destroy status move to the 'Ready for removal' tab. 
- makes the Ready for removal page only have cases where the destruction
  date is >= Date.today (i.e. no future dates)
- cases that are marked as 'Destroy' will remain on Pending tab until their planned destruction date is passed at which point they pass to ready for removal tab.


## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed

### Related JIRA tickets
[CT-4220](https://dsdmoj.atlassian.net/browse/CT-4220)
[CT-4221](https://dsdmoj.atlassian.net/browse/CT-4221)

### Manual testing instructions
- change some cases destruction dates to fit inside and outside the rules specified above, they should be in the right places at the right times 👍 
