### PR TITLE
Cdpt 253 unable to create overturned ico case

### DIFF
--- a/app/models/case/ico/base.rb
+++ b/app/models/case/ico/base.rb
@@ -46,7 +46,7 @@ class Case::ICO::Base < Case::Base
                  ico_decision: :string,
                  ico_decision_comment: :string,
                  late_team_id: :integer,
-                 date_draft_compliant: :date, 
+                 date_draft_compliant: :date,
                  original_internal_deadline: :date,
                  original_external_deadline: :date,
                  original_date_responded: :date
@@ -183,7 +183,7 @@ class Case::ICO::Base < Case::Base
   def external_deadline_within_limits?
     if original_external_deadline.present?
       validate_external_deadline_after_further_action?
-    else 
+    else
       validate_external_deadline_before_further_action?
     end
   end
@@ -195,14 +195,14 @@ class Case::ICO::Base < Case::Base
           :external_deadline,
           I18n.t('activerecord.errors.models.case.attributes.external_deadline.before_received')
         )
-      elsif external_deadline > received_date + 1.year
+      elsif external_deadline > received_date + 2.year
         errors.add(
           :external_deadline,
           I18n.t('activerecord.errors.models.case.attributes.external_deadline.too_far_past_received')
         )
       end
     end
-  end 
+  end
 
   def validate_external_deadline_after_further_action?
     if external_deadline.present? && internal_deadline > external_deadline

--- a/app/models/case/ico/base.rb
+++ b/app/models/case/ico/base.rb
@@ -195,7 +195,7 @@ class Case::ICO::Base < Case::Base
           :external_deadline,
           I18n.t('activerecord.errors.models.case.attributes.external_deadline.before_received')
         )
-      elsif external_deadline > received_date + 1.years
+      elsif external_deadline > received_date + 1.year
         errors.add(
           :external_deadline,
           I18n.t('activerecord.errors.models.case.attributes.external_deadline.too_far_past_received')

--- a/app/models/case/ico/base.rb
+++ b/app/models/case/ico/base.rb
@@ -195,7 +195,7 @@ class Case::ICO::Base < Case::Base
           :external_deadline,
           I18n.t('activerecord.errors.models.case.attributes.external_deadline.before_received')
         )
-      elsif external_deadline > received_date + 2.year
+      elsif external_deadline > received_date + 2.years
         errors.add(
           :external_deadline,
           I18n.t('activerecord.errors.models.case.attributes.external_deadline.too_far_past_received')

--- a/app/models/case/ico/base.rb
+++ b/app/models/case/ico/base.rb
@@ -195,7 +195,7 @@ class Case::ICO::Base < Case::Base
           :external_deadline,
           I18n.t('activerecord.errors.models.case.attributes.external_deadline.before_received')
         )
-      elsif external_deadline > received_date + 2.years
+      elsif external_deadline > received_date + 1.years
         errors.add(
           :external_deadline,
           I18n.t('activerecord.errors.models.case.attributes.external_deadline.too_far_past_received')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,7 +205,7 @@ en:
             <<: *foi_attr
             received_date:
               future: cannot be in the future
-              past: is too far in the past
+              past: ICO overturned decision received date is too far in the past (more than 29 days)
               blank: cannot be blank
             external_deadline:
               past: cannot be in the past

--- a/spec/models/case/ico/base_spec.rb
+++ b/spec/models/case/ico/base_spec.rb
@@ -99,10 +99,10 @@ describe Case::ICO::Base do
         .to eq ['cannot be before date received']
     end
 
-    it 'cannot be more than two years past received_date' do
+    it 'cannot be more than a year past received_date' do
       kase.update(
         received_date: Date.today,
-        external_deadline: Date.today + 2.years + 1.day,
+        external_deadline: Date.today + 1.year + 1.day,
       )
       expect(kase).not_to be_valid
       expect(kase.errors[:external_deadline])

--- a/spec/models/case/ico/base_spec.rb
+++ b/spec/models/case/ico/base_spec.rb
@@ -99,10 +99,10 @@ describe Case::ICO::Base do
         .to eq ['cannot be before date received']
     end
 
-    it 'cannot be more than a year past received_date' do
+    it 'cannot be more than two years past received_date' do
       kase.update(
         received_date: Date.today,
-        external_deadline: Date.today + 1.year + 1.day,
+        external_deadline: Date.today + 2.year + 1.day,
       )
       expect(kase).not_to be_valid
       expect(kase.errors[:external_deadline])

--- a/spec/models/case/ico/base_spec.rb
+++ b/spec/models/case/ico/base_spec.rb
@@ -102,7 +102,7 @@ describe Case::ICO::Base do
     it 'cannot be more than two years past received_date' do
       kase.update(
         received_date: Date.today,
-        external_deadline: Date.today + 2.year + 1.day,
+        external_deadline: Date.today + 2.years + 1.day,
       )
       expect(kase).not_to be_valid
       expect(kase.errors[:external_deadline])

--- a/spec/models/case/overturned_ico/foi_spec.rb
+++ b/spec/models/case/overturned_ico/foi_spec.rb
@@ -108,14 +108,14 @@ describe Case::OverturnedICO::FOI do
           it 'errors' do
             new_case.received_date = 29.days.ago
             expect(new_case).not_to be_valid
-            expect(new_case.errors[:received_date]).to eq ['is too far in the past']
+            expect(new_case.errors[:received_date]).to eq ['ICO overturned decision received date is too far in the past (more than 29 days)']
           end
         end
 
         context 'on create' do
           it 'errors' do
             record = described_class.create(received_date: 29.days.ago)
-            expect(record.errors[:received_date]).to eq ['is too far in the past']
+            expect(record.errors[:received_date]).to eq ['ICO overturned decision received date is too far in the past (more than 29 days)']
           end
         end
 


### PR DESCRIPTION
The overturned ico case decision is more than 29 days old. As a rule overturned ico case can not be created because of the validation.

## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
