### PR TITLE
CDPT-362 Set start date to next working day

### DIFF
--- a/app/services/deadline_calculator/business_days.rb
+++ b/app/services/deadline_calculator/business_days.rb
@@ -19,7 +19,7 @@ module DeadlineCalculator
     end
 
     def escalation_deadline(start_from=kase.created_at.to_date)
-      start = start_date(start_from)
+      start = next_working_day(start_from)
       calculate(kase.correspondence_type.escalation_time_limit, start)
     end
 
@@ -59,14 +59,14 @@ module DeadlineCalculator
     private
 
     def calculate(days, from=nil)
-      from ||= start_date(kase.received_date)
+      from ||= next_working_day(kase.received_date)
       (days - 1).business_days.after(from)
     end
 
-    def start_date(received_date)
-      received_date += 1
-      received_date += 1 until received_date.workday?
-      received_date
+    def next_working_day(date)
+      new_date = date + 1
+      new_date += 1 until new_date.workday?
+      new_date
     end
 
     def external_deadline_for_date(correspondence_type, date=nil)

--- a/app/services/deadline_calculator/business_days.rb
+++ b/app/services/deadline_calculator/business_days.rb
@@ -5,14 +5,14 @@ module DeadlineCalculator
     class << self
 
       def days_taken(start_date, end_date)
-        start_date.business_days_until(end_date, true) 
-      end 
-  
-      def days_late(start_date, end_date)
-        start_date.business_days_until(end_date, false) 
-      end 
+        start_date.business_days_until(end_date, true)
+      end
 
-    end 
+      def days_late(start_date, end_date)
+        start_date.business_days_until(end_date, false)
+      end
+
+    end
 
     def initialize(kase)
       @kase = kase
@@ -48,7 +48,7 @@ module DeadlineCalculator
       days_after_day_one = (time_limit + kase.correspondence_type.external_time_limit) - 1
       days_after_day_one.business_days.after(start_date(kase.received_date))
     end
-    
+
     def max_allowed_deadline_date(time_limit=nil)
       time_limit ||= (kase.correspondence_type.extension_time_limit || 0)
       days_after_day_one = (time_limit + kase.correspondence_type.external_time_limit) - 1
@@ -62,11 +62,9 @@ module DeadlineCalculator
     private
 
     def start_date(received_date)
-      actual_received_date = received_date
-      actual_received_date += 1 until actual_received_date.workday?
-      date = actual_received_date + 1
-      date += 1 until date.workday?
-      date
+      received_date += 1
+      received_date += 1 until received_date.workday?
+      received_date
     end
   end
 end

--- a/spec/lib/papertrail_spec.rb
+++ b/spec/lib/papertrail_spec.rb
@@ -34,7 +34,7 @@ describe 'papertrail', versioning: true do
 
 
   describe 'reify' do
-    it 'recreates the record and stores the previsou values' do
+    it 'recreates the record and stores the previous values' do
       Timecop.freeze(run_time) do
         kase = create_dummy_case
         expect(kase.received_date).to eq Date.parse('2018-04-19')
@@ -45,8 +45,8 @@ describe 'papertrail', versioning: true do
         update_dummy_case(kase)
         expect(kase.received_date).to eq Date.parse('2018-04-15')
         expect(kase.escalation_deadline).to eq Date.parse('2018-04-18')
-        expect(kase.internal_deadline).to eq Date.parse('2018-04-30')
-        expect(kase.external_deadline).to eq Date.parse('2018-05-15')
+        expect(kase.internal_deadline).to eq Date.parse('2018-04-27')
+        expect(kase.external_deadline).to eq Date.parse('2018-05-14')
 
         reified_kase = kase.versions.last.reify
 

--- a/spec/services/deadline_calculator/business_days_spec.rb
+++ b/spec/services/deadline_calculator/business_days_spec.rb
@@ -100,59 +100,59 @@ describe DeadlineCalculator::BusinessDays do
 
     context 'received on a Saturday' do
 
-      let(:sat_jul_01) { Time.utc(2017, 7, 1, 12, 0, 0) }
-      let(:thu_jul_06) { Time.utc(2017, 7, 6, 12, 0, 0) }
-      let(:mon_jul_17) { Time.utc(2017, 7, 17, 12, 0, 0) }
-      let(:mon_jul_31) { Time.utc(2017, 7, 31, 12, 0, 0) }
+      let(:sat_jul_03) { Time.utc(2021, 7, 3, 12, 0, 0) }
+      let(:wed_jul_07) { Time.utc(2021, 7, 7, 12, 0, 0) }
+      let(:fri_jul_16) { Time.utc(2021, 7, 16, 12, 0, 0) }
+      let(:fri_jul_30) { Time.utc(2021, 7, 30, 12, 0, 0) }
       let(:sat_may_01) { Time.utc(2021, 5, 1, 12, 0, 0) }
