### PR TITLE
cdpt 784 Prevent user sending Probation records email when selected Organisation has no email

### DIFF
--- a/app/controllers/cases/data_requests_controller.rb
+++ b/app/controllers/cases/data_requests_controller.rb
@@ -67,6 +67,8 @@ module Cases
     def send_email
       @recipient_emails = @data_request.recipient_emails
 
+      @no_email_present = @recipient_emails.empty?
+
       if @commissioning_document.probation? && !handled_sending_to_branston_archives?
         render :probation_send_email and return
       end
@@ -80,7 +82,6 @@ module Cases
         return false
       end
 
-      @no_email_present = @recipient_emails.empty?
 
       @email = ProbationCommissioningDocumentEmail.new(email_params)
       return false unless @email.valid?

--- a/app/controllers/cases/data_requests_controller.rb
+++ b/app/controllers/cases/data_requests_controller.rb
@@ -82,7 +82,6 @@ module Cases
         return false
       end
 
-
       @email = ProbationCommissioningDocumentEmail.new(email_params)
       return false unless @email.valid?
 

--- a/app/controllers/cases/data_requests_controller.rb
+++ b/app/controllers/cases/data_requests_controller.rb
@@ -80,6 +80,8 @@ module Cases
         return false
       end
 
+      @no_email_present = @recipient_emails.empty?
+
       @email = ProbationCommissioningDocumentEmail.new(email_params)
       return false unless @email.valid?
 

--- a/app/helpers/data_request_helper.rb
+++ b/app/helpers/data_request_helper.rb
@@ -1,0 +1,6 @@
+module DataRequestHelper
+  def only_branston_registry_email
+    @recipient_emails.empty? || (@recipient_emails.count == 1 && @recipient_emails.include?("BranstonRegistryRequests2@justice.gov.uk"))
+
+  end
+end

--- a/app/helpers/data_request_helper.rb
+++ b/app/helpers/data_request_helper.rb
@@ -1,6 +1,5 @@
 module DataRequestHelper
   def only_branston_registry_email
-    recipient_emails = instance_variable_get(:@recipient_emails)
-    recipient_emails.empty? || (recipient_emails.count == 1 && recipient_emails.include?(CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL))
+    @recipient_emails.empty? || (@recipient_emails.count == 1 && @recipient_emails.include?(CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL)) # rubocop:disable Rails::HelperInstanceVariable
   end
 end

--- a/app/helpers/data_request_helper.rb
+++ b/app/helpers/data_request_helper.rb
@@ -1,6 +1,6 @@
 module DataRequestHelper
   def only_branston_registry_email
-    @recipient_emails.empty? || (@recipient_emails.count == 1 && @recipient_emails.include?("BranstonRegistryRequests2@justice.gov.uk"))
-
+    recipient_emails = instance_variable_get(:@recipient_emails)
+    recipient_emails.empty? || (recipient_emails.count == 1 && recipient_emails.include?(CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL))
   end
 end

--- a/app/helpers/data_request_helper.rb
+++ b/app/helpers/data_request_helper.rb
@@ -1,5 +1,0 @@
-module DataRequestHelper
-  def only_branston_registry_email
-    @recipient_emails.empty? || (@recipient_emails.count == 1 && @recipient_emails.include?(CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL)) # rubocop:disable Rails::HelperInstanceVariable
-  end
-end

--- a/app/views/cases/data_requests/send_email.html.slim
+++ b/app/views/cases/data_requests/send_email.html.slim
@@ -6,7 +6,7 @@
 
 = link_to("Back", "javascript:history.back()", class: 'govuk-back-link')
 
-- if only_branston_registry_email
+- if @no_email_present
   <br/>
   <br/>
   <div class="moj-banner" role="region" aria-label="information">
@@ -41,5 +41,5 @@ span.visually-hidden
 
     div.button-holder
       = form_for @commissioning_document, method: :post, url: send_email_case_data_request_commissioning_document_path(@case, @data_request, @commissioning_document) do |f|
