### PR TITLE
CT-4228 Add legends to all date fields

### DIFF
--- a/app/views/admin/cases/ico/_new.html.slim
+++ b/app/views/admin/cases/ico/_new.html.slim
@@ -9,7 +9,7 @@
 
   .form-group
     = f.gov_uk_date_field :received_date, { legend_text: t('cases.new.received_date'),
-                                            form_hint_text: t('cases.new.received_date_copy'),
+                                            form_hint_text: t('helpers.hint.shared.date_example'),
                                             today_button: {class: ''} }
 
   .form-group

--- a/app/views/admin/cases/overturned_foi/_new.html.slim
+++ b/app/views/admin/cases/overturned_foi/_new.html.slim
@@ -5,7 +5,7 @@
   .form-group
     = f.gov_uk_date_field :received_date,
                           { legend_text: t('cases.new.received_date'),
-                            form_hint_text: t('cases.new.received_date_copy'),
+                            form_hint_text: t('helpers.hint.shared.date_example'),
                             today_button: {class: ''} }
   .form-group
     = f.gov_uk_date_field :external_deadline,

--- a/app/views/admin/cases/overturned_sar/_new.html.slim
+++ b/app/views/admin/cases/overturned_sar/_new.html.slim
@@ -5,7 +5,7 @@
   .form-group
     = f.gov_uk_date_field :received_date,
                           { legend_text: t('cases.new.received_date'),
-                            form_hint_text: t('cases.new.received_date_copy'),
+                            form_hint_text: t('helpers.hint.shared.date_example'),
                             today_button: {class: ''} }
   .form-group
     = f.gov_uk_date_field :external_deadline,

--- a/app/views/cases/closable/respond.html.slim
+++ b/app/views/cases/closable/respond.html.slim
@@ -23,7 +23,7 @@
     .form-group
       = f.gov_uk_date_field :date_responded,
               {legend_text: translate_for_case(@case, 'cases.respond', 'respond_date'),
-                      form_hint_text: t('.date_example'),
+                      form_hint_text: t('helpers.hint.shared.date_example'),
                       today_button: {class: ''} }
 
     - if @case.foi?

--- a/app/views/cases/data_requests/_form.html.slim
+++ b/app/views/cases/data_requests/_form.html.slim
@@ -25,7 +25,7 @@
 
       = f.gov_uk_date_field :date_requested, { \
         legend_text: 'Date requested',
-        form_hint_text: t('cases.new.date_sar_request_copy'),
+        form_hint_text: t('helpers.hint.shared.date_example'),
         today_button: { class: '' } \
       }
 
@@ -50,7 +50,7 @@
 
         = f.gov_uk_date_field :cached_date_received, { \
           legend_text: 'Date when data request is complete',
-          form_hint_text: t('cases.new.date_sar_received_copy'),
+          form_hint_text: t('helpers.hint.shared.date_example'),
           today_button: { class: '' } \
         }
 

--- a/app/views/cases/foi/_close_form.html.slim
+++ b/app/views/cases/foi/_close_form.html.slim
@@ -7,7 +7,7 @@
 = form_for @case, as: :foi, url: url do |f|
   .form-group
     = f.gov_uk_date_field :date_responded, { legend_text: t('cases.foi.close_form.close_date'),
-            form_hint_text: t('cases.foi.close_form.date_example'),
+            form_hint_text: t('helpers.hint.shared.date_example'),
             today_button: {class: ''} }
 
   - if @case.responded_late?

--- a/app/views/cases/foi/_edit_form_details.html.slim
+++ b/app/views/cases/foi/_edit_form_details.html.slim
@@ -12,5 +12,5 @@
   #date-draft-compliant
     = f.gov_uk_date_field :date_draft_compliant,
             {legend_text: t('cases.edit.date_draft_compliant'),
-                    form_hint_text: t('cases.edit.date_draft_compliant_example'),
+                    form_hint_text: t('helpers.hint.shared.date_example'),
                     today_button: {class: ''} }

