### PR TITLE
CDPT-297 Add cronjob for resetting sidekiq queues

### DIFF
--- a/config/kubernetes/production/cronjob-sidekiq-queues.yaml
+++ b/config/kubernetes/production/cronjob-sidekiq-queues.yaml
@@ -1,0 +1,32 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: clear-sidekiq-queues
+spec:
+  schedule: "0 5 * * 1"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: jobs
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:track-a-query-latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - sh
+              - "-c"
+              - "bundle exec rake sidekiq:clearQueues"
+            env:
+              - name: REDIS_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: url
+              - name: REDIS_AUTH_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: auth_token

--- a/lib/tasks/sidekiq.rake
+++ b/lib/tasks/sidekiq.rake
@@ -21,5 +21,15 @@ namespace :sidekiq do
     end
 
   end
+
+  desc 'Clear sidekiq processed and failed queues to save memory'
+  task :clearQueues => :environment do
+
+    require 'sidekiq/api'
+
+    Sidekiq::Stats.new.reset
+    Sidekiq::DeadSet.new.clear
+
+  end
 end
 


### PR DESCRIPTION
## Description
I couldn't find a way to automatically delete Redis jobs so hoping maybe this cronjob will do it. Quite crude atm but wanted to see if the approach is OK. Won't merge into main until I've tested this a bit more but thought to see if it's the way to go or not first. It's supposed to delete completed jobs but it's scheduled at a time that there shouldn't be jobs in progress anyway just to be cautious. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [x] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-297

### Deployment
Will need to be tested manually from local before releasing into pipeline

### Manual testing instructions
Run cronjob locally by changing time to immediate and keep an eye on production. 