-        = submit_tag t('button.send_email'), class: 'button data_request_send_email', disabled: only_branston_registry_email
+        = submit_tag t('button.send_email'), class: 'button data_request_send_email', disabled: @no_email_present
         = link_to(t('common.cancel'), case_data_request_path(@case, @data_request), class: 'acts-like-button data_request_cancel moj-style-link')

--- a/app/views/cases/data_requests/send_email.html.slim
+++ b/app/views/cases/data_requests/send_email.html.slim
@@ -6,7 +6,7 @@
 
 = link_to("Back", "javascript:history.back()", class: 'govuk-back-link')
 
-- if @recipient_emails.empty?
+- if @recipient_emails.empty? || (@recipient_emails.count == 1 && @recipient_emails.include?(CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL))
   <br/>
   <br/>
   <div class="moj-banner" role="region" aria-label="information">
@@ -41,5 +41,5 @@ span.visually-hidden
 
     div.button-holder
       = form_for @commissioning_document, method: :post, url: send_email_case_data_request_commissioning_document_path(@case, @data_request, @commissioning_document) do |f|
-        = submit_tag t('button.send_email'), class: 'button data_request_send_email', disabled: @recipient_emails.empty?
+        = submit_tag t('button.send_email'), class: 'button data_request_send_email', disabled:@recipient_emails.empty? || (@recipient_emails.count == 1 && @recipient_emails.include?(CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL))
         = link_to(t('common.cancel'), case_data_request_path(@case, @data_request), class: 'acts-like-button data_request_cancel moj-style-link')

--- a/app/views/cases/data_requests/send_email.html.slim
+++ b/app/views/cases/data_requests/send_email.html.slim
@@ -6,7 +6,7 @@
 
 = link_to("Back", "javascript:history.back()", class: 'govuk-back-link')
 
-- if @recipient_emails.empty? || (@recipient_emails.count == 1 && @recipient_emails.include?(CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL))
+- if only_branston_registry_email
   <br/>
   <br/>
   <div class="moj-banner" role="region" aria-label="information">
@@ -41,5 +41,5 @@ span.visually-hidden
 
     div.button-holder
       = form_for @commissioning_document, method: :post, url: send_email_case_data_request_commissioning_document_path(@case, @data_request, @commissioning_document) do |f|
-        = submit_tag t('button.send_email'), class: 'button data_request_send_email', disabled:@recipient_emails.empty? || (@recipient_emails.count == 1 && @recipient_emails.include?(CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL))
+        = submit_tag t('button.send_email'), class: 'button data_request_send_email', disabled: only_branston_registry_email
         = link_to(t('common.cancel'), case_data_request_path(@case, @data_request), class: 'acts-like-button data_request_cancel moj-style-link')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1564,7 +1564,7 @@ en:
         unprocessed: No changes made
       upto: "Up to"
       send_email:
-        no_email_address: The selected location does not have an email address.
+        no_email_address: The selected location does not have an email address. Please update or select another.
     commissioning_documents:
       new:
         heading: Select Day 1 request document

--- a/spec/controllers/cases/data_requests_controller_spec.rb
+++ b/spec/controllers/cases/data_requests_controller_spec.rb
@@ -228,6 +228,22 @@ RSpec.describe Cases::DataRequestsController, type: :controller do
       expect(assigns(:recipient_emails)).to eq("test@email.com")
     end
 
+    context "with no associated email" do
+      let(:params) do
+        {
+          id: data_request.id,
+          case_id: data_request.case_id,
+        }
+      end
+
+      it "returns no associated email present" do
+        allow_any_instance_of(DataRequest) # rubocop:disable RSpec/AnyInstance
+          .to receive(:recipient_emails).and_return([])
+        get(:send_email, params:)
+        expect(assigns(:no_email_present)).to eq(true)
+      end
+    end
+
     context "when probation document selected" do
       let(:template_name) { "probation" }
 
@@ -289,26 +305,6 @@ RSpec.describe Cases::DataRequestsController, type: :controller do
           post(:send_email, params:)
           expect(response).to render_template(:probation_send_email)
           expect(assigns(:email)).not_to be_valid
