### PR TITLE
Upgrade webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :test do
   gem 'rails-controller-testing', require: false
   gem 'shoulda-matchers', '~> 5.1'
   gem 'site_prism', '= 3.1'
-  gem 'webdrivers', '~> 5.0.0'
+  gem 'webdrivers', '~> 5.2.0'
   gem 'simplecov', '~> 0.21.2'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -630,7 +630,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.0.0)
+    webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0)
@@ -743,7 +743,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
-  webdrivers (~> 5.0.0)
+  webdrivers (~> 5.2.0)
   yard
 
 BUNDLED WITH


### PR DESCRIPTION
## Description
webdrivers 5.0.0 has a bug on M1 macs where it uses the wrong naming convention when trying to download chromedriver (https://github.com/titusfortner/webdrivers/issues/237). This is fixed in 5.2.0.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
