### PR TITLE
CDPT-374 Return if recipient not found

### DIFF
--- a/app/mailers/action_notifications_mailer.rb
+++ b/app/mailers/action_notifications_mailer.rb
@@ -45,7 +45,9 @@ class ActionNotificationsMailer < GovukNotifyRails::Mailer
   def notify_information_officers(kase, type)
     SentryContextProvider.set_context
 
-    recipient = kase.assignments.responding.accepted.first.user
+    recipient = kase.assignments.responding.accepted.first&.user
+    return unless recipient
+
     find_template(type)
 
     set_personalisation(

--- a/spec/mailers/action_notifications_mailer_spec.rb
+++ b/spec/mailers/action_notifications_mailer_spec.rb
@@ -282,6 +282,21 @@ RSpec.describe ActionNotificationsMailer, type: :mailer do
       end
     end
 
+    context 'no assigned user' do
+      let(:approved_case)   { create :approved_case,
+                                     name: 'Fyodor Ognievich Ilichion',
+                                     received_date: 10.business_days.ago,
+                                     subject: 'The anatomy of man' }
+      let(:assignment)      { approved_case.responder_assignment }
+
+      it "does not error" do
+        approved_case.responder_assignment.update(state: "pending")
+
+        expect {
+          described_class.new.notify_information_officers(approved_case, 'Ready to send')
+        }.not_to raise_error
+      end
+    end
   end
 
   describe 'notify_team' do


### PR DESCRIPTION
## Description
The job to notify_information_officers requires an assignment in the accepted state. There are instances where this does not exist which causes an exception when retrieving the recipient email.

We will now return early if no user is found to email.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
