### PR TITLE
Cdpt 1456 allow user to update rejected reason from case details

### DIFF
--- a/app/models/report_type.rb
+++ b/app/models/report_type.rb
@@ -31,7 +31,6 @@ class ReportType < ApplicationRecord
   scope :offender_sar, -> { where(offender_sar: true) }
   scope :offender_sar_complaint, -> { where(offender_sar_complaint: true) }
   scope :closed_cases_report, -> { where(abbr: "R007") }
-  scope :
 
   validates :default_reporting_period, presence: true, inclusion: { in: VALID_DEFAULT_REPORTING_PERIODS }
 

--- a/app/models/report_type.rb
+++ b/app/models/report_type.rb
@@ -31,6 +31,7 @@ class ReportType < ApplicationRecord
   scope :offender_sar, -> { where(offender_sar: true) }
   scope :offender_sar_complaint, -> { where(offender_sar_complaint: true) }
   scope :closed_cases_report, -> { where(abbr: "R007") }
+  scope :
 
   validates :default_reporting_period, presence: true, inclusion: { in: VALID_DEFAULT_REPORTING_PERIODS }
 

--- a/app/views/cases/offender_sar/_reason_rejected_details.html.slim
+++ b/app/views/cases/offender_sar/_reason_rejected_details.html.slim
@@ -1,4 +1,5 @@
-tr.rejected-reasons.section
+tr.rejected-reasons.section.section-rejected-reasons
   th = t('common.case.rejected_reason')
   td = raw case_details.rejected_reasons_descriptions
-  td = link_to t('common.links.change'), edit_step_case_sar_offender_path(case_details, "reason-rejected") if case_details.current_state == "rejected"
+  - if case_details.current_state == "rejected"
+    td = link_to t('common.links.change'), edit_step_case_sar_offender_path(case_details, "reason_rejected")

--- a/app/views/cases/offender_sar/_reason_rejected_details.html.slim
+++ b/app/views/cases/offender_sar/_reason_rejected_details.html.slim
@@ -1,4 +1,4 @@
 tr.rejected-reasons.section
   th = t('common.case.rejected_reason')
   td = raw case_details.rejected_reasons_descriptions
-  td = link_to t('common.links.change'), edit_step_case_sar_offender_path(case_details, "reason-rejected")
+  td = link_to t('common.links.change'), edit_step_case_sar_offender_path(case_details, "reason-rejected") if case_details.current_state == "rejected"

--- a/app/views/cases/offender_sar/_reason_rejected_details.html.slim
+++ b/app/views/cases/offender_sar/_reason_rejected_details.html.slim
@@ -1,3 +1,4 @@
 tr.rejected-reasons.section
   th = t('common.case.rejected_reason')
   td = raw case_details.rejected_reasons_descriptions
+  td = link_to t('common.links.change'), edit_step_case_sar_offender_path(case_details, "reason-rejected")

--- a/spec/features/cases/offender_sar/rejected_case_editing_spec.rb
+++ b/spec/features/cases/offender_sar/rejected_case_editing_spec.rb
@@ -4,7 +4,7 @@ require Rails.root.join("db/seeders/case_category_reference_seeder")
 feature "Offender SAR Case editing by a manager", :js do
   given(:manager)         { find_or_create :branston_user }
   given(:managing_team)   { create :managing_team, managers: [manager] }
-  given(:offender_sar_case) { create :offender_sar_case, :rejected, :third_party, received_date: Time.zone.today.to_date, rejected_reasons: %w[cctv_bwcv change_of_name_certificate court_data_request] }
+  given(:offender_sar_case) { create :offender_sar_case, :rejected, :third_party, received_date: Time.zone.today.to_date, rejected_reasons: %w[cctv_bwcv medical_data court_data_request] }
 
   background do
     find_or_create :team_branston
@@ -28,9 +28,33 @@ feature "Offender SAR Case editing by a manager", :js do
     expect(cases_show_page.case_history).to have_content "Valid case created"
 
     expect(cases_show_page).to have_content "CCTV / BWCV request"
-    expect(cases_show_page).to have_content "Change of name certificate"
+    expect(cases_show_page).to have_content "Medical data"
     expect(cases_show_page).to have_content "Court data request"
 
     expect(cases_show_page).to have_content(I18n.l(offender_sar_case.received_date - 1, format: :default))
   end