--- a/app/views/cases/foi/_new_form_common.html.slim
+++ b/app/views/cases/foi/_new_form_common.html.slim
@@ -10,5 +10,5 @@
 .form-group
   = f.gov_uk_date_field :received_date,
           {legend_text: t('cases.new.received_date'),
-                  form_hint_text: t('cases.new.received_date_copy'),
+                  form_hint_text: t('helpers.hint.shared.date_example'),
                   today_button: {class: ''} }

--- a/app/views/cases/ico/_close_form.html.slim
+++ b/app/views/cases/ico/_close_form.html.slim
@@ -7,7 +7,7 @@
 
   .form-group
     = f.gov_uk_date_field :date_ico_decision_received, { legend_text: t('.date_ico_decision_received_date'),
-            form_hint_text: t('.date_example'),
+            form_hint_text: t('helpers.hint.shared.date_example'),
             today_button: {class: ''} }
 
   - if @case.respond_to?(:ico_decision) && @case.ico_decision.present?

--- a/app/views/cases/ico/_form.html.slim
+++ b/app/views/cases/ico/_form.html.slim
@@ -7,7 +7,7 @@
 
 .form-group
   = f.gov_uk_date_field :received_date, { legend_text: t('cases.new.received_date'),
-                                          form_hint_text: t('cases.new.received_date_copy'),
+                                          form_hint_text: t('helpers.hint.shared.date_example'),
                                           today_button: {class: ''} }
 
 .form-group
@@ -40,5 +40,5 @@
  #date-draft-compliant
    = f.gov_uk_date_field :date_draft_compliant,
            {legend_text: t('cases.edit.date_draft_compliant'),
-                   form_hint_text: t('cases.edit.date_draft_compliant_example'),
+                   form_hint_text: t('helpers.hint.shared.date_example'),
                    today_button: {class: ''} }

--- a/app/views/cases/ico_foi/require_further_action.html.slim
+++ b/app/views/cases/ico_foi/require_further_action.html.slim
@@ -20,11 +20,11 @@ div class="case-#{@correspondence_type_key}"
 = form_for @case, as: :"#{@correspondence_type_key}", url: require_further_action_case_ico_foi_path(@case) do |f|
   .form-group
     = f.gov_uk_date_field :internal_deadline, { legend_text: t('cases.ico_foi.extend_internal_deadline'),
-            form_hint_text: t('cases.shared.date_responded_form.date_example'),
+            form_hint_text: t('helpers.hint.shared.date_example'),
             today_button: {class: ''} }
     br
     = f.gov_uk_date_field :external_deadline, { legend_text: t('cases.ico_foi.extend_external_deadline'),
-            form_hint_text: t('cases.shared.date_responded_form.date_example'),
+            form_hint_text: t('helpers.hint.shared.date_example'),
             today_button: {class: ''} }
 
   = f.submit 'Continue', {class: 'button'}

--- a/app/views/cases/offender_sar/_date_received_step.html.slim
+++ b/app/views/cases/offender_sar/_date_received_step.html.slim
@@ -10,8 +10,8 @@
 
   .form-group
     = f.gov_uk_date_field :received_date, { \
-        legend_text: '',
-        form_hint_text: t('cases.new.date_sar_received_copy'),
+        legend_text: t('cases.new.date_offender_sar_received_legend'),
+        form_hint_text: t('helpers.hint.shared.date_example'),
         today_button: { class: '' } \
       }
 

--- a/app/views/cases/offender_sar/_date_responded_step.html.slim
+++ b/app/views/cases/offender_sar/_date_responded_step.html.slim
@@ -18,7 +18,7 @@ div class="case-#{@correspondence_type_key}"
   = form_for @case, url: case_sar_offender_path(@case), as: :offender_sar do |f|
     .form-group
         = f.gov_uk_date_field :date_responded, { legend_text: t('cases.shared.date_responded_form.close_date'),
-                form_hint_text: t('cases.shared.date_responded_form.date_example'),
+                form_hint_text: t('helpers.hint.shared.date_example'),
                 today_button: {class: ''} }
 
     input name="current_step" type="hidden" value=@case.current_step

