### PR TITLE
CT-4222 Add 'Destroy' to GDPR Status Filter

### DIFF
--- a/app/services/case_filter/case_retention_state_filter.rb
+++ b/app/services/case_filter/case_retention_state_filter.rb
@@ -26,12 +26,11 @@ module CaseFilter
       RetentionSchedule.states_map.except(*excluded_states).stringify_keys
     end
 
-    # No need to show checkboxes for `to_be_destroyed` and `destroyed`, as cases
-    # with these retention states will not show in the tab where this filter is applied.
+    # No need to show checkbox for state `anonymised`, as these cases
+    # will not show in the tab where this filter is applied.
     def excluded_states
       [
-        RetentionSchedule::STATE_TO_BE_ANONYMISED,
-        RetentionSchedule::STATE_ANONYMISED
+        RetentionSchedule::STATE_ANONYMISED,
       ]
     end
   end

--- a/spec/services/case_filter/case_retention_state_filter_spec.rb
+++ b/spec/services/case_filter/case_retention_state_filter_spec.rb
@@ -22,7 +22,7 @@ describe CaseFilter::CaseRetentionStateFilter do
     it 'contains the choices for the filter' do
       expect(
         filter.available_choices
-      ).to eq({ filter_retention_state: {'not_set' => 'Not set', 'retain' => 'Retain', 'review' => 'Review'} })
+      ).to eq({ filter_retention_state: {'not_set' => 'Not set', 'retain' => 'Retain', 'review' => 'Review', 'to_be_anonymised' => 'Destroy'} })
     end
   end
 


### PR DESCRIPTION
## Description
On the ‘Pending Removal tab’ within the Filter by GDPR RRD status add the status of ‘Destroy’, so that the user can also filter for cases that are marked as Destroy on the Pending Removal tab.

This tab can contain cases in this state so it makes sense to allow this filter.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="1034" alt="Screenshot 2022-06-17 at 10 46 36" src="https://user-images.githubusercontent.com/687910/174273792-52a6804c-1547-4c26-92d1-c5243f9e2acf.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4132
https://dsdmoj.atlassian.net/browse/CT-4222

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to the ‘Pending Removal tab’ and within the Filter by GDPR RRD status you should see the "Destroy" checkbox.
