### PR TITLE
CT-4233 Display anonymised_at date in case details

### DIFF
--- a/app/views/cases/offender_sar/_case_details.html.slim
+++ b/app/views/cases/offender_sar/_case_details.html.slim
@@ -39,4 +39,4 @@
 
         - if case_details.closed?
           = render partial: 'cases/shared/closed_case_details', locals: { case_details: case_details, allow_editing: allow_editing }
-          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details, allow_editing: allow_editing }
+          = render partial: 'cases/shared/retention_details', locals: { retention_schedule: case_details.retention_schedule, allow_editing: allow_editing }

--- a/app/views/cases/offender_sar_complaint/_case_details.html.slim
+++ b/app/views/cases/offender_sar_complaint/_case_details.html.slim
@@ -38,7 +38,7 @@
 
         - if case_details.closed?
           = render partial: 'cases/shared/closed_case_details', locals: { case_details: case_details, allow_editing: allow_editing }
-          = render partial: 'cases/shared/retention_details', locals: { case_details: case_details, allow_editing: allow_editing }
+          = render partial: 'cases/shared/retention_details', locals: { retention_schedule: case_details.retention_schedule, allow_editing: allow_editing }
 
         = render partial: 'cases/offender_sar_complaint/approval_flags_details', locals: { case_details: case_details, allow_editing: allow_editing }
         = render partial: 'cases/offender_sar_complaint/appeal_outcome_details', locals: { case_details: case_details, allow_editing: allow_editing }

--- a/app/views/cases/shared/_retention_details.html.slim
+++ b/app/views/cases/shared/_retention_details.html.slim
@@ -1,11 +1,16 @@
-- if case_details.retention_schedule.present? && FeatureSet.branston_retention_scheduling.enabled?
+- if retention_schedule.present? && FeatureSet.branston_retention_scheduling.enabled?
   tbody.retention-details
     tr.section.planned-destruction-date
       th = t('common.case.retention_details.destruction_date')
-      td = l(case_details.retention_schedule.planned_destruction_date)
+      td = l(retention_schedule.planned_destruction_date)
       - if allow_editing
-        td = (@user.team_admin? ? link_to(t('common.links.change'), edit_retention_schedule_path(case_details.retention_schedule)) : ' ')
+        td = (@user.team_admin? ? link_to(t('common.links.change'), edit_retention_schedule_path(retention_schedule)) : ' ')
     tr.retention-schedule-state
       th = t('common.case.retention_details.status')
-      td = case_details.retention_schedule.human_state
+      td = retention_schedule.human_state
       td = ' '
+    - if retention_schedule.anonymised?
+      tr.anonymised-at-date
+        th = t('common.case.retention_details.anonymised_at')
+        td = l(retention_schedule.anonymised_at)
+        td = ' '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1004,6 +1004,7 @@ en:
       retention_details:
         destruction_date: Destruction date
         status: Retention status
+        anonymised_at: Anonymised on
       pnc_acronym_html: '<abbr title="Police national computer">PNC</abbr> number'
       postal_address: "Requester’s postal address"
       previous_case_numbers: Previous SAR cases

--- a/spec/features/cases/offender_sar/case_closing_spec.rb
+++ b/spec/features/cases/offender_sar/case_closing_spec.rb
@@ -89,6 +89,9 @@ feature 'Closing a case' do
         .to have_content('Retention status')
       expect(show_page.retention_details.retention_schedule_state.data.first.text)
         .to eq('Not set')
+
+      expect(show_page.retention_details)
+        .not_to have_content('Anonymised on')
     end
   end
 

--- a/spec/features/cases/offender_sar_complaint/case_closing_spec.rb
+++ b/spec/features/cases/offender_sar_complaint/case_closing_spec.rb
@@ -56,6 +56,8 @@ feature 'Closing a case' do
         .to have_content('Retention status')
       expect(show_page.retention_details.retention_schedule_state.data.first.text)
         .to eq('Not set')
+      expect(show_page.retention_details)
+        .not_to have_content('Anonymised on')
 
       visit("cases/#{original_case.id}")
       show_page = cases_show_page.case_details
@@ -68,6 +70,8 @@ feature 'Closing a case' do
         .to have_content('Retention status')
       expect(show_page.retention_details.retention_schedule_state.data.first.text)
         .to eq('Not set')
+      expect(show_page.retention_details)
+        .not_to have_content('Anonymised on')
 
       other_related_complaints.each do |kase|
         visit("cases/#{kase.id}")
@@ -81,6 +85,8 @@ feature 'Closing a case' do
           .to have_content('Retention status')
         expect(show_page.retention_details.retention_schedule_state.data.first.text)
           .to eq('Not set')
+        expect(show_page.retention_details)
+          .not_to have_content('Anonymised on')
       end
     end
   end

--- a/spec/features/cases/retention_schedules/anonymisation_spec.rb
+++ b/spec/features/cases/retention_schedules/anonymisation_spec.rb
@@ -86,7 +86,15 @@ feature 'Case retention schedules for GDPR', :js do
     expect(page).to have_content 'Anon location'
 
     expect(page).not_to have_content 'Start complaint'
-    expect(page).not_to have_content 'Change'
+
+    show_page = cases_show_page.case_details
+
+    expect(show_page.retention_details)
+      .not_to have_content('Change')
+    expect(show_page.retention_details.retention_schedule_state)
+      .to have_content('Retention status Anonymised')
+    expect(show_page.retention_details.anonymised_at)
+      .to have_content("Anonymised on #{I18n.l(Date.today)}")
   end
 
   def case_with_retention_schedule(case_type:, case_state:, rs_state:, date:)

--- a/spec/site_prism/page_objects/sections/cases/case_details_section.rb
+++ b/spec/site_prism/page_objects/sections/cases/case_details_section.rb
@@ -139,6 +139,10 @@ module PageObjects
           section :retention_schedule_state, '.retention-schedule-state' do
             elements :data, 'td'
           end
+
+          section :anonymised_at, '.anonymised-at-date' do
+            elements :date, 'td'
+          end
         end
 
         element :edit_case, :xpath, '//a[contains(.,"Edit case details")]'


### PR DESCRIPTION
## Description
A new “Anonymised on” field has been added to the retention details section in the “Case details” area.

This will only show if the case has been anonymised.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="1026" alt="Screenshot 2022-06-22 at 15 24 46" src="https://user-images.githubusercontent.com/687910/175063347-26e34a15-4fd8-4a3d-9ebf-ba02733426e8.png">


### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Go to an anonymised case and you should see the "Anonymised on [DATE]". If not anonymised, you will not see this. 