### PR TITLE
CT-4235 Update retention schedule case notes

### DIFF
--- a/app/models/case_transition.rb
+++ b/app/models/case_transition.rb
@@ -35,11 +35,18 @@ class CaseTransition < ApplicationRecord
   REMOVE_SAR_EXTENSION_EVENT = 'remove_sar_deadline_extension'.freeze
   ADD_MESSAGE_TO_CASE_EVENT = 'add_message_to_case'.freeze
   ADD_NOTE_TO_CASE_EVENT = 'add_note_to_case'.freeze
+  ANNOTATE_RETENTION_CHANGES = 'annotate_retention_changes'.freeze
+  ANNOTATE_SYSTEM_RETENTION_CHANGES = 'annotate_system_retention_changes'.freeze
 
   after_destroy :update_most_recent, if: :most_recent?
 
   validates :message, presence: true, if: -> {
-    [ADD_MESSAGE_TO_CASE_EVENT, ADD_NOTE_TO_CASE_EVENT].include? event
+    [
+      ADD_MESSAGE_TO_CASE_EVENT,
+      ADD_NOTE_TO_CASE_EVENT,
+      ANNOTATE_RETENTION_CHANGES,
+      ANNOTATE_SYSTEM_RETENTION_CHANGES,
+    ].include? event
   }
 
   jsonb_accessor :metadata,

--- a/config/locales/event.en.yml
+++ b/config/locales/event.en.yml
@@ -78,6 +78,8 @@ en:
     require_further_action_desc: Further information requested by the ICO
     require_further_action_unassigned_desc: Further information requested by the ICO
     require_further_action_to_responder_team_desc: Further information requested by the ICO
+    annotate_retention_changes: Retention details edited
+    annotate_system_retention_changes: Retention details edited - System update
 
   retention_schedule_case_notes:
     changes:

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -87,4 +87,5 @@
                 mark_as_awaiting_response_for_partial_case:
                 unmark_as_partial_case:
                 unmark_as_further_actions_required:
-
+                annotate_retention_changes:
+                annotate_system_retention_changes:

--- a/config/state_machine/configs/00_moj/50_offender_sar_complaint/20_offender_sar_complaint_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/50_offender_sar_complaint/20_offender_sar_complaint_standard_workflow.yml
@@ -184,6 +184,7 @@
                 send_dispatch_letter:
                 preview_cover_page:
                 edit_case:
+                annotate_retention_changes:
+                annotate_system_retention_changes:
                 reset_to_initial_state:
                   transition_to: to_be_assessed
-

--- a/spec/models/case_transition_spec.rb
+++ b/spec/models/case_transition_spec.rb
@@ -158,13 +158,21 @@ RSpec.describe CaseTransition, type: :model do
       kase = create :accepted_case
       transition = CaseTransition.new(
                                    case_id: kase.id,
-                                   event: 'add_message_to_case',
                                    acting_user_id: kase.responder.id,
                                    acting_team_id: kase.responding_team.id
       )
-      expect(transition).not_to be_valid
-      expect(transition.errors[:message]).to eq ["cannot be blank"]
 
+      %w(
+        add_message_to_case
+        add_note_to_case
+        annotate_retention_changes
+        annotate_system_retention_changes
+      ).each do |event|
+        transition.event = event
+
+        expect(transition).to_not be_valid
+        expect(transition.errors.added?(:message, :blank)).to eq(true)
+      end
     end
   end
 end

--- a/spec/presenters/retention_schedule_case_note_spec.rb
+++ b/spec/presenters/retention_schedule_case_note_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RetentionScheduleCaseNote do
       let(:changes) { {} }
 
       it 'does not write anything to the case history' do
-        expect(sm_double).not_to receive(:add_note_to_case!)
+        expect(sm_double).not_to receive(:annotate_retention_changes!)
         subject.log!(args)
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe RetentionScheduleCaseNote do
       it 'writes the change to the case history' do
         expect(
           sm_double
-        ).to receive(:add_note_to_case!).with(
+        ).to receive(:annotate_retention_changes!).with(
           acting_user: user, acting_team: team,
           message: 'Retention status changed from Not set to Review'
         )