+
+  scenario "user can see the 'change' link and edit the rejected reasons" do
+    expect(cases_show_page).to be_displayed(id: offender_sar_case.id)
+    cases_show_page.offender_sar_reason_rejected.change_link.click
+
+    expect(cases_edit_offender_sar_reason_rejected_page).to be_displayed
+    cases_edit_offender_sar_reason_rejected_page.choose_rejected_reason("telephone_transcripts")
+    click_on "Continue"
+
+    expect(cases_show_page).to have_content "Case updated"
+    expect(cases_show_page).to have_content "Telephone transcripts"
+  end
+
+  scenario "user cannot see the 'change' link after validating a rejected case" do
+    expect(cases_show_page).to be_displayed(id: offender_sar_case.id)
+
+    click_on "Create valid case"
+    expect(cases_edit_offender_sar_accepted_date_received_page).to be_displayed
+    cases_edit_offender_sar_accepted_date_received_page.set_received_date(1.day.ago)
+    click_on "Continue"
+
+    expect(cases_show_page.offender_sar_reason_rejected).not_to have_content "Change"
+  end
+
 end

--- a/spec/features/cases/offender_sar/rejected_case_editing_spec.rb
+++ b/spec/features/cases/offender_sar/rejected_case_editing_spec.rb
@@ -56,5 +56,4 @@ feature "Offender SAR Case editing by a manager", :js do
 
     expect(cases_show_page.offender_sar_reason_rejected).not_to have_content "Change"
   end
-
 end

--- a/spec/features/cases/offender_sar/rejected_case_editing_spec.rb
+++ b/spec/features/cases/offender_sar/rejected_case_editing_spec.rb
@@ -4,7 +4,7 @@ require Rails.root.join("db/seeders/case_category_reference_seeder")
 feature "Offender SAR Case editing by a manager", :js do
   given(:manager)         { find_or_create :branston_user }
   given(:managing_team)   { create :managing_team, managers: [manager] }
-  given(:offender_sar_case) { create :offender_sar_case, :rejected, :third_party, received_date: Time.zone.today.to_date, rejected_reasons: %w[cctv_bwcv medical_data court_data_request] }
+  given(:offender_sar_case) { create :offender_sar_case, :rejected, :third_party, received_date: Time.zone.today.to_date, rejected_reasons: %w[cctv_bwcv change_of_name_certificate court_data_request] }
 
   background do
     find_or_create :team_branston
@@ -28,13 +28,13 @@ feature "Offender SAR Case editing by a manager", :js do
     expect(cases_show_page.case_history).to have_content "Valid case created"
 
     expect(cases_show_page).to have_content "CCTV / BWCV request"
-    expect(cases_show_page).to have_content "Medical data"
+    expect(cases_show_page).to have_content "Change of name certificate"
     expect(cases_show_page).to have_content "Court data request"
 
     expect(cases_show_page).to have_content(I18n.l(offender_sar_case.received_date - 1, format: :default))
   end
 
-  scenario "user can see the 'change' link and edit the rejected reasons" do
+  scenario "user can click the 'change' link and edit the rejected reasons" do
     expect(cases_show_page).to be_displayed(id: offender_sar_case.id)
     cases_show_page.offender_sar_reason_rejected.change_link.click
 
@@ -54,6 +54,6 @@ feature "Offender SAR Case editing by a manager", :js do
     cases_edit_offender_sar_accepted_date_received_page.set_received_date(1.day.ago)
     click_on "Continue"
 
-    expect(cases_show_page.offender_sar_reason_rejected).not_to have_content "Change"
+    expect(cases_show_page.offender_sar_reason_rejected).not_to have_link "Change"
   end
 end

--- a/spec/site_prism/page_objects/pages/application.rb
+++ b/spec/site_prism/page_objects/pages/application.rb
@@ -57,6 +57,8 @@ module PageObjects
         cases_edit_offender_sar_reason_for_lateness: "Cases::Edit::OffenderSARPageRecordReasonForLateness",
         cases_edit_offender_sar_sent_to_sscl: "Cases::Edit::OffenderSARPageSentToSscl",
         cases_edit_offender_sar_accepted_date_received: "Cases::Edit::OffenderSARAcceptedDateReceived",