-        end
-      end
-
-      context "with no associated email" do
-        let(:params) do
-          {
-            id: data_request.id,
-            case_id: data_request.case_id,
-            probation_commissioning_document_email: {
-              probation: 1,
-              email_branston_archives: "yes",
-            },
-          }
-        end
-
-        it "has branston registry as only recipient email" do
-          post(:send_email, params:)
-          allow_any_instance_of(DataRequest) # rubocop:disable RSpec/AnyInstance
-            .to receive(:no_email_selected).and_return(true)
-          expect(assigns(:recipient_emails)).to eq([CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL])
         end
       end
     end

--- a/spec/controllers/cases/data_requests_controller_spec.rb
+++ b/spec/controllers/cases/data_requests_controller_spec.rb
@@ -229,13 +229,6 @@ RSpec.describe Cases::DataRequestsController, type: :controller do
     end
 
     context "with no associated email" do
-      let(:params) do
-        {
-          id: data_request.id,
-          case_id: data_request.case_id,
-        }
-      end
-
       it "returns no associated email present" do
         allow_any_instance_of(DataRequest) # rubocop:disable RSpec/AnyInstance
           .to receive(:recipient_emails).and_return([])

--- a/spec/controllers/cases/data_requests_controller_spec.rb
+++ b/spec/controllers/cases/data_requests_controller_spec.rb
@@ -291,6 +291,27 @@ RSpec.describe Cases::DataRequestsController, type: :controller do
           expect(assigns(:email)).not_to be_valid
         end
       end
+
+      context "with no associated email" do
+        let(:params) do
+          {
+            id: data_request.id,
+            case_id: data_request.case_id,
+            probation_commissioning_document_email: {
+              probation: 1,
+              email_branston_archives: "yes",
+            },
+          }
+        end
+
+        it "has branston registry as only recipient email" do
+          post(:send_email, params:)
+          allow_any_instance_of(DataRequest) # rubocop:disable RSpec/AnyInstance
+            .to receive(:no_email_selected).and_return(true)
+          expect(assigns(:recipient_emails)).to eq([CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL])
+        end
+      end
+
     end
 
     context "with non-probation document" do

--- a/spec/controllers/cases/data_requests_controller_spec.rb
+++ b/spec/controllers/cases/data_requests_controller_spec.rb
@@ -311,7 +311,6 @@ RSpec.describe Cases::DataRequestsController, type: :controller do
           expect(assigns(:recipient_emails)).to eq([CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL])
         end
       end
-
     end
 
     context "with non-probation document" do

--- a/spec/views/cases/data_requests/send_email_html_slim_spec.rb
+++ b/spec/views/cases/data_requests/send_email_html_slim_spec.rb
@@ -55,11 +55,11 @@ describe "cases/data_requests/send_email", type: :view do
         data_request_email_confirmation_page.load(rendered)
       end
 
-      it 'has required content' do
+      it "has required content" do
         expect(page.page_heading.heading.text).to eq "Are you sure you want to send the commissioning email?"
         expect(page.page_banner.text).to include "The selected location does not have an email address. Please update or select another."
         expect(page.button_send_email.disabled?).to eq true
-        expect(page.link_cancel.text).to eq 'Cancel'
+        expect(page.link_cancel.text).to eq "Cancel"
       end
     end
 

--- a/spec/views/cases/data_requests/send_email_html_slim_spec.rb
+++ b/spec/views/cases/data_requests/send_email_html_slim_spec.rb
@@ -31,6 +31,7 @@ describe "cases/data_requests/send_email", type: :view do
         assign(:case, data_request.kase)
         assign(:commissioning_document, commissioning_document)
         assign(:recipient_emails, [])
+        assign(:no_email_present, true)
 
         render
         data_request_email_confirmation_page.load(rendered)

--- a/spec/views/cases/data_requests/send_email_html_slim_spec.rb
+++ b/spec/views/cases/data_requests/send_email_html_slim_spec.rb
@@ -56,10 +56,8 @@ describe "cases/data_requests/send_email", type: :view do
       end
 
       it "has required content" do