--- a/app/views/cases/offender_sar/_partial_case_flags_step.html.slim
+++ b/app/views/cases/offender_sar/_partial_case_flags_step.html.slim
@@ -20,7 +20,7 @@
   div id="partial_case_info_panel"
     = f.gov_uk_date_field :partial_case_letter_sent_dated, { \
         legend_text: t('helpers.label.offender_sar.partial_case_letter_sent_dated'),
-        form_hint_text: t('helpers.hint.offender_sar.partial_case_letter_sent_dated'),
+        form_hint_text: t('helpers.hint.shared.date_example'),
         today_button: { class: '' } \
       }
 

--- a/app/views/cases/offender_sar/_request_details_step.html.slim
+++ b/app/views/cases/offender_sar/_request_details_step.html.slim
@@ -11,8 +11,8 @@
   .form-group
 
     = f.gov_uk_date_field :request_dated, { \
-        legend_text: '',
-        form_hint_text: t('cases.new.date_request_received_copy'),
+        legend_text: t('cases.new.request_dated_legend'),
+        form_hint_text: t('helpers.hint.shared.date_example'),
         today_button: { class: '' } \
       }
 

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -20,7 +20,7 @@
   = f.text_field :case_reference_number
 
   = f.gov_uk_date_field :date_of_birth, { legend_text: t('cases.new.date_of_birth'),
-    form_hint_text: t('cases.new.date_of_birth_copy') }
+    form_hint_text: t('helpers.hint.shared.date_example') }
 
   = f.radio_button_fieldset :subject_type,
     choices: Case::SAR::Offender::subject_types.keys

--- a/app/views/cases/offender_sar_complaint/_date_received_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_date_received_step.html.slim
@@ -10,8 +10,8 @@
 
   .form-group
     = f.gov_uk_date_field :received_date, { \
-        legend_text: '',
-        form_hint_text: t('cases.new.date_sar_received_copy'),
+        legend_text: t('cases.new.date_sar_received_legend'),
+        form_hint_text: t('helpers.hint.shared.date_example'),
         today_button: { class: '' } \
       }
 

--- a/app/views/cases/offender_sar_complaint/_date_responded_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_date_responded_step.html.slim
@@ -18,7 +18,7 @@ div class="case-#{@correspondence_type_key}"
   = form_for @case, url: case_sar_offender_complaint_path(@case), as: :offender_sar_complaint do |f|
     .form-group
         = f.gov_uk_date_field :date_responded, { legend_text: t('cases.shared.date_responded_form.close_date'),
-                form_hint_text: t('cases.shared.date_responded_form.date_example'),
+                form_hint_text: t('helpers.hint.shared.date_example'),
                 today_button: {class: ''} }
 
     = f.submit 'Continue', {class: 'button'}

--- a/app/views/cases/offender_sar_complaint/_request_details_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_request_details_step.html.slim
@@ -11,8 +11,8 @@
   .form-group
 
     = f.gov_uk_date_field :request_dated, { \
-        legend_text: '',
-        form_hint_text: t('cases.new.date_request_received_copy'),
+        legend_text: t('cases.new.complaint_request_dated_legend'),
+        form_hint_text: t('helpers.hint.shared.date_example'),
         today_button: { class: '' } \
       }
 

--- a/app/views/cases/offender_sar_complaint/_set_deadline_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_set_deadline_step.html.slim
@@ -11,7 +11,7 @@
   .form-group
     = f.gov_uk_date_field :external_deadline, { \
         legend_text: t('common.case.external_deadline'),
-        form_hint_text: t('cases.new.date_complaint_external_deadline'),
+        form_hint_text: t('helpers.hint.shared.date_example'),
         today_button: { class: '' } \
       }
 

--- a/app/views/cases/offender_sar_complaint/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar_complaint/_subject_details_step.html.slim
@@ -20,7 +20,7 @@
   = f.text_field :case_reference_number
 
   = f.gov_uk_date_field :date_of_birth, { legend_text: t('cases.new.date_of_birth'),
-    form_hint_text: t('cases.new.date_of_birth_copy') }
+    form_hint_text: t('helpers.hint.shared.date_example') }
 
   = f.radio_button_fieldset :subject_type,
     choices: Case::SAR::Offender::subject_types.keys

