### PR TITLE
CT-4219 Hide change links/buttons if case is readonly

### DIFF
--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -463,6 +463,10 @@ class Case::Base < ApplicationRecord
     closed? && !!retention_schedule.try(:anonymised?)
   end
 
+  def editable?
+    !readonly?
+  end
+
   def to_csv
     CSVExporter.new(self).to_csv
   end

--- a/app/views/cases/_case_messages.html.slim
+++ b/app/views/cases/_case_messages.html.slim
@@ -8,7 +8,7 @@ h2.request--heading Conversation
     - case_details.transitions.messages.order(:id).each do |chat|
       = render partial: 'messages/message', locals: {message_event: chat, user: current_user}
 
-- if policy(case_details).can_add_message_to_case?
+- if case_details.editable? && policy(case_details).can_add_message_to_case?
   = form_for case_details, as: :case, url: case_messages_path(case_details), method: :post, class: "message-form" do |f|
     .message-form data-ws-case-id="#{case_details.id}"
       .form-group

--- a/app/views/cases/_case_request.html.slim
+++ b/app/views/cases/_case_request.html.slim
@@ -2,13 +2,13 @@
   .grid-row.section-requested-heading
       h2.request--heading
         = t4c(case_details, 'common', 'request')
-      - if case_details.offender_sar?
-        .change-link
-          = link_to t('common.links.change'), edit_step_case_sar_offender_path(case_details, "requested_info")
-
-      - if case_details.offender_sar_complaint?
-        .change-link
-          = link_to t('common.links.change'), edit_step_case_sar_offender_complaint_path(case_details, "requested_info")
+      - if case_details.editable?
+        - if case_details.offender_sar?
+          .change-link
+            = link_to t('common.links.change'), edit_step_case_sar_offender_path(case_details, "requested_info")
+        - if case_details.offender_sar_complaint?
+          .change-link
+            = link_to t('common.links.change'), edit_step_case_sar_offender_complaint_path(case_details, "requested_info")
 
   .request--message.section-requested-info
     - if case_details.message.present?

--- a/app/views/cases/offender_sar/_case_details.html.slim
+++ b/app/views/cases/offender_sar/_case_details.html.slim
@@ -39,4 +39,4 @@
 
         - if case_details.closed?
           = render partial: 'cases/shared/closed_case_details', locals: { case_details: case_details, allow_editing: allow_editing }
-          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details }
+          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details, allow_editing: allow_editing }

--- a/app/views/cases/offender_sar/_partial_case_flags.html.slim
+++ b/app/views/cases/offender_sar/_partial_case_flags.html.slim
@@ -29,5 +29,6 @@
               - if case_details.further_actions_required.present?
                 = case_details.further_actions_required.humanize
 
-.button-holder
-  = link_to I18n.t('button.update_partial_flags'), edit_step_case_sar_offender_path(case_details, "partial_case_flags"), class: 'button-tertiary'
+- if allow_editing
+  .button-holder
+    = link_to I18n.t('button.update_partial_flags'), edit_step_case_sar_offender_path(case_details, "partial_case_flags"), class: 'button-tertiary'

--- a/app/views/cases/offender_sar_complaint/_case_details.html.slim
+++ b/app/views/cases/offender_sar_complaint/_case_details.html.slim
@@ -8,39 +8,39 @@
     table
       tbody.sar-basic-details
 
-        = render partial: 'cases/shared/case_type', locals: { case_details: case_details }
+        = render partial: 'cases/shared/case_type', locals: { case_details: case_details, allow_editing: allow_editing }
 
-        = render partial: 'cases/offender_sar_complaint/subject_details', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar_complaint/subject_details', locals: { case_details: case_details, allow_editing: allow_editing }
 
-        = render partial: 'cases/offender_sar_complaint/complaint_type', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar_complaint/complaint_type', locals: { case_details: case_details, allow_editing: allow_editing }
 
