### PR TITLE
Fix InitialSeed migration

### DIFF
--- a/db/data_migrations/20180101000000_initial_seed.rb
+++ b/db/data_migrations/20180101000000_initial_seed.rb
@@ -1,8 +1,8 @@
 class InitialSeed < ActiveRecord::DataMigration
   def up
-    require Rails.root.join("db/seeders/correspondence_type_seeder").to_s
-    require Rails.root.join("db/seeders/case_closure_metadata_seeder").to_s
-    require Rails.root.join("db/seeders/report_type_seeder").to_s
+    require Rails.root.join("db/seeders/correspondence_type_seeder")
+    require Rails.root.join("db/seeders/case_closure_metadata_seeder")
+    require Rails.root.join("db/seeders/report_type_seeder")
 
     CorrespondenceTypeSeeder.new.seed!
     ReportTypeSeeder.new.seed!(verbose: true)

--- a/db/data_migrations/20180101000000_initial_seed.rb
+++ b/db/data_migrations/20180101000000_initial_seed.rb
@@ -1,8 +1,8 @@
 class InitialSeed < ActiveRecord::DataMigration
   def up
-    require File.join(Rails.root, 'db', 'seeders', 'correspondence_type_seeder')
-    require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
-    require File.join(Rails.root, 'db', 'seeders', 'report_type_seeder')
+    require Rails.root.join("db/seeders/correspondence_type_seeder").to_s
+    require Rails.root.join("db/seeders/case_closure_metadata_seeder").to_s
+    require Rails.root.join("db/seeders/report_type_seeder").to_s
 
     CorrespondenceTypeSeeder.new.seed!
     ReportTypeSeeder.new.seed!(verbose: true)

--- a/db/data_migrations/20180101000000_initial_seed.rb
+++ b/db/data_migrations/20180101000000_initial_seed.rb
@@ -1,8 +1,8 @@
 class InitialSeed < ActiveRecord::DataMigration
   def up
-    require Rails.root("db/seeders/correspondence_type_seeder")
-    require Rails.root("db/seeders/case_closure_metadata_seeder")
-    require Rails.root("db/seeders/report_type_seeder")
+    require File.join(Rails.root, 'db', 'seeders', 'correspondence_type_seeder')
+    require File.join(Rails.root, 'db', 'seeders', 'case_closure_metadata_seeder')
+    require File.join(Rails.root, 'db', 'seeders', 'report_type_seeder')
 
     CorrespondenceTypeSeeder.new.seed!
     ReportTypeSeeder.new.seed!(verbose: true)


### PR DESCRIPTION
## Description

When attempting to use 'rails db:reseed' on local db, an error occurred as below. Using join on the Rails root fixes the issue. 

== 20180101000000 InitialSeed: migrating ======================================
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:
wrong number of arguments (given 1, expected 0)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
