### PR TITLE
CDPT-184 Add errors summary when creating commissioning document

### DIFF
--- a/app/models/commissioning_document.rb
+++ b/app/models/commissioning_document.rb
@@ -16,7 +16,8 @@ class CommissioningDocument
 
   attr_accessor :template_name
 
-  validates :template_name, presence: true, inclusion: { in: CommissioningDocument::TEMPLATE_TYPES.keys }
+  validates :template_name, presence: true
+  validates :template_name, inclusion: { in: CommissioningDocument::TEMPLATE_TYPES.keys }, if: -> { template_name.present? }
 
   def initialize(data_request:)
     @data_request = data_request

--- a/app/views/cases/commissioning_documents/new.html.slim
+++ b/app/views/cases/commissioning_documents/new.html.slim
@@ -14,6 +14,9 @@ span.visually-hidden
 
 = render partial: 'layouts/header'
 
+= GovukElementsErrorsHelper.error_summary @commissioning_document,
+    "#{pluralize(@commissioning_document.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""
+
 .grid-row.data-request
   .column-full
     h2.bold-medium.data-request__number

--- a/spec/models/commissioning_document_spec.rb
+++ b/spec/models/commissioning_document_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe CommissioningDocument, type: :model do
       it 'is not valid' do
         expect(subject).to_not be_valid
       end
+
+      it 'has one error' do
+        subject.valid?
+        expect(subject.errors.count).to eq 1
+      end
     end
 
     context 'invalid template value' do
@@ -23,12 +28,17 @@ RSpec.describe CommissioningDocument, type: :model do
       it 'is not valid' do
         expect(subject).to_not be_valid
       end
+
+      it 'has one error' do
+        subject.valid?
+        expect(subject.errors.count).to eq 1
+      end
     end
 
     context 'valid template value' do
       before { subject.template_name = template_type }
 
-      it 'is not valid' do
+      it 'is valid' do
         expect(subject).to be_valid
       end
     end


### PR DESCRIPTION
## Description
To be consistent with other forms, add an errors summary.

Validation of the value of the template_name is only done if a value is present. This prevents 2 errors appearing if no option is selected which could be confusing for users.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="1066" alt="Screenshot 2022-11-01 at 15 34 55" src="https://user-images.githubusercontent.com/1190196/199274761-f4d967af-875d-4703-b2da-ff3bab63eac7.png">

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