-        = render partial: 'cases/offender_sar_complaint/requested_on_behalf', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar_complaint/requested_on_behalf', locals: { case_details: case_details, allow_editing: allow_editing }
 
         - if case_details.third_party?
-          = render partial: 'cases/offender_sar_complaint/third_party_details', locals: { case_details: case_details }
+          = render partial: 'cases/offender_sar_complaint/third_party_details', locals: { case_details: case_details, allow_editing: allow_editing }
 
-        = render partial: 'cases/offender_sar_complaint/request_recipient', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar_complaint/request_recipient', locals: { case_details: case_details, allow_editing: allow_editing }
 
         - if case_details.third_party_recipient?
-          = render partial: 'cases/offender_sar_complaint/third_party_details', locals: { case_details: case_details }
+          = render partial: 'cases/offender_sar_complaint/third_party_details', locals: { case_details: case_details, allow_editing: allow_editing }
 
-        = render partial: 'cases/offender_sar_complaint/request_details', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar_complaint/request_details', locals: { case_details: case_details, allow_editing: allow_editing }
 
-        = render partial: 'cases/offender_sar_complaint/date_received', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar_complaint/date_received', locals: { case_details: case_details, allow_editing: allow_editing }
 
-        = render partial: 'cases/offender_sar_complaint/case_deadlines', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar_complaint/case_deadlines', locals: { case_details: case_details, allow_editing: allow_editing }
 
         - if case_details.has_date_draft_compliant?
-          = render partial: 'cases/shared/draft_compliance_details', locals: { case_details: case_details }
+          = render partial: 'cases/shared/draft_compliance_details', locals: { case_details: case_details, allow_editing: allow_editing }
 
         - if case_details.responding_team.present?
-          = render partial: 'cases/shared/responding_team', locals: { case_details: case_details }
+          = render partial: 'cases/shared/responding_team', locals: { case_details: case_details, allow_editing: allow_editing }
 
         - if case_details.closed?
-          = render partial: 'cases/shared/closed_case_details', locals: { case_details: case_details }
-          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details }
+          = render partial: 'cases/shared/closed_case_details', locals: { case_details: case_details, allow_editing: allow_editing }
+          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details, allow_editing: allow_editing }
 
-        = render partial: 'cases/offender_sar_complaint/approval_flags_details', locals: { case_details: case_details }
-        = render partial: 'cases/offender_sar_complaint/appeal_outcome_details', locals: { case_details: case_details }
-        = render partial: 'cases/offender_sar_complaint/outcome_details', locals: { case_details: case_details }
-        = render partial: 'cases/offender_sar_complaint/costs_details', locals: { case_details: case_details }
+        = render partial: 'cases/offender_sar_complaint/approval_flags_details', locals: { case_details: case_details, allow_editing: allow_editing }
+        = render partial: 'cases/offender_sar_complaint/appeal_outcome_details', locals: { case_details: case_details, allow_editing: allow_editing }
+        = render partial: 'cases/offender_sar_complaint/outcome_details', locals: { case_details: case_details, allow_editing: allow_editing }
+        = render partial: 'cases/offender_sar_complaint/costs_details', locals: { case_details: case_details, allow_editing: allow_editing }

--- a/app/views/cases/shared/_retention_details.html.slim
+++ b/app/views/cases/shared/_retention_details.html.slim
@@ -3,7 +3,8 @@
     tr.section.planned-destruction-date
       th = t('common.case.retention_details.destruction_date')
       td = l(case_details.retention_schedule.planned_destruction_date)
-      td = (@user.team_admin? ? link_to(t('common.links.change'), edit_retention_schedule_path(case_details.retention_schedule)) : ' ')
+      - if allow_editing
+        td = (@user.team_admin? ? link_to(t('common.links.change'), edit_retention_schedule_path(case_details.retention_schedule)) : ' ')
     tr.retention-schedule-state
       th = t('common.case.retention_details.status')
       td = case_details.retention_schedule.human_state

