### PR TITLE
CDPT-370 Avoid updating old cases when reindexing

### DIFF
--- a/app/jobs/search_index_updater_job.rb
+++ b/app/jobs/search_index_updater_job.rb
@@ -7,7 +7,7 @@ class SearchIndexUpdaterJob < ApplicationJob
     kase=Case::Base.find(case_id)
     if kase
       kase.update_index
-      kase.mark_as_clean!
+      kase.mark_as_clean! if kase.dirty?
     end
   end
 end

--- a/spec/jobs/search_index_updater_job_spec.rb
+++ b/spec/jobs/search_index_updater_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe SearchIndexUpdaterJob, type: :job do
   include ActiveJob::TestHelper
 
-  let!(:k1)     { create :case }
+  let!(:k1) { create :case }
 
   describe '#perform' do
     it 'processes k1' do
@@ -13,7 +13,7 @@ describe SearchIndexUpdaterJob, type: :job do
       SearchIndexUpdaterJob.new.perform(k1.id)
     end
 
-    it 'sets k1 and k4 to clean' do
+    it 'sets k1 to clean' do
       SearchIndexUpdaterJob.new.perform(k1.id)
       expect(k1.reload).to be_clean
     end


### PR DESCRIPTION
## Description
When a case is updated a reindex is triggered and the case is marked as "dirty"
After a case is reindexed the case is set as “clean” to stop unnecessary indexing.  
Some old cases fail validation, so updating causes an exception.

Reindexing can also be triggered when a case has not been updated, and in that instance there is no need to update the object and set it as "clean"

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
