### PR TITLE
Don't try to save if readonly

### DIFF
--- a/app/jobs/search_index_updater_job.rb
+++ b/app/jobs/search_index_updater_job.rb
@@ -6,7 +6,7 @@ class SearchIndexUpdaterJob < ApplicationJob
     kase = Case::Base.find(case_id)
     if kase
       kase.update_index
-      kase.mark_as_clean! if kase.dirty?
+      kase.mark_as_clean! if kase.dirty? && !kase.readonly?
     end
   end
 end


### PR DESCRIPTION
## Description
There have been a lot of exceptions where we have attempted to save readonly records when updating the search index. 
Records are set as readonly when they are loaded via a join.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
