### PR TITLE
CDPT-1068 Allow viewing but not editing of data request when case is closed

### DIFF
--- a/app/controllers/cases/data_requests_controller.rb
+++ b/app/controllers/cases/data_requests_controller.rb
@@ -138,7 +138,11 @@ module Cases
     end
 
     def authorize_action
-      authorize @case, :can_record_data_request?
+      if action_name == "show"
+        authorize @case, :show?
+      else
+        authorize @case, :can_record_data_request?
+      end
     end
   end
 end

--- a/app/views/cases/data_requests/show.html.slim
+++ b/app/views/cases/data_requests/show.html.slim
@@ -68,10 +68,10 @@ span.visually-hidden
           = t('helpers.label.data_request.date_completed')
         p.data_request_date_completed
           = l @data_request.cached_date_received, format: :default
-    - if @case.editable?
+    - if @case.editable? && policy(@case).can_record_data_request?
         = link_to t('.edit_link'), edit_case_data_request_path(@case, @data_request), class: 'data-requests__action'
-    hr
     - if @commissioning_document.present? && FeatureSet.email_commissioning_document.enabled?
+      hr
       div.commissioning-document
         h2.heading-medium
           = t('.emails_header')
@@ -87,12 +87,12 @@ span.visually-hidden
               td = @commissioning_document.updated_at
               td
                 span = @commissioning_document.download_link
-                - unless @commissioning_document.sent?
+                - unless @commissioning_document.sent? || !policy(@case).can_record_data_request?
                   = ' | '
                   span = @commissioning_document.replace_link
                   = ' | '
                   span = @commissioning_document.change_link
-        - unless @commissioning_document.sent?
+        - unless @commissioning_document.sent? || !policy(@case).can_record_data_request?
           div.button-holder
             = link_to t('button.send_email'), send_email_case_data_request_path(@case, @data_request), class: 'button data_request_send_email', style: 'margin-top: -6px'
 
@@ -113,6 +113,7 @@ span.visually-hidden
                   td = email.email_address
                   td = email.created_at
                   td = email.status
-    - else
+    - elsif policy(@case).can_record_data_request?
+      hr
       div.button-holder
         = link_to t('button.select_document'), new_case_data_request_commissioning_document_path(@case, @data_request), class: 'button data_request_select_document', style: 'margin-top: -6px'

--- a/app/views/cases/offender_sar/_data_requests.html.slim
+++ b/app/views/cases/offender_sar/_data_requests.html.slim
@@ -41,7 +41,7 @@
               td
                 = link_to t('cases.data_requests.show.link'), case_data_request_path(case_details, data_request), class: 'data-requests__show'
               td
-                - if allow_editing
+                - if policy(case_details).can_record_data_request? && allow_editing
                   = link_to t('cases.data_requests.edit.link'), edit_case_data_request_path(case_details, data_request), class: 'data-requests__edit'
 
           - if case_details.data_requests.many?
@@ -52,4 +52,3 @@
   - if case_details.current_state != 'to_be_assessed' && allow_editing
     = link_to I18n.t('button.exempt_pages'), edit_step_case_sar_offender_path(case_details, 'exempt_pages'), class: 'button-tertiary'
     = link_to I18n.t('button.final_page_count'), edit_step_case_sar_offender_path(case_details, 'final_page_count'), class: 'button-tertiary'
-

--- a/spec/controllers/cases/data_requests_controller_spec.rb
+++ b/spec/controllers/cases/data_requests_controller_spec.rb
@@ -91,6 +91,23 @@ RSpec.describe Cases::DataRequestsController, type: :controller do
       expect(assigns(:data_request).cached_num_pages).to eq 10
       expect(assigns(:data_request).cached_date_received).to eq Time.zone.yesterday
     end
+
+    context "when closed case" do
+      let(:data_request) do
+        create(
+          :data_request,
+          offender_sar_case: create(:offender_sar_case, :closed),
+          cached_num_pages: 10,
+          completed: true,
+          cached_date_received: Time.zone.yesterday,
+        )
+      end
+
+      it "allows access" do
+        get(:show, params:)
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe "#edit" do
@@ -116,6 +133,23 @@ RSpec.describe Cases::DataRequestsController, type: :controller do
       expect(assigns(:data_request)).to be_a DataRequest
       expect(assigns(:data_request).cached_num_pages).to eq 10
       expect(assigns(:data_request).cached_date_received).to eq Time.zone.yesterday
+    end
+
+    context "when closed case" do
+      let(:data_request) do
+        create(
+          :data_request,
+          offender_sar_case: create(:offender_sar_case, :closed),
+          cached_num_pages: 10,
+          completed: true,
+          cached_date_received: Time.zone.yesterday,
+        )
+      end
+
+      it "does not authorise access" do
+        get(:edit, params:)
+        expect(flash[:alert]).to eq "You cannot edit data request once the case has been closed."
+      end
     end
   end
 

--- a/spec/views/cases/data_requests/show_html_slim_spec.rb
+++ b/spec/views/cases/data_requests/show_html_slim_spec.rb
@@ -33,6 +33,18 @@ describe "cases/data_requests/show", type: :view do
 
     let(:page) { data_request_show_page }
 
+    let(:policy) do
+      instance_double("Pundit::Policy").tap do |p|
+        allow(view).to receive(:policy).and_return(p)
+      end
+    end
+
+    let(:can_record_data_request) { true }
+
+    before do
+      allow(policy).to receive(:can_record_data_request?).and_return can_record_data_request
+    end
+
     context "when data request without commissioning document" do
       before do
         assign(:data_request, data_request)
@@ -105,6 +117,22 @@ describe "cases/data_requests/show", type: :view do
         expect(page.commissioning_document.email_row.email_address.text).to eq email_address
         expect(page.commissioning_document.email_row.created_at.text).to eq "7 Jul 2023 14:53"
         expect(page.commissioning_document.email_row.status.text).to eq "Created"
+      end
+    end
+
+    context "when case is closed" do
+      let(:can_record_data_request) { false }
+
+      before do
+        assign(:data_request, data_request)
+        assign(:case, data_request.kase)
+
+        render
+        data_request_show_page.load(rendered)
+      end
+
+      it "does not have edit link" do
+        expect(page).not_to have_link_edit
       end
     end
   end


### PR DESCRIPTION
## Description
Allows access to show page, but removes links for editing. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
