### PR TITLE
CDPT-365 Handle RecordNotUnique error

### DIFF
--- a/app/models/warehouse/case_report.rb
+++ b/app/models/warehouse/case_report.rb
@@ -106,8 +106,9 @@ module Warehouse
           process_class_related_process(kase, case_report)
           case_report.save!
           case_report
-        rescue ActiveRecord::RecordNotUnique => err
+        rescue ActiveRecord::RecordNotUnique
           retry if (retries += 1) < 2
+          raise
         end
       end
       #rubocop:enable Metrics/PerceivedComplexity

--- a/app/models/warehouse/case_report.rb
+++ b/app/models/warehouse/case_report.rb
@@ -16,7 +16,7 @@ module Warehouse
     # Class methods to allow this class to be used in async jobs
     class << self
       def for(kase)
-        kase.warehouse_case_report || self.new(case_id: kase.id)
+        kase.reload.warehouse_case_report || self.new(case_id: kase.id)
       end
 
       # Every field is deliberately set explicitly, please do not use any
@@ -26,84 +26,89 @@ module Warehouse
       #rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
       #rubocop:disable Metrics/PerceivedComplexity
       def generate(kase)
-        case_report = self.for(kase)
+        begin
+          retries ||= 0
+          case_report = self.for(kase)
 
-        # Relationship fields - for data-integrity checks
-        case_report.creator_id = kase.creator.id
-        case_report.responding_team_id = kase.responding_team&.id
-        case_report.responder_id = kase.responder&.id
-        case_report.casework_officer_user_id = kase.casework_officer_user&.id
-        case_report.business_group_id = kase.responding_team&.business_group&.id
-        case_report.directorate_id = kase.responding_team&.directorate&.id
-        case_report.director_general_name_property_id = kase.responding_team&.business_group&.properties&.lead&.singular_or_nil&.id # Director General name
-        case_report.director_name_property_id = kase.responding_team&.directorate&.properties&.lead&.singular_or_nil&.id # Director name
-        case_report.deputy_director_name_property_id = kase.responding_team&.properties&.lead&.singular_or_nil&.id # Deputy Director name
-        case_report.info_held_status_id = kase.info_held_status&.id
-        case_report.refusal_reason_id = kase.refusal_reason&.id
-        case_report.outcome_id = kase.outcome&.id
-        case_report.appeal_outcome_id = kase.appeal_outcome&.id
+          # Relationship fields - for data-integrity checks
+          case_report.creator_id = kase.creator.id
+          case_report.responding_team_id = kase.responding_team&.id
+          case_report.responder_id = kase.responder&.id
+          case_report.casework_officer_user_id = kase.casework_officer_user&.id
+          case_report.business_group_id = kase.responding_team&.business_group&.id
+          case_report.directorate_id = kase.responding_team&.directorate&.id
+          case_report.director_general_name_property_id = kase.responding_team&.business_group&.properties&.lead&.singular_or_nil&.id # Director General name
+          case_report.director_name_property_id = kase.responding_team&.directorate&.properties&.lead&.singular_or_nil&.id # Director name
+          case_report.deputy_director_name_property_id = kase.responding_team&.properties&.lead&.singular_or_nil&.id # Deputy Director name
+          case_report.info_held_status_id = kase.info_held_status&.id
+          case_report.refusal_reason_id = kase.refusal_reason&.id
+          case_report.outcome_id = kase.outcome&.id
+          case_report.appeal_outcome_id = kase.appeal_outcome&.id
 
