### PR TITLE
Replace webdrivers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,6 @@ references:
         sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
         sudo apt-get update
         sudo apt-get install -y google-chrome-stable
-        RAILS_ENV=test bin/rails webdrivers:chromedriver:version
-        RAILS_ENV=test bin/rails webdrivers:chromedriver:update
 
   setup_test_reporter: &setup_test_reporter
     run:

--- a/.local-dev/bin/spec-install.sh
+++ b/.local-dev/bin/spec-install.sh
@@ -27,9 +27,6 @@ if ! bundle show rspec-core 2>/dev/null; then
   sub_header_divider "${YELLOW}Loading DB schema across multiple test databases${NC}"
   bundle exec rails parallel:load_schema | indent
 
-  sub_header_divider "${YELLOW}Attempting to update webdriver version for chrome${NC}"
-  bin/rails webdrivers:chromedriver:update | indent
-
   sub_header "${GREEN}Installation complete! Use ${YELLOW}rspec ${GREEN}like ${NC} bundle exec rspec [spec/path/to/_spec.rb][:line-number]\n\n${DARK_GRAY}******     ${GREEN}Or, use ${YELLOW}parallel testing${GREEN} like${NC} bundle exec rails parallel:spec"
 
   exit;

--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ group :test do
   gem "shoulda-matchers", "~> 5.1"
   gem "simplecov", "~> 0.22.0"
   gem "site_prism", "< 4.0"
-  gem "webdrivers", "~> 5.2.0"
 end
 
 group :development, :test do
@@ -95,7 +94,7 @@ group :development, :test do
   gem "rspec-collection_matchers"
   gem "rspec-rails", "~> 5.0"
   gem "rubocop-govuk", require: false
-  gem "selenium-webdriver", "~> 4.1.0"
+  gem "selenium-webdriver"
   gem "spring-commands-rspec"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,6 @@ GEM
     caxlsx_rails (0.6.3)
       actionpack (>= 3.1)
       caxlsx (>= 3.0)
-    childprocess (4.1.0)
     coderay (1.1.3)
     colorize (0.8.1)
     concurrent-ruby (1.2.2)
@@ -526,10 +525,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    selenium-webdriver (4.1.0)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     sentry-rails (5.3.1)
       railties (>= 5.0)
       sentry-ruby-core (~> 5.3.1)
@@ -606,12 +605,9 @@ GEM
     uniform_notifier (1.16.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webrick (1.7.0)
     webrobots (0.1.2)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -691,7 +687,7 @@ DEPENDENCIES
   rubyzip (>= 1.2.4)
   sablon
   sass-rails (~> 6.0)
-  selenium-webdriver (~> 4.1.0)
+  selenium-webdriver
   sentry-rails
   sentry-ruby
   shell-spinner
@@ -709,7 +705,6 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
-  webdrivers (~> 5.2.0)
   yard
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -215,8 +215,21 @@ rails parallel:spec:non_features
 
 #### Browser testing
 
-We use [headless chrome](https://developers.google.com/web/updates/2017/04/headless-chrome)
-for Capybara tests, which require JavaScript. You will need to install Chrome >= 59.
+We use chromedriver for Capybara tests, which require JavaScript. You can install using
+```
+brew install chromedriver
+```
+
+or to upgrade
+```
+brew upgrade chromedriver
+```
+
+If your Mac does not want to allow permission to the executable this can be overcome by running:
+```
+xattr -d com.apple.quarantine $(which chromedriver)
+```
+
 Where we don't require JavaScript to test a feature we use Capybara's default driver
 [RackTest](https://github.com/teamcapybara/capybara#racktest) which is ruby based
 and much faster as it does not require a server to be started.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,17 +20,9 @@ require "rspec/rails"
 require "capybara/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 require "capybara/rspec"
-
-# Webdrivers - Moved from deprecated chrome-helpers gem. Behaviour changed to require you to
-# explicitly issue a scroll command to bring off-screen elements below the fold up into view
-# before you click on them in feature specs
-# See https://stackoverflow.com/questions/55406656
-# and https://www.rubydoc.info/gems/capybara/Capybara/Node/Element#scroll_to-instance_method
-require "webdrivers"
 require "rails-controller-testing"
 require "paper_trail/frameworks/rspec"
 
-Webdrivers.cache_time = 86_400
 Capybara.default_max_wait_time = 4
 
 options = Selenium::WebDriver::Chrome::Options.new


### PR DESCRIPTION
## Description
A change to chrome (https://developer.chrome.com/blog/chrome-for-testing/) means that the latest version is not available via the webdrivers gem. 

It's use is no longer required with more recent versions of selenium-webdriver.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
