### PR TITLE
CT-4219 After retention destroy case is read only

### DIFF
--- a/app/forms/retention_schedule_form.rb
+++ b/app/forms/retention_schedule_form.rb
@@ -10,6 +10,7 @@ class RetentionScheduleForm < BaseFormObject
   validate :destruction_date_after_close_date, if: :planned_destruction_date
 
   validates_inclusion_of :state, in: :state_choices
+  validate :state_is_not_anonymised
 
   def state_choices
     allowed_states.map(&:to_s)
@@ -29,6 +30,12 @@ class RetentionScheduleForm < BaseFormObject
       states.delete(RetentionSchedule::STATE_ANONYMISED)
       states.delete(RetentionSchedule::STATE_NOT_SET) unless record.not_set?
     end
+  end
+
+  # If the case has been anonymised, we can't go back to any previous state.
+  # Although change links will be disabled, a malicious request could be crafted.
+  def state_is_not_anonymised
+    errors.add(:state, :forbidden) if record.anonymised?
   end
 
   def destruction_date_after_close_date

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -457,6 +457,12 @@ class Case::Base < ApplicationRecord
     raise NotImplementedError.new('Case type must implement self.factory')
   end
 
+  # Once a case has been anonymised we forbid any further updates.
+  # Note destroy/delete will still work.
+  def readonly?
+    closed? && !!retention_schedule.try(:anonymised?)
+  end
+
   def to_csv
     CSVExporter.new(self).to_csv
   end

--- a/app/services/retention_schedules/anonymise_case_service.rb
+++ b/app/services/retention_schedules/anonymise_case_service.rb
@@ -73,10 +73,8 @@ module RetentionSchedules
         anonymise_core_case_fields
         anonymise_case_notes
         anonymise_cases_data_requests_notes
-        update_cases_retention_schedule_state
         destroy_case_versions
-      
-        @kase.save
+        update_cases_retention_schedule_state
       end
     end
 
@@ -115,10 +113,7 @@ module RetentionSchedules
     end
 
     def update_cases_retention_schedule_state
-      retention_schedule = @kase.retention_schedule
-      retention_schedule.anonymise!
-      retention_schedule.erasure_date = Date.today
-      retention_schedule.save
+      @kase.retention_schedule.anonymise!
     end
 
     def destroy_case_versions

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -377,6 +377,7 @@ en:
               before_closure: must be after case closed date
             state:
               inclusion: is not a valid status
+              forbidden: cannot be changed once case is anonymised
 
   pundit:
     assignment_policy:

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -1695,4 +1695,47 @@ RSpec.describe Case::Base, type: :model do
     end
   end
 
+  describe '#readonly?' do
+    let(:retention_schedule) { nil }
+
+    context 'for a closed case' do
+      context 'with retention schedule' do
+        let(:retention_schedule) { double(RetentionSchedule, anonymised?: anonymised) }
+
+        before do
+          allow(closed_case).to receive(:retention_schedule).and_return(retention_schedule)
+        end
+
+        context 'anonymised state' do
+          let(:anonymised) { true }
+
+          it 'returns false' do
+            expect(closed_case.readonly?).to eq(true)
+          end
+        end
+
+        context 'not anonymised state' do
+          let(:anonymised) { false }
+
+          it 'returns false' do
+            expect(closed_case.readonly?).to eq(false)
+          end
+        end
+      end
+
+      context 'without retention schedule' do
+        it 'returns false' do
+          expect(closed_case.readonly?).to eq(false)
+        end
+      end
+    end
+
+    context 'for a non-closed case' do
+      let(:closed) { false }
+
+      it 'returns false' do
+        expect(assigned_case.readonly?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
Once a case has become anonymised, the case should be made read-only to prevent users from making any changes and adding any Personal Identifiable Information in the future.

To know if a case has been anonymised we check their retention schedule.

In addition, although there will be no UI for this, added an extra validation to the `RetentionScheduleForm` so it is not possible to change the `state` once it has reached the `anonymised` state.

This is a PR for the backend changes. In a follow-up PR the UI changes will be implemented (mainly, hiding the change links, etc.)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="833" alt="Screenshot 2022-06-20 at 09 48 50" src="https://user-images.githubusercontent.com/687910/174563442-eaa0249d-7e6e-4b29-91de-8acc2e6ba6c5.png">


### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Anonymise a case and once done, try to update any of their details. You can't.