-      let(:wed_jun_02) { Time.utc(2021, 6, 2, 12, 0, 0) }
-      let(:tue_may_18) { Time.utc(2021, 5, 18, 12, 0, 0) }
-      let(:fri_may_07) { Time.utc(2021, 5, 7, 12, 0, 0) }
+      let(:tue_jun_01) { Time.utc(2021, 6, 1, 12, 0, 0) }
+      let(:mon_may_17) { Time.utc(2021, 5, 17, 12, 0, 0) }
+      let(:thu_may_06) { Time.utc(2021, 5, 6, 12, 0, 0) }
 
       describe '.escalation_deadline' do
-        it 'is 3 days after first working day after received date' do
-          Timecop.freeze sat_jul_01 do
+        it 'is 3 working days after received date' do
+          Timecop.freeze sat_jul_03 do
             expect(deadline_calculator.escalation_deadline)
-              .to eq thu_jul_06.to_date
+              .to eq wed_jul_07.to_date
           end
         end
 
-        it 'is 3 days after first working day after received date - not counting bank holiday Mon May 03' do
+        it 'is 3 working days after received date - bank holiday Mon May 03 is not counted' do
           Timecop.freeze sat_may_01 do
             expect(deadline_calculator.escalation_deadline)
-              .to eq fri_may_07.to_date
+              .to eq thu_may_06.to_date
           end
         end
       end
 
       describe '.external_deadline' do
-        it 'is 20 working days first working day after received date' do
-          Timecop.freeze sat_jul_01 do
+        it 'is 20 working days after received date' do
+          Timecop.freeze sat_jul_03 do
             expect(deadline_calculator.external_deadline)
-              .to eq mon_jul_31.to_date
+              .to eq fri_jul_30.to_date
           end
         end
 
-        it 'is 20 working days first working day after received date - not counting bank holiday Mon May 03' do
+        it 'is 20 working days after received date - bank holidays Mon May 03 and Mon May 31 are not counted' do
           Timecop.freeze sat_may_01 do
             expect(deadline_calculator.external_deadline)
-              .to eq wed_jun_02.to_date
+              .to eq tue_jun_01.to_date
           end
         end
       end
 
       describe '.internal_deadline' do
-        it 'is 10 working days first working day after received date' do
-          Timecop.freeze sat_jul_01 do
+        it 'is 10 working days after received date' do
+          Timecop.freeze sat_jul_03 do
             expect(deadline_calculator.internal_deadline)
-              .to eq mon_jul_17.to_date
+              .to eq fri_jul_16.to_date
           end
         end
 
-        it 'is 10 working days first working day after received date' do
+        it 'is 10 working days after received date - bank holiday Mon May 03 is not counted' do
           Timecop.freeze sat_may_01 do
             expect(deadline_calculator.internal_deadline)
-              .to eq tue_may_18.to_date
+              .to eq mon_may_17.to_date
           end
         end
       end

--- a/spec/services/deadline_calculator/business_days_spec.rb
+++ b/spec/services/deadline_calculator/business_days_spec.rb
@@ -1,14 +1,11 @@
 require 'rails_helper'
 
 describe DeadlineCalculator::BusinessDays do
-
   context 'FOI requests' do
-
     let(:foi_case) { build :foi_case,
                            received_date: Date.today,
                            created_at: Date.today
     }
-
     let(:deadline_calculator) { described_class.new foi_case }
 
     context 'received on a workday' do
@@ -20,7 +17,6 @@ describe DeadlineCalculator::BusinessDays do
       let(:thu_jun_15) { Time.utc(2017, 6, 15, 12, 0, 0) }
       let(:fri_jun_30) { Time.utc(2017, 6, 30, 12, 0, 0) }
       let(:fri_jul_14) { Time.utc(2017, 7, 14, 12, 0, 0) }
-
 
       describe '#time_units_desc_for_deadline' do
         it 'single' do
@@ -99,7 +95,6 @@ describe DeadlineCalculator::BusinessDays do
     end
 
     context 'received on a Saturday' do
-
       let(:sat_jul_03) { Time.utc(2021, 7, 3, 12, 0, 0) }
       let(:wed_jul_07) { Time.utc(2021, 7, 7, 12, 0, 0) }
       let(:fri_jul_16) { Time.utc(2021, 7, 16, 12, 0, 0) }
@@ -199,7 +194,7 @@ describe DeadlineCalculator::BusinessDays do
           .to eq 0
       end
 
-      it 'start date ealier than end day' do
+      it 'start date earlier than end day' do
         expect(deadline_calculator.class.days_late(thu_may_18.to_date, tue_may_23.to_date))
           .to eq 3
       end


### PR DESCRIPTION
## Description
Guidance from ICO means the start date for calculating deadlines for FOI and FOI-IR should always be the next working day.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
