### PR TITLE
Remove +1 to destruction date calculation

### DIFF
--- a/app/services/retention_schedules/add_schedule_service.rb
+++ b/app/services/retention_schedules/add_schedule_service.rb
@@ -86,7 +86,7 @@ module RetentionSchedules
       months = Settings.retention_timings.off_sars.erasure.months
       retention_period = years.years + months.months
 
-      closure_date + retention_period + 1.day
+      closure_date + retention_period
     end
 
     def closure_date

--- a/spec/services/retention_schedules/add_shedule_service_spec.rb
+++ b/spec/services/retention_schedules/add_shedule_service_spec.rb
@@ -79,7 +79,7 @@ describe RetentionSchedules::AddScheduleService do
   let(:expected_off_sar_erasure_date) {
     # defined as these in Settings.retention_timings.off_sars
     # and then referenced in service class
-    (4.business_days.ago + 8.years + 6.months + 1.day).to_date
+    (4.business_days.ago + 8.years + 6.months).to_date
   }
 
   before do


### PR DESCRIPTION
## Description
Remove +1 to destruction date calculation, as it is no longer required

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Related JIRA tickets
[CT-4224](https://dsdmoj.atlassian.net/browse/CT-4224)

### Manual testing instructions
- if you close a case the date should only be date_responded + 8 years 6 months, rather than 8 years 6 months, and one day.
- script to add RetentionSchedules will need to be re-run on QA