--- a/app/views/cases/show.html.slim
+++ b/app/views/cases/show.html.slim
@@ -11,46 +11,49 @@
 
 = render partial: 'shared/components/case_page_heading', locals: {kase: @case}
 
+- allow_editing = @case.editable?
+
 div id="case-#{@correspondence_type_key}" class="case"
-  section.case-info.has-actions
-    h2.visually-hidden
-      = "Actions you can take on this case"
-    .button-holder
-      - if (@filtered_permitted_events - [:edit_case, :destroy_case]).any?
-        - if policy(@case).approve?
-          = action_button_for(:approve)
-        - if policy(@case).upload_responses?
-          = action_button_for(:add_responses)
-        - if policy(@case).upload_response_and_approve?
-          = action_button_for(:upload_response_and_approve)
-        - if policy(@case).upload_response_and_return_for_redraft?
-          = action_button_for(:upload_response_and_return_for_redraft)
+  - if allow_editing
+    section.case-info.has-actions
+      h2.visually-hidden
+        = "Actions you can take on this case"
+      .button-holder
+        - if (@filtered_permitted_events - [:edit_case, :destroy_case]).any?
+          - if policy(@case).approve?
+            = action_button_for(:approve)
+          - if policy(@case).upload_responses?
+            = action_button_for(:add_responses)
+          - if policy(@case).upload_response_and_approve?
+            = action_button_for(:upload_response_and_approve)
+          - if policy(@case).upload_response_and_return_for_redraft?
+            = action_button_for(:upload_response_and_return_for_redraft)
 
-        - if policy(@case).can_respond?
-          = action_button_for(:respond)
+          - if policy(@case).can_respond?
+            = action_button_for(:respond)
 
-        - if policy(@case).can_accept_or_reject_approver_assignment?
-          = render partial: 'cases/shared/take_case_on_or_de_escalate',
-            locals: { case_details: @case }
+          - if policy(@case).can_accept_or_reject_approver_assignment?
+            = render partial: 'cases/shared/take_case_on_or_de_escalate',
+              locals: { case_details: @case }
 
-        - permitted_events = @permitted_events - [:add_responses, :approve, :respond, :reassign_user, :upload_response_and_approve, :upload_response_and_return_for_redraft]
-        - permitted_events = permitted_events - [:mark_as_awaiting_response_for_partial_case, :mark_as_partial_case, :unmark_as_partial_case, :mark_as_further_actions_required, :unmark_as_further_actions_required]
-        - if @case.type_abbreviation.in? %w( SAR OVERTURNED_SAR )
-          - permitted_events.delete(:close)
+          - permitted_events = @permitted_events - [:add_responses, :approve, :respond, :reassign_user, :upload_response_and_approve, :upload_response_and_return_for_redraft]
+          - permitted_events = permitted_events - [:mark_as_awaiting_response_for_partial_case, :mark_as_partial_case, :unmark_as_partial_case, :mark_as_further_actions_required, :unmark_as_further_actions_required]
+          - if @case.type_abbreviation.in? %w( SAR OVERTURNED_SAR )
+            - permitted_events.delete(:close)
 
-        - permitted_events.each do |event|
-          = action_button_for(event)
+          - permitted_events.each do |event|
+            = action_button_for(event)
 
-        - if policy(@case).assignments_execute_reassign_user?
-          = action_button_for(:reassign_user)
+          - if policy(@case).assignments_execute_reassign_user?
+            = action_button_for(:reassign_user)
 
-      = action_buttons_for_allowed_events(@case, :extend_for_pit, :remove_pit_extension).join(' ').html_safe
+        = action_buttons_for_allowed_events(@case, :extend_for_pit, :remove_pit_extension).join(' ').html_safe
 
