### PR TITLE
CDPT-368 Allow assigning to non-branston users

### DIFF
--- a/app/state_machines/workflows/predicates.rb
+++ b/app/state_machines/workflows/predicates.rb
@@ -13,24 +13,12 @@ class Workflows::Predicates
     end
   end
 
-  def responder_is_member_of_assigned_team_and_assigned?
-    if @kase.responding_team && @kase.assigned?
-      @kase.responding_team.users.include?(@user)
-    else
-      false
-    end
-  end
-
   def is_tmm_case?
     @kase.sar? && @kase.refusal_reason == CaseClosure::RefusalReason.sar_tmm
   end
 
-  def responder_is_member_of_assigned_team_and_not_assigned?
-    if @kase.responding_team && !@kase.assigned?
-      @kase.responding_team.users.include?(@user)
-    else
-      false
-    end
+  def responder_is_not_assigned?
+    !@kase.assigned?
   end
 
   def is_litigation_complaint?

--- a/config/state_machine/configs/00_moj/50_offender_sar_complaint/20_offender_sar_complaint_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/50_offender_sar_complaint/20_offender_sar_complaint_standard_workflow.yml
@@ -17,9 +17,8 @@
                 preview_cover_page:
                 edit_case:
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_assigned?
                 reset_to_initial_state:
                   transition_to: to_be_assessed
               data_review_required:
@@ -28,9 +27,8 @@
                 mark_as_require_response:
                   transition_to: response_required
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_data_received:
                 add_note_to_case:
                 send_acknowledgement_letter:
@@ -42,9 +40,8 @@
                 mark_as_waiting_for_data:
                   transition_to: waiting_for_data
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_data_received:
                 add_note_to_case:
                 send_acknowledgement_letter:
@@ -59,9 +56,8 @@
                   if: Workflows::Predicates#is_not_litigation_complaint?
                   transition_to: response_required
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_data_received:
                 add_note_to_case:
                 send_acknowledgement_letter:
@@ -73,9 +69,8 @@
                 mark_as_vetting_in_progress:
                   transition_to: vetting_in_progress
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_data_received:
                 add_note_to_case:
                 preview_cover_page:
@@ -86,9 +81,8 @@
                 mark_as_ready_to_copy:
                   transition_to: ready_to_copy
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_data_received:
                 add_note_to_case:
                 preview_cover_page:
@@ -103,9 +97,8 @@
                   if: Workflows::Predicates#is_litigation_complaint?
                   transition_to: ready_to_dispatch
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 add_data_received:
                 add_note_to_case:
                 preview_cover_page:
@@ -117,9 +110,8 @@
                   if: Workflows::Predicates#is_litigation_complaint?
                   transition_to: legal_proceedings_ongoing
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 send_dispatch_letter:
                 add_data_received:
                 add_note_to_case:
@@ -139,9 +131,8 @@
                   if: Workflows::Predicates#is_not_litigation_complaint?
                   transition_to: closed
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
                 send_dispatch_letter:
                 add_data_received:
                 add_note_to_case:
@@ -164,9 +155,8 @@
                 preview_cover_page:
                 edit_case:
                 assign_to_team_member:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_not_assigned?
+                  if: Workflows::Predicates#responder_is_not_assigned?
                 reassign_user:
-                  if: Workflows::Predicates#responder_is_member_of_assigned_team_and_assigned?
                 reset_to_initial_state:
                   transition_to: to_be_assessed
               closed:

--- a/spec/factories/business_units.rb
+++ b/spec/factories/business_units.rb
@@ -136,6 +136,21 @@ FactoryBot.define do
     end
   end
 
+  factory :team_sscl, parent: :business_unit do
+    name { 'SSCL' }
+    email { 'sscl@localhost' }
+    code { 'SSCL' }
+    directorate { find_or_create :dacu_directorate }
+    responders { [find_or_create(:sscl_user, :orphan)] }
+
+    after(:create) do |bu, _evaluator|
+      bu.correspondence_types = []
+      bu.correspondence_types << find_or_create(:offender_sar_correspondence_type)
+      bu.correspondence_types << find_or_create(:offender_sar_complaint_correspondence_type)
+      bu.save!
+    end
+  end
+
   factory :team_disclosure, aliases: [:team_dacu_disclosure], parent: :approving_team do
     name { 'Disclosure' }
     email { 'dacu.disclosure@localhost' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -99,6 +99,16 @@ FactoryBot.define do
       managing_teams { [find_or_create(:team_branston, :empty)] }
     end
 
+    factory :sscl_user, parent: :user do
+      transient do
+        identifier { 'sscl responding user' }
+      end
+
+      full_name      { identifier }
+      email          { email_from_name(full_name) }
+      responding_teams { [find_or_create(:team_sscl, :empty)] }
+    end
+
     factory :team_admin, parent: :user do
       transient do
         identifier { 'team-admin user ' }


### PR DESCRIPTION
## Description
When an offender SAR complaint is created, the case is auto assigned to the creator. This fails if the creator does not belong to the team that is assigned to that correspondence type. There is a team from SSCL who also create these cases and the assigning fails for them and causes an exception.

This change removes the restriction and means anyone that can create an offender SAR complaint will can be assigned to it. As well as stopping the exception, this will also mean these users can see their assigned cases in the "My Open Cases" tab.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
Error seen before change
<img width="1146" alt="Screenshot 2022-11-16 at 17 05 48" src="https://user-images.githubusercontent.com/1190196/202479359-f7074e83-d0c7-4384-aeac-d9592daaeb48.png">

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
A user with the email darkwin@digital.justice.uk can be used in development to test this by creating an offender SAR complaint. With the changes applied, the case will be created and no error will be seen.
