### PR TITLE
CT-4234 Add retention case notes on SAR closure

### DIFF
--- a/app/presenters/retention_schedule_case_note.rb
+++ b/app/presenters/retention_schedule_case_note.rb
@@ -13,13 +13,25 @@ class RetentionScheduleCaseNote
     end
 
     def to_s
-      I18n.t(
-        self.class::ATTR_NAME, scope: scope, from: from, to: to
-      ) unless blank?
+      return if blank?
+
+      if @from && @to
+        I18n.t(
+          self.class::ATTR_NAME, scope: scope_for_update, from: from, to: to
+        )
+      else
+        I18n.t(
+          self.class::ATTR_NAME, scope: scope_for_create, to: to
+        )
+      end
     end
 
-    def scope
-      [:retention_schedule_case_notes, :changes]
+    def scope_for_update
+      [:retention_schedule_case_notes, :update]
+    end
+
+    def scope_for_create
+      [:retention_schedule_case_notes, :create]
     end
   end
 
@@ -28,6 +40,12 @@ class RetentionScheduleCaseNote
 
     def from; I18n.t(@from, scope: 'dictionary.retention_schedule_states'); end
     def to; I18n.t(@to, scope: 'dictionary.retention_schedule_states'); end
+
+    # On creation, the state is always `Not set` and this has no interest
+    # in the case history, so we skip the message (from `nil` to `not_set`)
+    def blank?
+      @from.blank?
+    end
   end
 
   class DateChange < AttrChange

--- a/app/services/case_closure_service.rb
+++ b/app/services/case_closure_service.rb
@@ -26,7 +26,7 @@ class CaseClosureService
 
   def add_retention_schedule
     service = RetentionSchedules::AddScheduleService.new(
-      kase: @kase
+      kase: @kase, user: @user
     )
     service.call
   end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -119,7 +119,7 @@ ignore_unused:
   - 'teams.directorate_detail.destroy'
   - 'teams.business_unit_detail.destroy'
   - 'dictionary.*'
-  - 'retention_schedule_case_notes.changes.*'
+  - 'retention_schedule_case_notes.{create,update}.*'
   - users.show.heading_all_cases
   - users.show.heading_my_cases
   - users.show.message_notification

--- a/config/locales/event.en.yml
+++ b/config/locales/event.en.yml
@@ -82,6 +82,8 @@ en:
     annotate_system_retention_changes: Retention details edited - System update
 
   retention_schedule_case_notes:
-    changes:
+    update:
       state: Retention status changed from %{from} to %{to}
       planned_destruction_date: Destruction date changed from %{from} to %{to}
+    create:
+      planned_destruction_date: Destruction date set to %{to}

--- a/lib/tasks/retention_schedules.rake
+++ b/lib/tasks/retention_schedules.rake
@@ -51,7 +51,7 @@ namespace :retention_schedules do
 
       puts "Kases count: #{kases.count}"
 
-      batch_size = args[:batch_size].to_i
+      batch_size = args.fetch(:batch_size, 500).to_i
 
       puts "Batch size: #{batch_size}"
       
@@ -60,7 +60,7 @@ namespace :retention_schedules do
           percent_counter += 1
           begin 
             service = RetentionSchedules::AddScheduleService.new(
-              kase: kase
+              kase: kase, user: nil
             )
             service.call
             

--- a/spec/presenters/retention_schedule_case_note_spec.rb
+++ b/spec/presenters/retention_schedule_case_note_spec.rb
@@ -76,14 +76,14 @@ RSpec.describe RetentionScheduleCaseNote do
     end
 
     context 'for a system update' do
-      let(:changes) { { state: [:not_set, :review] } }
+      let(:changes) { { state: [nil, :not_set], planned_destruction_date: [nil, Date.new(2025,12,31)] } }
 
       it 'writes the system change to the case history' do
         expect(
           sm_double
         ).to receive(:annotate_system_retention_changes!).with(
           acting_user: user, acting_team: team,
-          message: 'Retention status changed from Not set to Review'
+          message: "Destruction date set to 31-12-2025"
         )
 
         subject.log!(**args, is_system: true)


### PR DESCRIPTION
## Description
When a case is closed, the system calculates and updates the case's retention schedule. It also looks for any linked cases and updates the destruction date on all those related cases.

Upon any of these updates, a case note will be added to any affected case, stating the retention schedule changes, but noting this was a "System update" as it was not a direct action of the user (the user just closed a case).

If this is for new retention schedules, state will always be `Not set` (the default), so we don't add this to the case note, we only add the destruction date.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="1086" alt="Screenshot 2022-06-27 at 11 08 40" src="https://user-images.githubusercontent.com/687910/175919346-01208fb1-786e-4f63-8e40-30f0cbad4095.png">


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CT-4234
https://dsdmoj.atlassian.net/browse/CT-4235

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
On SAR case closure, a case history entry will be added to the case, and any linked case, stating it was a "System update".