-        # Report fields - for output
-        case_report.number = kase.number
-        case_report.case_type = kase.decorate.pretty_type
-        case_report.current_state = kase.decorate.status
-        case_report.responding_team = kase.responding_team&.name
-        case_report.responder = kase.responder&.full_name
-        case_report.date_received = kase.received_date
-        case_report.internal_deadline = kase.flagged? ? kase.internal_deadline : nil
-        case_report.external_deadline = kase.external_deadline
-        case_report.date_responded = kase.date_responded
-        case_report.date_compliant_draft_uploaded = kase.date_draft_compliant
-        case_report.trigger = kase.flagged? ? 'Yes' : nil
-        case_report.name = kase.name
-        case_report.requester_type = kase.sar? ? nil : kase.requester_type.humanize
-        case_report.message = self.dequote_and_truncate(kase.message)
+          # Report fields - for output
+          case_report.number = kase.number
+          case_report.case_type = kase.decorate.pretty_type
+          case_report.current_state = kase.decorate.status
+          case_report.responding_team = kase.responding_team&.name
+          case_report.responder = kase.responder&.full_name
+          case_report.date_received = kase.received_date
+          case_report.internal_deadline = kase.flagged? ? kase.internal_deadline : nil
+          case_report.external_deadline = kase.external_deadline
+          case_report.date_responded = kase.date_responded
+          case_report.date_compliant_draft_uploaded = kase.date_draft_compliant
+          case_report.trigger = kase.flagged? ? 'Yes' : nil
+          case_report.name = kase.name
+          case_report.requester_type = kase.sar? ? nil : kase.requester_type.humanize
+          case_report.message = self.dequote_and_truncate(kase.message)
 
-        case_report.info_held = kase.info_held_status&.name
-        case_report.outcome = kase.outcome&.name
-        case_report.refusal_reason = kase.refusal_reason&.name
-        case_report.exemptions = self.exemptions(kase)
+          case_report.info_held = kase.info_held_status&.name
+          case_report.outcome = kase.outcome&.name
+          case_report.refusal_reason = kase.refusal_reason&.name
+          case_report.exemptions = self.exemptions(kase)
 
-        case_report.postal_address = kase.postal_address
-        case_report.email = kase.email
-        case_report.appeal_outcome = kase.appeal_outcome&.name
-        case_report.third_party = kase.respond_to?(:third_party) ? self.humanize_boolean(kase.third_party) : nil
-        case_report.reply_method = kase.respond_to?(:reply_method) ? kase.reply_method.humanize : nil
-        case_report.sar_subject_type = kase.respond_to?(:subject_type) ? kase.subject_type.humanize : nil
-        case_report.sar_subject_full_name = kase.respond_to?(:subject_full_name) ? kase.subject_full_name : nil
-        case_report.business_unit_responsible_for_late_response = kase.decorate.late_team_name
-        case_report.extended = self.extension_count(kase) > 0 ? 'Yes' : 'No'
-        case_report.extension_count = self.extension_count(kase)
-        case_report.deletion_reason = kase.reason_for_deletion
-        case_report.casework_officer = kase.casework_officer
-        case_report.created_by = kase.creator.full_name
-        case_report.date_created = kase.created_at # Date created
+          case_report.postal_address = kase.postal_address
+          case_report.email = kase.email
+          case_report.appeal_outcome = kase.appeal_outcome&.name
+          case_report.third_party = kase.respond_to?(:third_party) ? self.humanize_boolean(kase.third_party) : nil
+          case_report.reply_method = kase.respond_to?(:reply_method) ? kase.reply_method.humanize : nil
+          case_report.sar_subject_type = kase.respond_to?(:subject_type) ? kase.subject_type.humanize : nil
+          case_report.sar_subject_full_name = kase.respond_to?(:subject_full_name) ? kase.subject_full_name : nil
+          case_report.business_unit_responsible_for_late_response = kase.decorate.late_team_name
+          case_report.extended = self.extension_count(kase) > 0 ? 'Yes' : 'No'
+          case_report.extension_count = self.extension_count(kase)
+          case_report.deletion_reason = kase.reason_for_deletion
+          case_report.casework_officer = kase.casework_officer
+          case_report.created_by = kase.creator.full_name
+          case_report.date_created = kase.created_at # Date created
 
