### PR TITLE
Fix request_type migration for local development

### DIFF
--- a/db/data_migrations/20210629202656_update__data_requests_request_types.rb
+++ b/db/data_migrations/20210629202656_update__data_requests_request_types.rb
@@ -1,21 +1,5 @@
 class UpdateDataRequestsRequestTypes < ActiveRecord::DataMigration
   def up
-    # The first execute was a DB migration (db/migrate) and since we've archived old migrations,
-    # it is not run, but the second execute assumes it has been run. So as a workaround, we
-    # unify both migrations in this one file so that the `db:reseed` can complete successfully.
-    #
-    execute <<-SQL
-      UPDATE data_requests SET request_type = 'all_prison_records';
-      CREATE TYPE request_types_enum AS ENUM ('all_prison_records', 'security_records', 'nomis_records', 'nomis_contact_logs', 'probation_records', 'prison_and_probation_records', 'other');
-      ALTER TABLE data_requests ALTER COLUMN request_type TYPE request_types_enum USING request_type::text::request_types_enum;
-      DROP TYPE request_types;
-    SQL
-
-    execute <<-SQL
-      UPDATE data_requests SET request_type = 'other', request_type_note='prison_and_probation_records' where id in (select id from data_requests where request_type='prison_and_probation_records');
-      CREATE TYPE request_types AS ENUM ('all_prison_records', 'security_records', 'nomis_records', 'nomis_other', 'nomis_contact_logs', 'probation_records', 'cctv_and_bwcf', 'telephone_recordings', 'telephone_pin_logs', 'probation_archive', 'mappa', 'pdp', 'court', 'other', 'cross_borders', 'cat_a', 'ndelius');
-      ALTER TABLE data_requests ALTER COLUMN request_type TYPE request_types USING request_type::text::request_types;
-      DROP TYPE request_types_enum;
-    SQL
+    # noop as the previous data was different to what has subsequently been added to structure.sql
   end
 end

--- a/db/data_migrations/20210629202656_update__data_requests_request_types.rb
+++ b/db/data_migrations/20210629202656_update__data_requests_request_types.rb
@@ -13,7 +13,7 @@ class UpdateDataRequestsRequestTypes < ActiveRecord::DataMigration
 
     execute <<-SQL
       UPDATE data_requests SET request_type = 'other', request_type_note='prison_and_probation_records' where id in (select id from data_requests where request_type='prison_and_probation_records');
-      CREATE TYPE request_types AS ENUM ('all_prison_records', 'security_records', 'nomis_records', 'nomis_other', 'nomis_contact_logs', 'probation_records', 'cctv_and_bwcf', 'telephone_recordings', 'telephone_pin_logs', 'probation_archive', 'mappa', 'pdp', 'court', 'other');
+      CREATE TYPE request_types AS ENUM ('all_prison_records', 'security_records', 'nomis_records', 'nomis_other', 'nomis_contact_logs', 'probation_records', 'cctv_and_bwcf', 'telephone_recordings', 'telephone_pin_logs', 'probation_archive', 'mappa', 'pdp', 'court', 'other', 'cross_borders', 'cat_a', 'ndelius');
       ALTER TABLE data_requests ALTER COLUMN request_type TYPE request_types USING request_type::text::request_types;
       DROP TYPE request_types_enum;
     SQL

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -4,7 +4,7 @@ namespace :db do
   task :clear => :environment do
     if is_on_production?
       puts "Cannot run this command on production environment!"
-    else          
+    else
       HostEnv.safe do
         clear_database
       end
@@ -24,18 +24,18 @@ namespace :db do
       Rake::Task['db:seed:dev:users'].invoke
     end
   end
-  
+
   task :structure_load => :environment do
     if is_on_production?
       puts "Cannot run this command on production environment!"
-    else          
+    else
       structure_file = "#{Rails.root}/db/structure.sql"
       db_connection_url = ENV['DATABASE_URL'] || 'postgres://postgres:@localhost/correspondence_platform_development'
       command = "psql #{db_connection_url} < #{structure_file}"
       system command
     end
   end
- 
+
   def clear_database
     conn = ActiveRecord::Base.connection
     tables = conn.tables
@@ -48,8 +48,6 @@ namespace :db do
       attachment_type
       cases_delivery_methods
       requester_type
-      request_types_enum
-      request_types
       search_query_type
       state
       team_roles


### PR DESCRIPTION
## Description
When `rake db:reseed` is run locally, the local DB is cleared, then structure.sql is loaded. After that data migrations are run.
This was causing an issue as there was a data migration for the `request_types` type which was out of date and was replacing the correct data.

This migration has been removed.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
