### PR TITLE
Make sort text for sort order reflect sort actions

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -3,8 +3,8 @@ module SearchHelper
   SEARCH_SCOPE_SET = {
     :search_result_order_by_oldest_first => { "order" => "cases.id ASC"},
     :search_result_order_by_newest_first => {"order" => "cases.received_date DESC, cases.id DESC"},
-    :search_result_order_by_oldest_destruction_date => {"order" => 'retention_schedule.planned_destruction_date DESC'},
-    :search_result_order_by_newest_destruction_date => {"order" => 'retention_schedule.planned_destruction_date ASC'},
+    :search_result_order_by_oldest_destruction_date => {"order" => 'retention_schedule.planned_destruction_date ASC'},
+    :search_result_order_by_newest_destruction_date => {"order" => 'retention_schedule.planned_destruction_date DESC'},
     :search => {"order" => nil},
   }.freeze
 

--- a/spec/features/cases/retention_schedules/interaction_spec.rb
+++ b/spec/features/cases/retention_schedules/interaction_spec.rb
@@ -176,16 +176,16 @@ feature 'Case retention schedules for GDPR', :js do
     click_on 'Show newest destruction date first'
 
     page_order_correct?(
-      not_set_timely_kase.number.to_s, 
-      retain_timely_kase.number.to_s
+      retain_timely_kase.number.to_s,
+      not_set_timely_kase.number.to_s
     )
 
     expect(page).to have_content 'Show oldest destruction date first'
 
     click_on 'Show oldest destruction date first'
     page_order_correct?(
-      retain_timely_kase.number.to_s,
-      not_set_timely_kase.number.to_s
+      not_set_timely_kase.number.to_s,
+      retain_timely_kase.number.to_s
     )
 
     Capybara.find(:css, "#retention-checkbox-#{not_set_timely_kase.id}", visible: false).set(true)


### PR DESCRIPTION
## Description
The sort text for retention schedules was the opposite to what it was meant to be, clicking:

- "Sort by oldest destruction date" - sorted by newest
- "Sort by newest destruction date - sorted by oldest

This PR makes the text reflect the action

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Related JIRA tickets
[CT-4232](https://dsdmoj.atlassian.net/browse/CT-4232)

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Click the links on the RRD page you should see the page sort correctly based on the link you just clicked.
