### PR TITLE
Fix ci deprecation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,10 +235,10 @@ jobs:
       - *set_up_the_database
       - *rubocop
       - *brakeman
-      # - *update_chrome
-      # - *setup_test_reporter
-      # - *run_unit_and_feature_tests
-      # - *upload_test_coverage
+      - *update_chrome
+      - *setup_test_reporter
+      - *run_unit_and_feature_tests
+      - *upload_test_coverage
 
   build_branch_and_push_to_ecr:
     executor: machine_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
-  aws-cli: circleci/aws-cli@4.0.0 # use v4 of this orb
+  aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
   aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 references:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,11 @@ orbs:
   aws-cli: circleci/aws-cli@4.0.0 # use v4 of this orb
   aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
+executors:
+  machine_executor:
+    machine:
+      image: default
+
 references:
   defaults: &defaults
     working_directory: ~/track-a-query
@@ -236,10 +241,7 @@ jobs:
       # - *upload_test_coverage
 
   build_branch_and_push_to_ecr:
-    # executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
-    machine:
-      image: default
-
+    executor: machine_executor
     <<: *defaults
     steps:
       - checkout
@@ -255,7 +257,7 @@ jobs:
             - build_tag
 
   build_main_and_push_to_ecr:
-    executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
+    executor: machine_executor
     <<: *defaults
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 references:
   defaults: &defaults
@@ -166,14 +166,11 @@ references:
         echo $BUILD_TAG > workspace/build_tag
 
   build_and_push_image: &build_and_push_image
-    aws-ecr/build_and_push_image:
+    aws-ecr/build-image:
+      push-image: true
       tag: $BUILD_TAG
       region: $ECR_REGION
       repo: $ECR_REPOSITORY
-      auth:
-        aws-cli/setup:
-          role_arn: $ECR_ROLE_TO_ASSUME
-          region: $ECR_REGION
       extra-build-args: |
         --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
         --build-arg COMMIT_ID=$CIRCLE_SHA1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 references:
   defaults: &defaults
@@ -166,7 +166,7 @@ references:
         echo $BUILD_TAG > workspace/build_tag
 
   build_and_push_image: &build_and_push_image
-    aws-ecr/build-image:
+    aws-ecr/build_image:
       push-image: true
       tag: $BUILD_TAG
       region: $ECR_REGION
@@ -235,8 +235,6 @@ jobs:
       # - *upload_test_coverage
 
   build_branch_and_push_to_ecr:
-    machine:
-      image: default
     executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
 
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,10 @@ references:
       tag: $BUILD_TAG
       region: $ECR_REGION
       repo: $ECR_REPOSITORY
+      auth:
+        aws-cli/setup:
+          role_arn: $ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
       extra-build-args: |
         --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
         --build-arg COMMIT_ID=$CIRCLE_SHA1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,13 +166,13 @@ references:
         echo $BUILD_TAG > workspace/build_tag
 
   build_and_push_image: &build_and_push_image
-    aws-ecr/build_image:
-      push_image: true
+    aws-ecr/build-image:
+      push-image: true
       tag: $BUILD_TAG
       region: $ECR_REGION
       repo: $ECR_REPOSITORY
-      account_id: $AWS_ECR_REGISTRY_ID
-      extra_build_args: |
+      # account_id: $AWS_ECR_REGISTRY_ID
+      extra-build-args: |
         --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
         --build-arg COMMIT_ID=$CIRCLE_SHA1 \
         --build-arg BUILD_TAG=$BUILD_TAG \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,8 @@ jobs:
       # - *upload_test_coverage
 
   build_branch_and_push_to_ecr:
+    machine:
+      image: default
     executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
 
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,6 @@ references:
       tag: $BUILD_TAG
       region: $ECR_REGION
       repo: $ECR_REPOSITORY
-      # account_id: $AWS_ECR_REGISTRY_ID
       extra-build-args: |
         --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
         --build-arg COMMIT_ID=$CIRCLE_SHA1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
-  aws-cli: circleci/aws-cli@4.1.2 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@9.0 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
+  aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 references:
   defaults: &defaults
@@ -236,7 +236,9 @@ jobs:
       # - *upload_test_coverage
 
   build_branch_and_push_to_ecr:
-    executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
+    # executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
+    machine:
+      image: default
 
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,7 @@ references:
       tag: $BUILD_TAG
       region: $ECR_REGION
       repo: $ECR_REPOSITORY
+      account_id: $AWS_ECR_REGISTRY_ID
       extra_build_args: |
         --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
         --build-arg COMMIT_ID=$CIRCLE_SHA1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,8 +166,7 @@ references:
         echo $BUILD_TAG > workspace/build_tag
 
   build_and_push_image: &build_and_push_image
-    aws-ecr/build-image:
-      push-image: true
+    aws-ecr/build_and_push_image:
       tag: $BUILD_TAG
       region: $ECR_REGION
       repo: $ECR_REPOSITORY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
-  aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
+  aws-cli: circleci/aws-cli@4.0.0 # use v4 of this orb
   aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 references:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,11 +167,11 @@ references:
 
   build_and_push_image: &build_and_push_image
     aws-ecr/build_image:
-      push-image: true
+      push_image: true
       tag: $BUILD_TAG
       region: $ECR_REGION
       repo: $ECR_REPOSITORY
-      extra-build-args: |
+      extra_build_args: |
         --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
         --build-arg COMMIT_ID=$CIRCLE_SHA1 \
         --build-arg BUILD_TAG=$BUILD_TAG \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
   aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 references:
   defaults: &defaults
@@ -236,6 +236,7 @@ jobs:
 
   build_branch_and_push_to_ecr:
     executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
+
     <<: *defaults
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 orbs:
   slack: circleci/slack@3.4.2
-  aws-cli: circleci/aws-cli@4.1.3 # use v4 of this orb
-  aws-ecr: circleci/aws-ecr@9.0.2 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
+  aws-cli: circleci/aws-cli@4.1.2 # use v4 of this orb
+  aws-ecr: circleci/aws-ecr@9.0 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 references:
   defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,10 +229,10 @@ jobs:
       - *set_up_the_database
       - *rubocop
       - *brakeman
-      - *update_chrome
-      - *setup_test_reporter
-      - *run_unit_and_feature_tests
-      - *upload_test_coverage
+      # - *update_chrome
+      # - *setup_test_reporter
+      # - *run_unit_and_feature_tests
+      # - *upload_test_coverage
 
   build_branch_and_push_to_ecr:
     executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon


### PR DESCRIPTION
## Description
The build is using an image that is no longer available. We have being using the executor from circleci/aws-ecr, but the image used is being deprecated. Updating the orb causes issues, so a new executor has been added.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
