### PR TITLE
CT-4134 Branston GDPR - Edit RRD permissions

### DIFF
--- a/app/controllers/concerns/form_object_updatable.rb
+++ b/app/controllers/concerns/form_object_updatable.rb
@@ -11,7 +11,7 @@ module FormObjectUpdatable
     )
 
     if @form_object.save
-      block.call
+      block.call(@form_object)
     else
       render opts.fetch(:render, :edit)
     end

--- a/app/forms/retention_schedule_form.rb
+++ b/app/forms/retention_schedule_form.rb
@@ -4,6 +4,9 @@ class RetentionScheduleForm < BaseFormObject
   attribute :planned_destruction_date, :date
   attribute :state, :string
 
+  # Transient attribute used for the case history log
+  attr_reader :previous_values
+
   acts_as_gov_uk_date :planned_destruction_date
 
   validates_presence_of :planned_destruction_date
@@ -16,6 +19,15 @@ class RetentionScheduleForm < BaseFormObject
   end
 
   private
+
+  def persist!
+    @previous_values = {
+      state: record.human_state,
+      date:  record.planned_destruction_date
+    }
+
+    super
+  end
 
   # If the retention schedule has progressed already to any state other than the
   # initial `not_set`, we don't allow reverting back to the initial state, so we

--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -324,6 +324,14 @@ class Case::BasePolicy < ApplicationPolicy
     check_user_can_manage_offender_sar
   end
 
+  def can_perform_retention_actions?
+    clear_failed_checks
+
+    # Note: the feature flag check is temporary, as a precaution
+    FeatureSet.branston_retention_scheduling.enabled? &&
+      show? && user.team_admin? && self.case.closed?
+  end
+
   def method_missing(method, *args)
     if method.to_s =~ /can_(.+)\?$/
       event_name = $1

--- a/app/views/cases/offender_sar/_case_details.html.slim
+++ b/app/views/cases/offender_sar/_case_details.html.slim
@@ -39,4 +39,4 @@
 
         - if case_details.closed?
           = render partial: 'cases/shared/closed_case_details', locals: { case_details: case_details, allow_editing: allow_editing }
-          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details, allow_editing: allow_editing }
+          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details }

--- a/app/views/cases/offender_sar_complaint/_case_details.html.slim
+++ b/app/views/cases/offender_sar_complaint/_case_details.html.slim
@@ -38,7 +38,7 @@
 
         - if case_details.closed?
           = render partial: 'cases/shared/closed_case_details', locals: { case_details: case_details }
-          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details, allow_editing: allow_editing }
+          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details }
 
         = render partial: 'cases/offender_sar_complaint/approval_flags_details', locals: { case_details: case_details }
         = render partial: 'cases/offender_sar_complaint/appeal_outcome_details', locals: { case_details: case_details }

--- a/app/views/cases/shared/_retention_details.html.slim
+++ b/app/views/cases/shared/_retention_details.html.slim
@@ -3,7 +3,7 @@
     tr.section.planned-destruction-date
       th = t('common.case.retention_details.destruction_date')
       td = l(case_details.retention_schedule.planned_destruction_date)
-      td = (allow_editing ? link_to(t('common.links.change'), edit_retention_schedule_path(case_details.retention_schedule)) : ' ')
+      td = (@user.team_admin? ? link_to(t('common.links.change'), edit_retention_schedule_path(case_details.retention_schedule)) : ' ')
     tr.retention-schedule-state
       th = t('common.case.retention_details.status')
       td = case_details.retention_schedule.human_state

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -90,7 +90,7 @@ ignore_unused:
   # GOVUK Form Builder uses these translations
   - 'helpers.{fieldset,hint,label}.*'
   # Default date/time format used
-  - '{date,time}.formats.default'
+  - '{date,time}.formats.{default,compact}'
   - 'time.formats.default_date'
   # ActiveRecord errors and attributes
   - 'activerecord.{errors.models,attributes}.*'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -422,6 +422,7 @@ en:
       can_record_data_request?: You cannot edit data request once the case has been closed.
       can_mark_as_partial_case?: You cannot mark the case as confirmed SSCL COVID-19 partial case.
       can_mark_as_further_actions_required?: You cannot mark the case as SSCL managing case.
+      can_perform_retention_actions?: You are not authorised to edit the retention details of this case.
     case/sar/offender_complaint_policy:
       <<: *case_policy
       can_record_data_request?: You cannot edit data request once the case has been closed.
@@ -462,6 +463,7 @@ en:
   date:
     formats:
       default: "%-d %b %Y"
+      compact: "%d-%m-%Y"
 
   time:
     formats:
@@ -1642,6 +1644,9 @@ en:
     update:
       flash:
         success: Retention details successfully updated
+      case_note_html: |
+        Retention status changed from %{state_from} to %{state_to}
+        Destruction date changed from %{date_from} to %{date_to}
 
   users:
     new:

--- a/spec/controllers/retention_schedules_controller_spec.rb
+++ b/spec/controllers/retention_schedules_controller_spec.rb
@@ -1,23 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe RetentionSchedulesController, type: :controller do
-  let(:team_admin) { find_or_create :team_admin }
+  let(:admin_team) { find_or_create :team_for_admin_users }
+
+  let(:branston_team_admin_user) { find_or_create :branston_user }
+  let(:branston_user) { create :branston_user, email: 'non.team.admin@test.com' }
 
   let(:case_with_rrd) {
     create(
       :offender_sar_case, :closed, :with_retention_schedule,
-      planned_destruction_date: Date.tomorrow
+      planned_destruction_date: Date.new(2024, 12, 18)
     )
   }
 
   let(:retention_schedule) { case_with_rrd.retention_schedule }
 
-  # TODO: implement proper access control and add tests here when ready.
+  before do
+    tur = TeamsUsersRole.new(
+      team_id: admin_team.id,
+      user_id: branston_team_admin_user.id,
+      role: 'team_admin'
+    )
+
+    branston_team_admin_user.team_roles << tur
+  end
 
   describe '#edit' do
     context 'when user has access' do
       before do
-        sign_in team_admin
+        sign_in branston_team_admin_user
       end
 
       it 'builds the form object and renders the view' do
@@ -37,12 +48,25 @@ RSpec.describe RetentionSchedulesController, type: :controller do
         end
       end
     end
+
+    context 'when user has no access' do
+      before do
+        sign_in branston_user
+      end
+
+      it 'is not authorised' do
+        get :edit, params: { id: retention_schedule.id }
+
+        expect(flash[:alert]).to eq 'You are not authorised to edit the retention details of this case.'
+        expect(response).to redirect_to root_path
+      end
+    end
   end
 
   describe '#update' do
     context 'when user has access' do
       before do
-        sign_in team_admin
+        sign_in branston_team_admin_user
       end
 
       context 'when the update was successful' do
@@ -59,6 +83,9 @@ RSpec.describe RetentionSchedulesController, type: :controller do
 
           expect(retention_schedule.reload.review?).to eq(true)
           expect(retention_schedule.reload.planned_destruction_date).to eq(Date.new(2050, 12, 31))
+
+          last_history_message = case_with_rrd.transitions.case_history.last.message
+          expect(last_history_message).to eq("Retention status changed from Not set to Review\nDestruction date changed from 18-12-2024 to 31-12-2050\n")
 
           expect(flash[:notice]).to eq('Retention details successfully updated')
           expect(response).to redirect_to(case_path(case_with_rrd))
@@ -82,6 +109,19 @@ RSpec.describe RetentionSchedulesController, type: :controller do
             patch :update, params: { id: 12345 }
           }.to raise_exception(ActiveRecord::RecordNotFound)
         end
+      end
+    end
+
+    context 'when user has no access' do
+      before do
+        sign_in branston_user
+      end
+
+      it 'is not authorised' do
+        patch :update, params: { id: retention_schedule.id }
+
+        expect(flash[:alert]).to eq 'You are not authorised to edit the retention details of this case.'
+        expect(response).to redirect_to root_path
       end
     end
   end

--- a/spec/forms/retention_schedule_form_spec.rb
+++ b/spec/forms/retention_schedule_form_spec.rb
@@ -11,7 +11,13 @@ RSpec.describe RetentionScheduleForm do
   end
 
   describe 'logic specific to this form' do
-    let(:record) { double('Record', case: case_double, not_set?: schedule_not_set) }
+    let(:record) {
+      double('Record',
+             case: case_double,
+             not_set?: schedule_not_set,
+             human_state: 'Not set',
+             planned_destruction_date: planned_destruction_date)
+    }
     let(:case_double) { double(Case::Base, date_responded: Date.today) }
 
     let(:planned_destruction_date) { Date.tomorrow }
@@ -114,6 +120,15 @@ RSpec.describe RetentionScheduleForm do
           ).and_return(true)
 
           expect(subject.save).to be(true)
+        end
+
+        it 'saves the previous attribute values for later inspection' do
+          expect(record).to receive(:update).and_return(true)
+          expect(subject.save).to be(true)
+
+          expect(
+            subject.previous_values
+          ).to eq({date: planned_destruction_date, state: 'Not set'})
         end
       end
     end


### PR DESCRIPTION
## Description
Follow-up to PRs #2021 and #2023.

Implements the permissions mechanism to ensure only Branston team admins can manipulate the retention details.

Note: I presume the bulk action should also have some kind of check but I've left that out for now.

Also in this PR after a successful retention update, a note will be added to the case message history with what was changed (previous value and new values). A further refinement might be if nothing has changed, do not add a history message but that is a minor thing that can wait.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="809" alt="Screenshot 2022-06-15 at 17 28 56" src="https://user-images.githubusercontent.com/687910/173878515-278e3ad6-b0e3-4cfa-b291-a06db66c1881.png">

<img width="1033" alt="Screenshot 2022-06-15 at 17 29 34" src="https://user-images.githubusercontent.com/687910/173878626-e4642297-b8a7-46d6-922b-05ea6efee37c.png">


### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Check you can see the Change link and access the link with a team admin and you can't if you are not a team admin.
Change something (or just click continue really) and check the new message in the case history.