-        expect(page.page_heading.heading.text).to eq "Are you sure you want to send the commissioning email?"
         expect(page.page_banner.text).to include "The selected location does not have an email address. Please update or select another."
         expect(page.button_send_email.disabled?).to eq true
-        expect(page.link_cancel.text).to eq "Cancel"
       end
     end
 

--- a/spec/views/cases/data_requests/send_email_html_slim_spec.rb
+++ b/spec/views/cases/data_requests/send_email_html_slim_spec.rb
@@ -44,6 +44,25 @@ describe "cases/data_requests/send_email", type: :view do
       end
     end
 
+    context 'data request contact with only the branston probation records email given' do
+      before do
+        assign(:data_request, data_request)
+        assign(:case, data_request.kase)
+        assign(:commissioning_document, commissioning_document)
+        assign(:recipient_emails, [CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL])
+
+        render
+        data_request_email_confirmation_page.load(rendered)
+        @page = data_request_email_confirmation_page
+      end
+      it 'has required content' do
+        expect(@page.page_heading.heading.text).to eq 'Are you sure you want to send the commissioning email?'
+        expect(@page.page_banner.text).to include 'The selected location does not have an email address.'
+        expect(@page.button_send_email.disabled?).to eq true
+        expect(@page.link_cancel.text).to eq 'Cancel'
+      end
+    end
+
     context "with data request with contact which has email address" do
       before do
         assign(:data_request, data_request)

--- a/spec/views/cases/data_requests/send_email_html_slim_spec.rb
+++ b/spec/views/cases/data_requests/send_email_html_slim_spec.rb
@@ -38,13 +38,13 @@ describe "cases/data_requests/send_email", type: :view do
 
       it "has required content" do
         expect(page.page_heading.heading.text).to eq "Are you sure you want to send the commissioning email?"
-        expect(page.page_banner.text).to include "The selected location does not have an email address."
+        expect(page.page_banner.text).to include "The selected location does not have an email address. Please update or select another."
         expect(page.button_send_email.disabled?).to eq true
         expect(page.link_cancel.text).to eq "Cancel"
       end
     end
 
-    context 'data request contact with only the branston probation records email given' do
+    context "with data request contact with only the branston probation records email given" do
       before do
         assign(:data_request, data_request)
         assign(:case, data_request.kase)
@@ -53,13 +53,13 @@ describe "cases/data_requests/send_email", type: :view do
 
         render
         data_request_email_confirmation_page.load(rendered)
-        @page = data_request_email_confirmation_page
       end
+
       it 'has required content' do
-        expect(@page.page_heading.heading.text).to eq 'Are you sure you want to send the commissioning email?'
-        expect(@page.page_banner.text).to include 'The selected location does not have an email address.'
-        expect(@page.button_send_email.disabled?).to eq true
-        expect(@page.link_cancel.text).to eq 'Cancel'
+        expect(page.page_heading.heading.text).to eq "Are you sure you want to send the commissioning email?"
+        expect(page.page_banner.text).to include "The selected location does not have an email address. Please update or select another."
+        expect(page.button_send_email.disabled?).to eq true
+        expect(page.link_cancel.text).to eq 'Cancel'
       end
     end
 

--- a/spec/views/cases/data_requests/send_email_html_slim_spec.rb
+++ b/spec/views/cases/data_requests/send_email_html_slim_spec.rb
@@ -50,6 +50,7 @@ describe "cases/data_requests/send_email", type: :view do
         assign(:case, data_request.kase)
         assign(:commissioning_document, commissioning_document)
         assign(:recipient_emails, [CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL])
+        assign(:no_email_present, true)
 
         render
         data_request_email_confirmation_page.load(rendered)


### PR DESCRIPTION
## Description
If recipient emails are empty (regardless of whether the branston registry email is present), ensures that the moj info banner and email cannot be sent

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?modal=detail&selectedIssue=CDPT-784

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