-        # Some of this info can be seen in the Case > Teams page
-        # Business group: of the responding Business Unit/KILO (e.g. Comms & Info)
-        # Director general: head of the business group
-        # Director name: head of directorate
-        # Deputy Director: head of business unit
-        case_report.business_group = kase.responding_team&.business_group&.name
-        case_report.directorate_name = kase.responding_team&.directorate&.name
-        case_report.director_general_name = kase.responding_team&.business_group&.team_lead # Director General name
-        case_report.director_name = kase.responding_team&.directorate&.team_lead # Director name
-        case_report.deputy_director_name = kase.responding_team&.team_lead # Deputy Director name
+          # Some of this info can be seen in the Case > Teams page
+          # Business group: of the responding Business Unit/KILO (e.g. Comms & Info)
+          # Director general: head of the business group
+          # Director name: head of directorate
+          # Deputy Director: head of business unit
+          case_report.business_group = kase.responding_team&.business_group&.name
+          case_report.directorate_name = kase.responding_team&.directorate&.name
+          case_report.director_general_name = kase.responding_team&.business_group&.team_lead # Director General name
+          case_report.director_name = kase.responding_team&.directorate&.team_lead # Director name
+          case_report.deputy_director_name = kase.responding_team&.team_lead # Deputy Director name
 
-        # Draft Timeliness related information
-        case_report.draft_in_time = self.humanize_boolean(kase.within_draft_deadline?) # Draft in time
-        case_report.in_target = self.humanize_boolean(kase.response_in_target?) # In Target
-        case_report.number_of_days_late = kase.num_days_late # Number of days late
-        case_report.number_of_days_taken = kase.num_days_taken
-        case_report.number_of_days_taken_after_extension = kase.num_days_taken_after_extension
-        case_report.original_internal_deadline = kase.respond_to?(:original_internal_deadline) ? kase.original_internal_deadline : nil
-        case_report.original_external_deadline = kase.respond_to?(:original_external_deadline) ? kase.original_external_deadline : nil
-        case_report.num_days_late_against_original_deadline = kase.respond_to?(:original_external_deadline) ? kase.num_days_late_against_original_deadline : nil
-        case_report.request_method = kase.respond_to?(:request_method) ? kase.request_method : nil
+          # Draft Timeliness related information
+          case_report.draft_in_time = self.humanize_boolean(kase.within_draft_deadline?) # Draft in time
+          case_report.in_target = self.humanize_boolean(kase.response_in_target?) # In Target
+          case_report.number_of_days_late = kase.num_days_late # Number of days late
+          case_report.number_of_days_taken = kase.num_days_taken
+          case_report.number_of_days_taken_after_extension = kase.num_days_taken_after_extension
+          case_report.original_internal_deadline = kase.respond_to?(:original_internal_deadline) ? kase.original_internal_deadline : nil
+          case_report.original_external_deadline = kase.respond_to?(:original_external_deadline) ? kase.original_external_deadline : nil
+          case_report.num_days_late_against_original_deadline = kase.respond_to?(:original_external_deadline) ? kase.num_days_late_against_original_deadline : nil
+          case_report.request_method = kase.respond_to?(:request_method) ? kase.request_method : nil
 
-        process_class_related_process(kase, case_report)
-        case_report.save!
-        case_report
+          process_class_related_process(kase, case_report)
+          case_report.save!
+          case_report
+        rescue ActiveRecord::RecordNotUnique => err
+          retry if (retries += 1) < 2
+        end
       end
       #rubocop:enable Metrics/PerceivedComplexity
       #rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength


### PR DESCRIPTION
## Description
When a case is created, a WarehouseCaseReport is created and associated to the case. This happens asynchronously via a Redis job.
The WarehouseCaseReport is kept in sync with the case via Jobs whenever the case is updated.

If a new case is immediately updated after creation a race condition can occur because the update case object is not aware of the associated WarehouseCaseReport. So the sync code tries to create a new WarehouseCaseReport which fails because the Primary Key for the table is the case ID which already exists.

The solution implemented here is to rescue `ActiveRecord::RecordNotUnique` exceptions and retry. This works because the Case is reloaded which will load the associated WarehouseCaseReport which has just been created, rather than trying to create a new one.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
