### PR TITLE
CDPT-567 Add email address for Probation commissioning document template

### DIFF
--- a/app/models/commissioning_document.rb
+++ b/app/models/commissioning_document.rb
@@ -22,6 +22,8 @@ class CommissioningDocument < ApplicationRecord
   validates :data_request, presence: true
   validates :template_name, presence: true
 
+  delegate :recipient_emails, to: :template
+
   def document
     return unless valid?
 

--- a/app/models/commissioning_document_template/base.rb
+++ b/app/models/commissioning_document_template/base.rb
@@ -22,6 +22,10 @@ module CommissioningDocumentTemplate
       }
     end
 
+    def recipient_emails
+      []
+    end
+
     private
 
     def template_name

--- a/app/models/commissioning_document_template/probation.rb
+++ b/app/models/commissioning_document_template/probation.rb
@@ -18,5 +18,9 @@ module CommissioningDocumentTemplate
         data_required: data_request.data_required || default_data_required
       )
     end
+
+    def recipient_emails
+      ["BranstonRegistryRequests2@justice.gov.uk"]
+    end
   end
 end

--- a/app/models/data_request.rb
+++ b/app/models/data_request.rb
@@ -77,8 +77,10 @@ class DataRequest < ApplicationRecord
     date_from.blank? && date_to.blank?
   end
 
-  def has_emails?
-    !!contact&.data_request_emails.present?
+  def recipient_emails
+    emails = contact&.data_request_emails&.split(%r/\s/) || []
+    emails += commissioning_document.recipient_emails if commissioning_document.present?
+    emails
   end
 
   private

--- a/app/views/cases/data_requests/send_email.html.slim
+++ b/app/views/cases/data_requests/send_email.html.slim
@@ -15,7 +15,7 @@ span.visually-hidden
 .grid-row.data-request
   .column-full
 
-    - unless @data_request.has_emails?
+    - if @data_request.recipient_emails.empty?
       div.govuk-warning-text
         span.govuk-warning-text__icon (aria-hidden="true") !
         strong.govuk-warning-text__text
@@ -30,13 +30,11 @@ span.visually-hidden
         = t('common.note')
       = t('helpers.label.data_request.send_email_note_text')
 
-    - if @data_request.has_emails?
+    - if @data_request.recipient_emails.present?
       div
-        = raw @data_request.contact.data_request_emails.gsub(/\s\s/, "<br>").html_safe
+        = raw @data_request.recipient_emails.join("<br>").html_safe
 
     div.button-holder
       = form_for @commissioning_document, method: :post, url: send_email_case_data_request_commissioning_document_path(@case, @data_request, @commissioning_document) do |f|
-
-        = submit_tag t('button.send_email'), class: 'button data_request_send_email', disabled:!@data_request.has_emails?
-
+        = submit_tag t('button.send_email'), class: 'button data_request_send_email', disabled: @data_request.recipient_emails.empty?
         = link_to(t('common.cancel'), case_data_request_path(@case, @data_request), class: 'acts-like-button button-left-spacing data_request_cancel')

--- a/spec/models/commissioning_document_template/probation_spec.rb
+++ b/spec/models/commissioning_document_template/probation_spec.rb
@@ -43,4 +43,10 @@ RSpec.describe CommissioningDocumentTemplate::Probation do
       end
     end
   end
+
+  describe "#recipient_emails" do
+    it "returns an array of email addresses" do
+      expect(subject.recipient_emails).to eq ["BranstonRegistryRequests2@justice.gov.uk"]
+    end
+  end
 end

--- a/spec/models/data_request_spec.rb
+++ b/spec/models/data_request_spec.rb
@@ -358,7 +358,6 @@ RSpec.describe DataRequest, type: :model do
     let(:email_2) { 'b.jones@email.com' }
     let(:email_3) { 'c.evans@gmail.com' }
     let(:contact_without_email) { build(:contact, data_request_emails:nil) }
-    let(:contact_without_email) { build(:contact, data_request_emails:nil) }
     let(:contact_with_one_email) { build(:contact , data_request_emails: email_1) }
     let(:contact_with_two_emails) { build(:contact , data_request_emails: "#{email_1}\n#{email_2}") }
     let(:commissioning_document) { build(:commissioning_document) }

--- a/spec/models/data_request_spec.rb
+++ b/spec/models/data_request_spec.rb
@@ -353,21 +353,43 @@ RSpec.describe DataRequest, type: :model do
     end
   end
 
-  describe '#has_emails' do
+  describe "#recipient_emails" do
+    let(:email_1) { 'a.smith@email.com' }
+    let(:email_2) { 'b.jones@email.com' }
+    let(:email_3) { 'c.evans@gmail.com' }
     let(:contact_without_email) { build(:contact, data_request_emails:nil) }
-    let(:contact_with_email) { build(:contact , data_request_emails: 'a.smith@email.com') }
+    let(:contact_without_email) { build(:contact, data_request_emails:nil) }
+    let(:contact_with_one_email) { build(:contact , data_request_emails: email_1) }
+    let(:contact_with_two_emails) { build(:contact , data_request_emails: "#{email_1}\n#{email_2}") }
+    let(:commissioning_document) { build(:commissioning_document) }
 
     context 'when there is a contact with no email' do
       subject(:data_request) { build :data_request, contact:contact_without_email}
-      it { expect(subject.has_emails?).to eq false }
+      it { expect(subject.recipient_emails).to eq [] }
     end
+
     context 'when there is a contact with one email' do
-      subject(:data_request) { build :data_request, contact:contact_with_email}
-      it { expect(subject.has_emails?).to eq true }
+      subject(:data_request) { build :data_request, contact:contact_with_one_email}
+      it { expect(subject.recipient_emails).to eq [email_1] }
     end
+
+    context 'when there is a contact with two emails' do
+      subject(:data_request) { build :data_request, contact:contact_with_two_emails}
+      it { expect(subject.recipient_emails).to eq [email_1, email_2] }
+    end
+
     context 'when there is no contact' do
       subject(:data_request) { build :data_request}
-      it { expect(subject.has_emails?).to eq false }
+      it { expect(subject.recipient_emails).to eq [] }
+    end
+
+    context 'when there is a commissioning_document with a recipient email' do
+      before do
+        allow(commissioning_document).to receive(:recipient_emails).and_return [email_3]
+      end
+
+      subject(:data_request) { build :data_request, commissioning_document: commissioning_document}
+      it { expect(subject.recipient_emails).to eq [email_3] }
     end
   end
 end


### PR DESCRIPTION
## Description
All probation template emails need to be emailed to an additional email address.

A new `recipient_emails` method on data_request will hold template specific email addresses and email addresses from the data request contact.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