--- a/app/views/cases/offender_sar_complaint/reopen.html.slim
+++ b/app/views/cases/offender_sar_complaint/reopen.html.slim
@@ -8,7 +8,7 @@
   .form-group
     = f.gov_uk_date_field :external_deadline, { \
         legend_text: t('common.case.external_deadline'),
-        form_hint_text: t('cases.new.date_complaint_external_deadline'),
+        form_hint_text: t('helpers.hint.shared.date_example'),
         today_button: { class: '' } \
       }
 

--- a/app/views/cases/overturned_shared/_new_form.html.slim
+++ b/app/views/cases/overturned_shared/_new_form.html.slim
@@ -16,7 +16,7 @@ hr
 .form-group
   = f.gov_uk_date_field :external_deadline,
                         { legend_text: "Final deadline" ,
-                          form_hint_text: "For example, 01 02 2018" }
+                          form_hint_text: t('helpers.hint.shared.date_example') }
   p
     .form-hint
       | The draft deadline will be set to 20 working days before the final deadline.

--- a/app/views/cases/sar/_close_form.html.slim
+++ b/app/views/cases/sar/_close_form.html.slim
@@ -3,7 +3,7 @@
 = form_for @case, as: :sar, url: url do |f|
   .form-group
     = f.gov_uk_date_field :date_responded, { legend_text: t('cases.sar.close_form.close_date'),
-            form_hint_text: t('cases.sar.close_form.date_example'),
+            form_hint_text: t('helpers.hint.shared.date_example'),
             today_button: {class: ''} }
 
   .missing-info

--- a/app/views/cases/sar/_new_form_common.html.slim
+++ b/app/views/cases/sar/_new_form_common.html.slim
@@ -19,7 +19,7 @@ section
   .form-group
     = f.gov_uk_date_field :received_date,
             {legend_text: t('cases.new.received_date'),
-                    form_hint_text: t('cases.new.received_date_copy'),
+                    form_hint_text: t('helpers.hint.shared.date_example'),
                     today_button: {class: ''} }
 
 
@@ -57,5 +57,5 @@ section
    #date-draft-compliant
      = f.gov_uk_date_field :date_draft_compliant,
              {legend_text: t('cases.edit.date_draft_compliant'),
-                     form_hint_text: t('cases.edit.date_draft_compliant_example'),
+                     form_hint_text: t('helpers.hint.shared.date_example'),
                      today_button: {class: ''} }

--- a/app/views/cases/sar_internal_review/_close_form.html.slim
+++ b/app/views/cases/sar_internal_review/_close_form.html.slim
@@ -2,7 +2,7 @@
 = form_for @case, as: :sar_internal_review, url: url do |f|
   .form-group
     = f.gov_uk_date_field :date_responded, { legend_text: t('cases.sar.close_form.close_date'),
-            form_hint_text: t('cases.sar.close_form.date_example'),
+            form_hint_text: t('helpers.hint.shared.date_example'),
             today_button: {class: ''} }
 
   .js-sar-internal-review

--- a/app/views/cases/sar_internal_review/_new_form_common.html.slim
+++ b/app/views/cases/sar_internal_review/_new_form_common.html.slim
@@ -22,7 +22,7 @@ section
   .form-group
     = f.gov_uk_date_field :received_date,
             {legend_text: t('cases.new.received_date'),
-                    form_hint_text: t('cases.new.received_date_copy'),
+                    form_hint_text: t('helpers.hint.shared.date_example'),
                     today_button: {class: ''} }
 
 

--- a/app/views/cases/search_filters/_date_range.html.slim
+++ b/app/views/cases/search_filters/_date_range.html.slim
@@ -19,9 +19,9 @@ fieldset
     .form-group
       = f.gov_uk_date_field filter.class.date_from_field,
               { legend_text: t('cases.searches.show.date_from'),
-                      form_hint_text: t('cases.searches.show.date_hint') }
+                      form_hint_text: t('helpers.hint.shared.date_example') }
 
     .form-group
       = f.gov_uk_date_field filter.class.date_to_field,
               { legend_text: t('cases.searches.show.date_to'),
-                      form_hint_text: t('cases.searches.show.date_hint') }
+                      form_hint_text: t('helpers.hint.shared.date_example') }