@@ -51,7 +51,7 @@ RSpec.describe RetentionScheduleCaseNote do
       it 'writes the change to the case history' do
         expect(
           sm_double
-        ).to receive(:add_note_to_case!).with(
+        ).to receive(:annotate_retention_changes!).with(
           acting_user: user, acting_team: team,
           message: 'Destruction date changed from 25-10-2018 to 31-12-2025'
         )
@@ -66,12 +66,27 @@ RSpec.describe RetentionScheduleCaseNote do
       it 'writes the change to the case history' do
         expect(
           sm_double
-        ).to receive(:add_note_to_case!).with(
+        ).to receive(:annotate_retention_changes!).with(
           acting_user: user, acting_team: team,
           message: "Retention status changed from Not set to Review\nDestruction date changed from 25-10-2018 to 31-12-2025"
         )
 
         subject.log!(args)
+      end
+    end
+
+    context 'for a system update' do
+      let(:changes) { { state: [:not_set, :review] } }
+
+      it 'writes the system change to the case history' do
+        expect(
+          sm_double
+        ).to receive(:annotate_system_retention_changes!).with(
+          acting_user: user, acting_team: team,
+          message: 'Retention status changed from Not set to Review'
+        )
+
+        subject.log!(**args, is_system: true)
       end
     end
   end

--- a/spec/services/retention_schedules_update_service_spec.rb
+++ b/spec/services/retention_schedules_update_service_spec.rb
@@ -119,7 +119,7 @@ describe RetentionSchedulesUpdateService do
 
   def case_with_retention_schedule(case_type:, state:, date:)
     kase = create(
-      case_type, 
+      case_type, :closed,
       retention_schedule: 
         RetentionSchedule.new( 
          state: state,

--- a/spec/state_machines/workflows/offender_sar_complaint_permitted_events/ico_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_complaint_permitted_events/ico_spec.rb
@@ -91,7 +91,9 @@ describe ConfigurableStateMachine::Machine do
         full_events: [
           :preview_cover_page, 
           :add_note_to_case, 
-          :edit_case, 
+          :edit_case,
+          :annotate_retention_changes,
+          :annotate_system_retention_changes,
           :send_dispatch_letter, 
           :add_complaint_appeal_outcome, 
           :add_approval_flags_for_ico, 

--- a/spec/state_machines/workflows/offender_sar_complaint_permitted_events/litigation_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_complaint_permitted_events/litigation_spec.rb
@@ -111,7 +111,9 @@ describe ConfigurableStateMachine::Machine do
         full_events: [
           :preview_cover_page, 
           :add_note_to_case, 
-          :edit_case, 
+          :edit_case,
+          :annotate_retention_changes,
+          :annotate_system_retention_changes,
           :send_dispatch_letter, 
           :reset_to_initial_state,
           :add_complaint_costs, 

--- a/spec/state_machines/workflows/offender_sar_complaint_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_complaint_permitted_events/standard_spec.rb
@@ -90,6 +90,8 @@ describe ConfigurableStateMachine::Machine do
           :preview_cover_page, 
           :add_note_to_case,
           :edit_case,
+          :annotate_retention_changes,
+          :annotate_system_retention_changes,
           :send_dispatch_letter,
           :reset_to_initial_state
         ]

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -66,7 +66,9 @@ describe ConfigurableStateMachine::Machine do
           :mark_as_partial_case,
           :unmark_as_further_actions_required,
           :unmark_as_partial_case,
-          :mark_as_awaiting_response_for_partial_case
+          :mark_as_awaiting_response_for_partial_case,
+          :annotate_retention_changes,
+          :annotate_system_retention_changes,
         ]
       },
     ].freeze


### PR DESCRIPTION
## Description
When the retention details are updated, the case history displayed the updates under a heading of “Note added:”. This should now read `Retention details edited`.

Previously the existing event `add_note_to_case` was being used but this event is reserved for other kind of case notes, so new events have been created for retention schedule notes.

Also a second event has been created for system updates, in preparation for a follow-up PR.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="1088" alt="Screenshot 2022-06-23 at 13 13 00" src="https://user-images.githubusercontent.com/687910/175296415-cb3ef31a-ae59-4802-921e-d5d6d0e044c1.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4235

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
After changing any retention detail, the case history should show the changes, with the new heading "Retention details edited".
