### PR TITLE
Refactor the retention schedule case notes

### DIFF
--- a/app/forms/retention_schedule_form.rb
+++ b/app/forms/retention_schedule_form.rb
@@ -4,9 +4,6 @@ class RetentionScheduleForm < BaseFormObject
   attribute :planned_destruction_date, :date
   attribute :state, :string
 
-  # Transient attribute used for the case history log
-  attr_reader :previous_values
-
   acts_as_gov_uk_date :planned_destruction_date
 
   validates_presence_of :planned_destruction_date
@@ -19,15 +16,6 @@ class RetentionScheduleForm < BaseFormObject
   end
 
   private
-
-  def persist!
-    @previous_values = {
-      state: record.human_state,
-      date:  record.planned_destruction_date
-    }
-
-    super
-  end
 
   # If the retention schedule has progressed already to any state other than the
   # initial `not_set`, we don't allow reverting back to the initial state, so we

--- a/app/presenters/retention_schedule_case_note.rb
+++ b/app/presenters/retention_schedule_case_note.rb
@@ -1,0 +1,74 @@
+class RetentionScheduleCaseNote
+  attr_accessor :kase, :user, :changes
+
+  class AttrChange
+    attr_accessor :from, :to
+
+    def initialize(changes)
+      @from, @to = changes.dig(self.class::ATTR_NAME)
+    end
+
+    def blank?
+      @from.blank? && @to.blank?
+    end
+
+    def to_s
+      I18n.t(
+        self.class::ATTR_NAME, scope: scope, from: from, to: to
+      ) unless blank?
+    end
+
+    def scope
+      [:retention_schedule_case_notes, :changes]
+    end
+  end
+
+  class StateChange < AttrChange
+    ATTR_NAME = :state
+
+    def from; I18n.t(@from, scope: 'dictionary.retention_schedule_states'); end
+    def to; I18n.t(@to, scope: 'dictionary.retention_schedule_states'); end
+  end
+
+  class DateChange < AttrChange
+    ATTR_NAME = :planned_destruction_date
+
+    def from; I18n.l(@from, format: :compact); end
+    def to; I18n.l(@to, format: :compact); end
+  end
+
+  def initialize(kase:, user:, changes:)
+    @kase = kase
+    @user = user
+    @changes = changes
+
+    add_note_to_case!
+  end
+  private_class_method :new
+
+  def self.log!(**args)
+    new(args)
+  end
+
+  private
+
+  def add_note_to_case!
+    return if changes.empty?
+
+    @kase.state_machine.add_note_to_case!(
+      acting_user: @user,
+      acting_team: @user.case_team(@kase),
+      message: message
+    )
+  end
+
+  def message
+    state_change = StateChange.new(changes)
+    date_change  = DateChange.new(changes)
+
+    [
+      state_change,
+      date_change,
+    ].compact_blank.join("\n")
+  end
+end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -118,6 +118,8 @@ ignore_unused:
   - 'teams.business_group_detail.destroy'
   - 'teams.directorate_detail.destroy'
   - 'teams.business_unit_detail.destroy'
+  - 'dictionary.retention_schedule_states.*'
+  - 'retention_schedule_case_notes.changes.*'
   - users.show.heading_all_cases
   - users.show.heading_my_cases
   - users.show.message_notification

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,14 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  dictionary:
+    retention_schedule_states: &retention_schedule_states
+      not_set: Not set
+      retain: Retain
+      review: Review
+      to_be_anonymised: Destroy
+      anonymised: Anonymised
+
   activerecord:
     attributes:
       business_unit:
@@ -891,10 +899,7 @@ en:
         overturned_foi: Overturned FOI
       retention_schedule_form:
         state:
-          not_set: Not set
-          retain: Retain
-          review: Review
-          to_be_anonymised: Destroy
+          <<: *retention_schedule_states
     links:
       case_details:
         edit_case: 'Edit case details'
@@ -1644,9 +1649,6 @@ en:
     update:
       flash:
         success: Retention details successfully updated
-      case_note_html: |
-        Retention status changed from %{state_from} to %{state_to}
-        Destruction date changed from %{date_from} to %{date_to}
 
   users:
     new:

--- a/config/locales/event.en.yml
+++ b/config/locales/event.en.yml
@@ -78,3 +78,8 @@ en:
     require_further_action_desc: Further information requested by the ICO
     require_further_action_unassigned_desc: Further information requested by the ICO
     require_further_action_to_responder_team_desc: Further information requested by the ICO
+
+  retention_schedule_case_notes:
+    changes:
+      state: Retention status changed from %{from} to %{to}
+      planned_destruction_date: Destruction date changed from %{from} to %{to}

--- a/spec/controllers/retention_schedules_controller_spec.rb
+++ b/spec/controllers/retention_schedules_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe RetentionSchedulesController, type: :controller do
           expect(retention_schedule.reload.planned_destruction_date).to eq(Date.new(2050, 12, 31))
 
           last_history_message = case_with_rrd.transitions.case_history.last.message
-          expect(last_history_message).to eq("Retention status changed from Not set to Review\nDestruction date changed from 18-12-2024 to 31-12-2050\n")
+          expect(last_history_message).to eq("Retention status changed from Not set to Review\nDestruction date changed from 18-12-2024 to 31-12-2050")
 
           expect(flash[:notice]).to eq('Retention details successfully updated')
           expect(response).to redirect_to(case_path(case_with_rrd))