-      - if (@filtered_permitted_events - [:edit_case, :destroy_case]).any?
-        - if policy(@case).destroy_case?
-          = action_button_for_destroy_case(@case)
+        - if (@filtered_permitted_events - [:edit_case, :destroy_case]).any?
+          - if policy(@case).destroy_case?
+            = action_button_for_destroy_case(@case)
 
-        - action_button_for(:progress_for_clearance)
+          - action_button_for(:progress_for_clearance)
 
   section.case-info
     = render partial: 'cases/case_status', locals: {case_details: @case}
@@ -60,11 +63,11 @@ div id="case-#{@correspondence_type_key}" class="case"
 
   - if @case.offender_sar? && @case.closed?
     section.case-info
-      = render partial: 'cases/offender_sar/partial_case_flags', locals: {case_details: @case}
+      = render partial: 'cases/offender_sar/partial_case_flags', locals: { case_details: @case, allow_editing: allow_editing }
 
   - if @case.type_of_offender_sar?
     section.case-info
-      = render partial: 'cases/offender_sar/data_requests', locals: { case_details: @case, allow_editing: true}
+      = render partial: 'cases/offender_sar/data_requests', locals: { case_details: @case, allow_editing: allow_editing }
 
   - if FeatureSet.offender_sar_complaints.enabled? || !@case.type_of_offender_sar?
     = render partial: 'shared/components/case_linked_cases'
@@ -75,7 +78,7 @@ div id="case-#{@correspondence_type_key}" class="case"
 
   section.case-info
     = render partial: "cases/#{@case.type_abbreviation.parameterize.underscore}/case_details",
-             locals: {case_details: @case, link_type: nil, allow_editing: true}
+             locals: {case_details: @case, link_type: nil, allow_editing: allow_editing}
 
   - if !@case.type_of_offender_sar?
     section.case-info
@@ -93,7 +96,7 @@ div id="case-#{@correspondence_type_key}" class="case"
     section.case-info.has-page-break
       = render partial: 'cases/case_history', locals: { case_transitions: @case_transitions }
 
-  - if @case.type_of_offender_sar?
+  - if @case.type_of_offender_sar? && allow_editing
     section.notes-section
       = render partial: 'cases/offender_sar/case_notes', locals: { case_details: @case }
 

--- a/spec/features/cases/retention_schedules/anonymisation_spec.rb
+++ b/spec/features/cases/retention_schedules/anonymisation_spec.rb
@@ -84,6 +84,9 @@ feature 'Case retention schedules for GDPR', :js do
     expect(page).to have_content 'XXXX XXXX'
     expect(page).to have_content 'Information has been anonymised'
     expect(page).to have_content 'Anon location'
+
+    expect(page).not_to have_content 'Start complaint'
+    expect(page).not_to have_content 'Change'
   end
 
   def case_with_retention_schedule(case_type:, case_state:, rs_state:, date:)

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -1738,4 +1738,11 @@ RSpec.describe Case::Base, type: :model do
       end
     end
   end
+
+  describe '#editable?' do
+    it 'is the opposite of `readonly?` method' do
+      expect(closed_case).to receive(:readonly?).and_return(true)
+      expect(closed_case.editable?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
## Description
This is a follow-up to PR #2032 where the backend side was introduced.

In this PR we hide from the UI functionality like change links, buttons, etc. that is no longer usable once a case has been anonymised and thus is in read only mode.

I might have missed some place but it easy to fix later on. And in any case even if the user tries to update something the backend side will stop them raising an exception.

Note: I've tried to piggy-back as much as possible on the already existing `allow_editing` partial propagation. However this affects mainly the Change links, not the buttons and some other actions, so I had to add some conditionals in some other places.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="1099" alt="Screenshot 2022-06-20 at 15 45 54" src="https://user-images.githubusercontent.com/687910/174759789-753a4749-4bb8-4434-a984-7874e3137d52.png">


### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to the details page for an anonymised case, and you should not be able to execute any update action (buttons, change links, etc. are hidden from the UI).