+        cases_edit_offender_sar_reason_rejected: "Cases::Edit::OffenderSARPageReasonRejected",
+
 
         cases_new_offender_sar_complaint_confirm_case: "Cases::New::OffenderSARComplaintPageConfirmCase",
         cases_new_offender_sar_complaint_link_offender_sar: "Cases::New::OffenderSARComplaintPageLinkSarCase",

--- a/spec/site_prism/page_objects/pages/application.rb
+++ b/spec/site_prism/page_objects/pages/application.rb
@@ -59,7 +59,6 @@ module PageObjects
         cases_edit_offender_sar_accepted_date_received: "Cases::Edit::OffenderSARAcceptedDateReceived",
         cases_edit_offender_sar_reason_rejected: "Cases::Edit::OffenderSARPageReasonRejected",
 
-
         cases_new_offender_sar_complaint_confirm_case: "Cases::New::OffenderSARComplaintPageConfirmCase",
         cases_new_offender_sar_complaint_link_offender_sar: "Cases::New::OffenderSARComplaintPageLinkSarCase",
         cases_new_offender_sar_complaint_complaint_type: "Cases::New::OffenderSARComplaintPageComplaintType",

--- a/spec/site_prism/page_objects/pages/cases/edit/offender_sar_page_reason_rejected_edit.rb
+++ b/spec/site_prism/page_objects/pages/cases/edit/offender_sar_page_reason_rejected_edit.rb
@@ -1,0 +1,24 @@
+module PageObjects
+  module Pages
+    module Cases
+      module Edit
+        class OffenderSARPageReasonRejected < PageObjects::Pages::Base
+          set_url "/cases/offender_sars/{id}/edit/reason_rejected"
+
+          section :primary_navigation,
+                  PageObjects::Sections::PrimaryNavigationSection, ".global-nav"
+
+          section :page_heading,
+                  PageObjects::Sections::PageHeadingSection, ".page-heading"
+
+          element :rejected_reason, "#rejected_reasons"
+          element :submit_button, ".button"
+
+          def choose_rejected_reason(choice)
+            make_check_box_choice("offender_sar_rejected_reasons_#{choice}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/pages/cases/show_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/show_page.rb
@@ -104,6 +104,10 @@ module PageObjects
           element :change_link, "a"
         end
 
+        section :offender_sar_reason_rejected, ".section-rejected-reasons" do
+          element :change_link, "a"
+        end
+
         section :offender_sar_requested_info, ".section-requested-heading" do
           element :change_link, "a"
         end

--- a/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
@@ -73,7 +73,24 @@ describe "cases/offender_sar/case_details.html.slim", type: :view do
       }
 
       partial = offender_sar_case_details_section(rendered).sar_basic_details
+
       expect(partial.rejected_reason.data.text).to eq "Further identification"
+    end
+
+    it "removes the rejected reason details 'change' link after creating a valid rejected case" do
+      rejected_case = (create :offender_sar_case, :rejected, rejected_reasons: %w[further_identification]).decorate
+      rejected_case.close(branston_user)
+      assign(:case, rejected_case)
+
+      render partial: "cases/offender_sar/case_details", locals: {
+        case_details: rejected_case,
+        link_type: nil,
+        allow_editing: true,
+      }
+
+      partial = offender_sar_case_details_section(rendered).sar_basic_details
+
+      expect(partial.rejected_reason.has_link?).to be false
     end
 
     it "does not display Business unit responsible for late response when case closed" do

--- a/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
+++ b/spec/views/cases/offender_sar/_case_details_html_slim_spec.rb
@@ -77,7 +77,7 @@ describe "cases/offender_sar/case_details.html.slim", type: :view do
       expect(partial.rejected_reason.data.text).to eq "Further identification"
     end
 
-    it "removes the rejected reason details 'change' link after creating a valid rejected case" do
+    it "removes the rejected reason details 'change' link when the case is no longer rejected" do
       rejected_case = (create :offender_sar_case, :rejected, rejected_reasons: %w[further_identification]).decorate
       rejected_case.close(branston_user)
       assign(:case, rejected_case)


### PR DESCRIPTION
## Description
Ensure user can update rejected reasons if the case is still rejected. If the case is no longer rejected, remove the 'change' link so the user cannot edit the reasons. 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?selectedIssue=CDPT-1456

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
