### PR TITLE
Fix offender sar creation page flow 

### DIFF
--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -29,7 +29,7 @@ module Cases
 
     def new
       permitted_correspondence_types
-      @is_rejected = params["rejected"]
+      @rejected = params["rejected"]
       authorize case_type, :can_add_case?
       @case = build_case_from_session(case_type)
       @case.current_step = params[:step]

--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -331,12 +331,12 @@ module Cases
       request_dated_exists = values.fetch("request_dated", false)
       values["request_dated"] = nil unless request_dated_exists
 
-      rejected_set_current_state(params, values)
+      rejected_set_current_state(values)
 
       correspondence_type.new(values).decorate
     end
 
-    def rejected_set_current_state(params, values)
+    def rejected_set_current_state(values)
       case params["rejected"]
       when "true"
         values["current_state"] = "rejected"

--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -29,7 +29,7 @@ module Cases
 
     def new
       permitted_correspondence_types
-      @is_rejected = params.key?("rejected")
+      @is_rejected = params["rejected"]
       authorize case_type, :can_add_case?
       @case = build_case_from_session(case_type)
       @case.current_step = params[:step]
@@ -330,9 +330,19 @@ module Cases
       # similar workaround needed for request dated
       request_dated_exists = values.fetch("request_dated", false)
       values["request_dated"] = nil unless request_dated_exists
-      values["current_state"] = "rejected" if params.key?("rejected")
+
+      rejected_set_current_state(params, values)
 
       correspondence_type.new(values).decorate
+    end
+
+    def rejected_set_current_state(params, values)
+      case params["rejected"]
+      when "true"
+        values["current_state"] = "rejected"
+      when "false"
+        values["current_state"] = "data_to_be_requested"
+      end
     end
 
     def session_persist_state(params)

--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -341,7 +341,7 @@ module Cases
       when "true"
         values["current_state"] = "rejected"
       when "false"
-        values["current_state"] = "data_to_be_requested"
+        values.delete("current_state")
       end
     end
 

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -32,8 +32,6 @@
     - fieldset.radio_input(true, text_method: :humanize)
     - fieldset.radio_input(false, text_method: :humanize)
 
-  = f.hidden_field :current_state, value: "#{@is_rejected == "true" ? 'rejected' : 'data_to_be_requested'}"
-
   input name="current_step" type="hidden" value=@case.current_step
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -32,7 +32,7 @@
     - fieldset.radio_input(true, text_method: :humanize)
     - fieldset.radio_input(false, text_method: :humanize)
 
-  = f.hidden_field :current_state, value: "rejected" if @is_rejected
+  = f.hidden_field :current_state, value: "#{@is_rejected == "true" ? 'rejected' : 'data_to_be_requested'}"
 
   input name="current_step" type="hidden" value=@case.current_step
 

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -32,6 +32,8 @@
     - fieldset.radio_input(true, text_method: :humanize)
     - fieldset.radio_input(false, text_method: :humanize)
 
+  / = f.hidden_field :current_state, value: "#{@is_rejected == "true" ? 'rejected' : 'data_to_be_requested'}"
+
   input name="current_step" type="hidden" value=@case.current_step
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -32,7 +32,7 @@
     - fieldset.radio_input(true, text_method: :humanize)
     - fieldset.radio_input(false, text_method: :humanize)
 
-  = f.hidden_field :current_state, value: "#{@is_rejected == "true" ? 'rejected' : 'data_to_be_requested'}"
+  = f.hidden_field :current_state, value: "#{@rejected == "true" ? 'rejected' : 'data_to_be_requested'}"
 
   input name="current_step" type="hidden" value=@case.current_step
 

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -32,7 +32,7 @@
     - fieldset.radio_input(true, text_method: :humanize)
     - fieldset.radio_input(false, text_method: :humanize)
 
