### PR TITLE
CDPT-581 Use method instead of proc

### DIFF
--- a/app/models/case_transition.rb
+++ b/app/models/case_transition.rb
@@ -40,14 +40,7 @@ class CaseTransition < ApplicationRecord
 
   after_destroy :update_most_recent, if: :most_recent?
 
-  validates :message, presence: true, if: -> {
-    [
-      ADD_MESSAGE_TO_CASE_EVENT,
-      ADD_NOTE_TO_CASE_EVENT,
-      ANNOTATE_RETENTION_CHANGES,
-      ANNOTATE_SYSTEM_RETENTION_CHANGES,
-    ].include? event
-  }
+  validates :message, presence: true, if: :requires_message?
 
   jsonb_accessor :metadata,
                  message:                    :text,
@@ -89,5 +82,14 @@ class CaseTransition < ApplicationRecord
     last_transition = self.case.transitions.order(:sort_key).last
     return unless last_transition.present?
     last_transition.update_column(:most_recent, true)
+  end
+
+  def requires_message?
+    [
+      ADD_MESSAGE_TO_CASE_EVENT,
+      ADD_NOTE_TO_CASE_EVENT,
+      ANNOTATE_RETENTION_CHANGES,
+      ANNOTATE_SYSTEM_RETENTION_CHANGES,
+    ].include? event
   end
 end


### PR DESCRIPTION
## Description
An exception was being raised when a user submitted a message without any text. This was caused by a strange bug whereby some internal rails code was trying to serialise the case_transition object but was failing because it contained a proc that was being used to perform validation on the message attribute.

The issue is fixed by changing the validation to use a method instead of the proc. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