--- a/app/views/cases/shared/_date_responded_form.html.slim
+++ b/app/views/cases/shared/_date_responded_form.html.slim
@@ -9,11 +9,11 @@
   .form-group
     - unless @case.ico?
       = f.gov_uk_date_field :date_responded, { legend_text: t('cases.shared.date_responded_form.close_date'),
-              form_hint_text: t('cases.shared.date_responded_form.date_example'),
+              form_hint_text: t('helpers.hint.shared.date_example'),
               today_button: {class: ''} }
     - else
       = f.gov_uk_date_field :date_ico_decision_received, { legend_text: t('cases.shared.date_responded_form.date_ico_decision_received_date'),
-              form_hint_text: t('cases.shared.date_responded_form.date_example'),
+              form_hint_text: t('helpers.hint.shared.date_example'),
               today_button: {class: ''} }
 
   = f.submit 'Continue', {class: 'button'}

--- a/app/views/retention_schedules/edit.html.slim
+++ b/app/views/retention_schedules/edit.html.slim
@@ -17,7 +17,7 @@
 = form_for @form_object, url: retention_schedule_path(@form_object.record), method: :put do |f|
   .form-group
     = f.gov_uk_date_field :planned_destruction_date, { \
-        legend_text: '', form_hint_text: t('cases.new.date_sar_received_copy') \
+        legend_text: t('.planned_destruction_date.legend'), form_hint_text: t('.planned_destruction_date.hint') \
       }
   .form-group
     = f.radio_button_fieldset :state, choices: @form_object.state_choices

--- a/app/views/stats/new.html.slim
+++ b/app/views/stats/new.html.slim
@@ -59,10 +59,10 @@
 
     .period-start
       = f.gov_uk_date_field :period_start, {legend_text: t('stats.common.period_start'),
-              form_hint_text: t('cases.new.received_date_copy')}
+              form_hint_text: t('helpers.hint.shared.date_example')}
 
     .period-end
       = f.gov_uk_date_field :period_end, {legend_text: t('stats.common.period_end'),
-              form_hint_text: t('cases.new.received_date_copy')}
+              form_hint_text: t('helpers.hint.shared.date_example')}
 
   = f.submit 'Create custom report', class:'button', data: { disable_with: false }

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -110,7 +110,6 @@ ignore_unused:
   - 'cases.new*.sub_heading'
   - '*.case/*'
   - 'cases.show.case.attachments_heading'
-  - 'cases.respond.respond_date'
   - 'notices.case_cleared'
   - 'common.case.request'
   - 'nav.pages.teams.*'
@@ -118,7 +117,7 @@ ignore_unused:
   - 'teams.business_group_detail.destroy'
   - 'teams.directorate_detail.destroy'
   - 'teams.business_unit_detail.destroy'
-  - 'dictionary.retention_schedule_states.*'
+  - 'dictionary.*'
   - 'retention_schedule_case_notes.changes.*'
   - users.show.heading_all_cases
   - users.show.heading_my_cases

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@
 
 en:
   dictionary:
+    date_hint_text: &date_hint_text "For example, 31 07 2019"
     retention_schedule_states: &retention_schedule_states
       not_set: Not set
       retain: Retain
@@ -585,13 +586,14 @@ en:
       retention_schedule_form:
         state: What is the retention status?
     hint:
+      shared:
+        date_example: *date_hint_text
       case:
         linked_case_number: " For example 170131001"
         upload_comment: This will be added to the converstation section of the case.
       data_request:
         location: Where is the data held?
       data_request_log:
-        date_received: For example, 31 07 2019
         num_pages: Record new total number of pages
       feedback:
         comment: |
@@ -603,8 +605,6 @@ en:
         related_case_number:  Enter related case  reference number, for example 170131001.
       offender_sar:
         case_reference_number: "You can include multiple numbers separated by a comma or a space."
-        date_of_birth: "For example, 12 11 2007"
-        partial_case_letter_sent_dated: "For example, 12 11 2007"
         message_hint: Include any details that will be useful for processing the case (optional)
         reason_for_lateness_note_hint: Please provide details to why this case is late
         number_exempt_pages: "Pages removed from the SAR as exemptions"
@@ -1200,7 +1200,6 @@ en:
         heading: Edit case closure details
         submit: Save changes
       respond:
-        date_example: For example, 30 1 2017
         case/ico:
           respond_date: Add date this response was sent to ICO
         heading: Mark as sent
@@ -1231,7 +1230,6 @@ en:
     ico:
       close_form:
         date_ico_decision_received_date: Date decision was received at MoJ
-        date_example: For example, 30 1 2017
       form:
         uploaded_request_files: Upload relevant files (optional)
     ico_foi: 
@@ -1259,7 +1257,6 @@ en:
     edit:
       heading: Edit case details
       date_draft_compliant: Date compliant draft was uploaded
-      date_draft_compliant_example: "For example, 01 02 2018"
       offender_sar:
         number_final_pages: 'Update final page count'
         number_exempt_pages: 'Update exempt pages'
@@ -1305,21 +1302,18 @@ en:
       correspondence_type_errors:
         unknown: "Unknown correspondence type \"%{type}\""
         not_authorised: "You are not authorised to create \"%{type}\" correspondences"
-      date_sar_request_copy: "For example, 12 11 2007"
-      date_sar_received_copy: "For example, 12 11 2007"
-      date_complaint_external_deadline: "For example, 12 11 2007"
-      date_request_received_copy: "For example, 12 11 2007"
+      request_dated_legend: What is the date on the request?
+      complaint_request_dated_legend: What is the date on the complaint?
+      date_sar_received_legend: When was the complaint received at MOJ?
+      date_offender_sar_received_legend: When was the SAR received?
       date_of_birth: "Date of birth"
-      date_of_birth_copy: "For example, 24 11 1992"
       external_deadline: "Final deadline"
-      external_deadline_copy: "For example, 01 02 2018"
       internal_deadline: Draft deadline
       heading: Add case details
       created_at: Created at
       created_at_copy: 'Date to use as creation date of case, ex. "Oct 2", "Oct 2, 2017", "02-10-2017", "2017-10-02 12:00:00"'
       received_date: Date received at MOJ
       received_date_short: Received date
-      received_date_copy: "For example, 01 02 2018"
       received_date_copy_long: Date correspondence was received, ex. "Oct 2", "Oct 2, 2017", "02-10-2017", "2017-10-02 12:00:00"
       only_select_one: Please only select one.
       case/ico:
@@ -1352,7 +1346,6 @@ en:
     shared:
       date_responded_form:
         close_date:  Date response sent
-        date_example: For example, 30 1 2017
         date_ico_decision_received_date: Date decision received from ICO
     show:
       case/ico:
@@ -1381,14 +1374,12 @@ en:
       case_details:
         cannot_update_closure_html: "This is an old case with closure details that cannot be edited. If you need to edit this case <a href=\"#new_feedback\">let us know</a>."
       close_form:
-        date_example: For example, 30 1 2017
         close_date:  Date response sent
       send_back_heading: 'Send case back for change'
     sar:
       new_form_common:
         dropzone: "Requestor's proof of ID and other documents"
       close_form:
-        date_example: For example, 30 1 2017
         close_date:  Date response sent
     sar_extensions:
       create:
@@ -1419,7 +1410,6 @@ en:
         heading: Search
         date_from: From
         date_to: To
-        date_hint: For example. 31 01 2017
     offender_sar:
       subject_heading: Who is the subject?
       requester_heading: Who is making the subject access request?
@@ -1647,6 +1637,9 @@ en:
       heading: What are the retention details?
       subheading: Edit retention details
       submit: Continue
+      planned_destruction_date:
+        legend: What is the destruction date?
+        hint: For example, 31 12 2026
     update:
       flash:
         success: Retention details successfully updated


### PR DESCRIPTION
## Description
As part of the QA for ticket CT-4134, it was raised some date fields didn't have a legend.

I've added it to all dates I could find that were missing them and also I've DRY all dates hint text.

There are no functional changes in this PR despite many files being changed (the partials abuse is quite bad and should require a whole refactor and DRY in itself).

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="806" alt="Screenshot 2022-06-20 at 12 14 52" src="https://user-images.githubusercontent.com/687910/174590056-5e9e9d58-40d7-46c1-96b5-427e537b2230.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4134

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to any page that contains date fields and previously didn't have legend, now they will have a proper legend. Also hint texts have been unified across the app.