-  / = f.hidden_field :current_state, value: "#{@is_rejected == "true" ? 'rejected' : 'data_to_be_requested'}"
+  = f.hidden_field :current_state, value: "#{@is_rejected == "true" ? 'rejected' : 'data_to_be_requested'}"
 
   input name="current_step" type="hidden" value=@case.current_step
 

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -32,6 +32,8 @@
     - fieldset.radio_input(true, text_method: :humanize)
     - fieldset.radio_input(false, text_method: :humanize)
 
+  = f.hidden_field :current_state, value: "#{@is_rejected == "true" ? 'rejected' : 'data_to_be_requested'}"
+
   input name="current_step" type="hidden" value=@case.current_step
 
   = f.submit 'Continue', class: 'button'

--- a/app/views/cases/offender_sar_select_type.html.slim
+++ b/app/views/cases/offender_sar_select_type.html.slim
@@ -14,7 +14,7 @@ ul#create-correspondences
   label.form-label
     = t('helpers.label.correspondence_types.status.valid')
   li
-      = p link_to t('.valid_offender_sar'), new_case_sar_offender_path
+      = p link_to t('.valid_offender_sar'), new_case_sar_offender_path(params: {rejected: false})
   <br/>
 
   label.form-label

--- a/spec/features/cases/offender_sar/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar/case_creating_spec.rb
@@ -19,6 +19,7 @@ feature "Offender SAR Case creation by a manager", js: true do
     and_fill_in_requested_info_page
     and_fill_in_request_details_page
     and_fill_in_date_received_page
+    then_expect_case_state_to_be_rejected
     then_expect_open_cases_page_to_be_correct
   end
 
@@ -83,6 +84,25 @@ feature "Offender SAR Case creation by a manager", js: true do
       "6fe2bd8a-ebd2-49a4-b1c9-94955d9472f1",
     )
     then_expect_no_third_party_info_stored("6fe2bd8a-ebd2-49a4-b1c9-94955d9472f1")
+  end
+
+  scenario "6 user starts a rejected case but restarts midway to a valid case" do
+    when_i_navigate_to_rejected_offender_sar_subject_page
+    and_fill_in_subject_details_page
+    and_fill_in_requester_details_page_for_rejected_case(:third_party)
+    and_fill_in_reason_rejected_page
+
+    # User decides to cancel a rejected case and switches to creating a valid case.
+    cases_page.load
+    when_i_navigate_to_offender_sar_subject_page
+    and_fill_in_subject_details_page
+    and_fill_in_requester_details_page(:third_party)
+    and_fill_in_recipient_details_page(recipient: "subject_recipient")
+    and_fill_in_requested_info_page
+    and_fill_in_request_details_page
+    and_fill_in_date_received_page
+    then_expect_case_state_to_be_data_to_be_requested
+    then_expect_open_cases_page_to_be_correct
   end
 
   def then_expect_cases_show_page_to_be_correct_for_solicitor_requesting_data_for_data_subject
@@ -193,6 +213,18 @@ feature "Offender SAR Case creation by a manager", js: true do
     expect(cases_show_page).to be_displayed
     expect(cases_show_page).to have_content "Case created successfully"
     expect(cases_show_page.page_heading).to have_content "Sabrina Adams"
+  end
+
+  def then_expect_case_state_to_be_data_to_be_requested
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content "Case created successfully"
+    expect(cases_show_page.case_status).to have_content "Data to be requested"
+  end
+
+  def then_expect_case_state_to_be_rejected
+    expect(cases_show_page).to be_displayed
+    expect(cases_show_page).to have_content "Case created successfully"
+    expect(cases_show_page.case_status).to have_content "Rejected"
   end
 
   def then_expect_open_cases_page_to_be_correct


### PR DESCRIPTION
## Description
For valid and rejected offender sar creation. When swapping midway through the creation steps from valid to rejected (e.g if the user changed their mind on the case type to create), the state was not changing to reflect this change. 

Therefore, starting a valid case after a partially made rejected case would incorrectly render the reason-rejected page and give the case a rejected state.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
