### PR TITLE
Script / add schedule service amendments

### DIFF
--- a/app/services/retention_schedules/add_schedule_service.rb
+++ b/app/services/retention_schedules/add_schedule_service.rb
@@ -39,7 +39,9 @@ module RetentionSchedules
     def add_retention_schedules
       if @kase.linked_cases.present?
         add_retention_schedule
-        add_retention_schedules_to_linked_cases
+        if @kase.offender_sar_complaint?
+          add_retention_schedules_to_linked_cases
+        end
       else
         add_retention_schedule
       end


### PR DESCRIPTION
Cases that are Offender SARs don't have to add retention_schedules
their linked cases on closure closure or when the initial script runs.

This is because for Branston cases Offender SARs only link to Offender
SAR complaints and not other Offender SARs.

The script was having an issue whereby it was updating linked cases for
Offender SARs, which meant that planned destruction date for the
associated complaints was being updated to match the complaints, when it
should have been the case that the Offender SAR complaint planned destruction
dates were mirrored in their associated Offender SAR cases.

## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[CT-4229](https://dsdmoj.atlassian.net/browse/CT-4229)

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
