### PR TITLE
CDPT-367 Set due day to next working day

### DIFF
--- a/app/models/commissioning_document_template/base.rb
+++ b/app/models/commissioning_document_template/base.rb
@@ -33,7 +33,9 @@ module CommissioningDocumentTemplate
     end
 
     def deadline(count)
-      date_format(Date.current + count.days)
+      due = Date.current + count.days
+      due += 1 while !due.workday?
+      date_format(due)
     end
 
     def date_format(date)

--- a/app/models/commissioning_document_template/base.rb
+++ b/app/models/commissioning_document_template/base.rb
@@ -34,7 +34,7 @@ module CommissioningDocumentTemplate
 
     def deadline(count)
       due = Date.current + count.days
-      due += 1 while !due.workday?
+      due += 1 until due.workday?
       date_format(due)
     end
 

--- a/spec/models/commissioning_document_template/base_spec.rb
+++ b/spec/models/commissioning_document_template/base_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+module CommissioningDocumentTemplate
+  class TestClass < CommissioningDocumentTemplate::Base
+    def context
+      super.merge(deadline: deadline(5))
+    end
+  end
+end
+
+RSpec.describe CommissioningDocumentTemplate::TestClass do
+  let(:kase) { build(:offender_sar_case) }
+  let(:data_request) { build(:data_request, offender_sar_case: kase) }
+  subject { described_class.new(data_request: data_request) }
+
+  describe 'deadlines' do
+    it 'sets deadline to next working day' do
+      Timecop.freeze(Date.new(2022, 11, 15)) do # Tuesday
+        expect(subject.context[:deadline]).to eq '21/11/2022' # Monday
+      end
+
+      Timecop.freeze(Date.new(2022, 11, 18)) do # Friday
+        expect(subject.context[:deadline]).to eq '23/11/2022' # Wednesday
+      end
+
+      Timecop.freeze(Date.new(2022, 8, 22)) do # Monday
+        expect(subject.context[:deadline]).to eq '30/08/2022' # Tuesday after bank holiday
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
The response date for data to be returned for Offender SARs is either 5 days or 20 days depending on the data required.
If the due date falls on a weekend or bank holiday, then it should be set to the next working day.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