--- a/spec/forms/retention_schedule_form_spec.rb
+++ b/spec/forms/retention_schedule_form_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe RetentionScheduleForm do
     let(:record) {
       double('Record',
              case: case_double,
-             not_set?: schedule_not_set,
-             human_state: 'Not set',
-             planned_destruction_date: planned_destruction_date)
+             not_set?: schedule_not_set)
     }
     let(:case_double) { double(Case::Base, date_responded: Date.today) }
 
@@ -120,15 +118,6 @@ RSpec.describe RetentionScheduleForm do
           ).and_return(true)
 
           expect(subject.save).to be(true)
-        end
-
-        it 'saves the previous attribute values for later inspection' do
-          expect(record).to receive(:update).and_return(true)
-          expect(subject.save).to be(true)
-
-          expect(
-            subject.previous_values
-          ).to eq({date: planned_destruction_date, state: 'Not set'})
         end
       end
     end

--- a/spec/presenters/retention_schedule_case_note_spec.rb
+++ b/spec/presenters/retention_schedule_case_note_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+RSpec.describe RetentionScheduleCaseNote do
+  subject { described_class }
+
+  describe '.new' do
+    it 'is a private method' do
+      expect(subject.respond_to?(:new)).to eq(false)
+    end
+  end
+
+  describe '.log!' do
+    let(:kase) { instance_double(Case::Base, state_machine: sm_double) }
+    let(:user) { instance_double(User) }
+    let(:team) { 'Team XYZ' }
+
+    let(:sm_double) { double('StateMachine') }
+    let(:args) { { kase: kase, user: user, changes: changes } }
+
+    before do
+      allow(user).to receive(:case_team).and_return(team)
+    end
+
+    context 'when there are no changes' do
+      let(:changes) { {} }
+
+      it 'does not write anything to the case history' do
+        expect(sm_double).not_to receive(:add_note_to_case!)
+        subject.log!(args)
+      end
+    end
+
+    context 'when there are changes only in the `state` attribute' do
+      let(:changes) { { state: [:not_set, :review] } }
+
+      it 'writes the change to the case history' do
+        expect(
+          sm_double
+        ).to receive(:add_note_to_case!).with(
+          acting_user: user, acting_team: team,
+          message: 'Retention status changed from Not set to Review'
+        )
+
+        subject.log!(args)
+      end
+    end
+
+    context 'when there are changes only in the `planned_destruction_date` attribute' do
+      let(:changes) { { planned_destruction_date: [Date.new(2018,10,25), Date.new(2025,12,31)] } }
+
+      it 'writes the change to the case history' do
+        expect(
+          sm_double
+        ).to receive(:add_note_to_case!).with(
+          acting_user: user, acting_team: team,
+          message: 'Destruction date changed from 25-10-2018 to 31-12-2025'
+        )
+
+        subject.log!(args)
+      end
+    end
+
+    context 'when there are changes in both attributes' do
+      let(:changes) { { state: [:not_set, :review], planned_destruction_date: [Date.new(2018,10,25), Date.new(2025,12,31)] } }
+
+      it 'writes the change to the case history' do
+        expect(
+          sm_double
+        ).to receive(:add_note_to_case!).with(
+          acting_user: user, acting_team: team,
+          message: "Retention status changed from Not set to Review\nDestruction date changed from 25-10-2018 to 31-12-2025"
+        )
+
+        subject.log!(args)
+      end
+    end
+  end
+end

--- a/spec/services/retention_schedules_update_service_spec.rb
+++ b/spec/services/retention_schedules_update_service_spec.rb
@@ -75,7 +75,7 @@ describe RetentionSchedulesUpdateService do
                           .last
                           .message
 
-      expected_message = "Case RRD status updated from Review to Destroy" 
+      expected_message = "Retention status changed from Review to Destroy"
       expect(history_message).to eq(expected_message)
     end
   end


### PR DESCRIPTION
## Description
As part of some previous PRs, we now have 2 places where we add retention schedule notes to the case history, and these messages relate to the same so we can unify and make the code nicer with a little presenter.

This presenter also handles the logic for which message (if any) to add to the history, as it can be only the `state` was changed but not the `planned_destruction_date` or the opposite, or even no changes at all.

This is done out of the box with ActiveRecord Dirty (`model.saved_changes` returns a map of the changes if any).

The presenter will also localise the date and translate the state. All quite easy to tweak if we want any different message in the future or even more attributes.

Note: this same mechanism can be applied to similar use-cases in the future. For now as we only use this for one note type (retention schedules) I've put everything in a class, but it has already almost the structure to use inheritance or some concern to be used for other kind of annotations based on attribute changes.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="1075" alt="Screenshot 2022-06-16 at 15 34 54" src="https://user-images.githubusercontent.com/687910/174094067-dea1b32a-7915-4f97-97b5-bfe16cd54cf1.png">


### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Change some case retention schedules via the UI, in the RRD tabs or edit a retention schedule via their "Change" link, and observe the case message(s) being added depending on what you change.
