### PR TITLE
Rejected - other rejected reason fixes

### DIFF
--- a/app/decorators/case/sar/offender_decorator.rb
+++ b/app/decorators/case/sar/offender_decorator.rb
@@ -22,8 +22,14 @@ class Case::SAR::OffenderDecorator < Case::SAR::OffenderBaseDecorator
   end
 
   def rejected_reasons_descriptions
+    other_string = if other_rejected_reason.present?
+      ": #{other_rejected_reason}"
+    else
+      ""
+                   end
+
     rejected_reasons.map { |reason|
       Case::SAR::Offender::REJECTED_REASONS[reason]
-    }.append(other_rejected_reason).compact.join("<br>")
+    }.compact.join("<br>") + other_string
   end
 end

--- a/app/decorators/case/sar/offender_decorator.rb
+++ b/app/decorators/case/sar/offender_decorator.rb
@@ -22,7 +22,7 @@ class Case::SAR::OffenderDecorator < Case::SAR::OffenderBaseDecorator
   end
 
   def rejected_reasons_descriptions
-    other_string = if other_rejected_reason.present?
+    other_reason_text = if other_rejected_reason.present?
                      ": #{other_rejected_reason}"
                    else
                      ""
@@ -30,6 +30,6 @@ class Case::SAR::OffenderDecorator < Case::SAR::OffenderBaseDecorator
 
     rejected_reasons.map { |reason|
       Case::SAR::Offender::REJECTED_REASONS[reason]
-    }.compact.join("<br>") + other_string
+    }.compact.join("<br>") + other_reason_text
   end
 end

--- a/app/decorators/case/sar/offender_decorator.rb
+++ b/app/decorators/case/sar/offender_decorator.rb
@@ -23,9 +23,9 @@ class Case::SAR::OffenderDecorator < Case::SAR::OffenderBaseDecorator
 
   def rejected_reasons_descriptions
     other_string = if other_rejected_reason.present?
-      ": #{other_rejected_reason}"
-    else
-      ""
+                     ": #{other_rejected_reason}"
+                   else
+                     ""
                    end
 
     rejected_reasons.map { |reason|

--- a/app/decorators/case/sar/offender_decorator.rb
+++ b/app/decorators/case/sar/offender_decorator.rb
@@ -23,10 +23,10 @@ class Case::SAR::OffenderDecorator < Case::SAR::OffenderBaseDecorator
 
   def rejected_reasons_descriptions
     other_reason_text = if other_rejected_reason.present?
-                     ": #{other_rejected_reason}"
-                   else
-                     ""
-                   end
+                          ": #{other_rejected_reason}"
+                        else
+                          ""
+                        end
 
     rejected_reasons.map { |reason|
       Case::SAR::Offender::REJECTED_REASONS[reason]

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -193,6 +193,7 @@ class Case::SAR::Offender < Case::Base
   before_save :use_subject_as_requester,
               if: -> { name.blank? }
   before_save :set_case_originally_rejected, if: -> { rejected? }
+  before_save :verify_other_rejected_reason, if: -> { rejected? }
 
   def validate_third_party_states_consistent
     if third_party && recipient == "third_party_recipient"
@@ -477,6 +478,10 @@ private
 
   def set_case_originally_rejected
     self.case_originally_rejected = true
+  end
+
+  def verify_other_rejected_reason
+    self.other_rejected_reason = "" unless rejected_reasons.include?("other")
   end
 
   def ensure_third_party_states_consistent

--- a/spec/decorators/case/sar/offender_decorator_spec.rb
+++ b/spec/decorators/case/sar/offender_decorator_spec.rb
@@ -94,7 +94,7 @@ describe Case::SAR::OffenderDecorator do
       end
 
       it "returns the REJECTED_REASONS hash value" do
-        expect(offender_sar_case.rejected_reasons_descriptions).to eq "Other<br>Other reason"
+        expect(offender_sar_case.rejected_reasons_descriptions).to eq "Other: Other reason"
       end
     end
   end

--- a/spec/models/case/sar/offender_spec.rb
+++ b/spec/models/case/sar/offender_spec.rb
@@ -89,6 +89,28 @@ describe Case::SAR::Offender do
     end
   end
 
+  describe "#rejected_reasons" do
+    context "when the rejected reason other checkbox is selected and a reason is given" do
+      let(:case_rejected) { create(:offender_sar_case, :rejected, rejected_reasons: %w[other], other_rejected_reason: "More information") }
+
+      it "sets the rejected reason" do
+        expect(case_rejected.rejected_reasons).to eq(%w[other])
+        expect(case_rejected.other_rejected_reason).to eq("More information")
+      end
+    end
+
+    context "when the rejected reason other checkbox is de-selected and a reason is present" do
+      let(:case_rejected) { create(:offender_sar_case, :rejected, rejected_reasons: %w[other], other_rejected_reason: "More information") }
+
+      it "sets the other rejected reason to blank" do
+        case_rejected.update!(rejected_reasons: %w[cctv_bwcv])
+
+        expect(case_rejected.rejected_reasons).to eq(%w[cctv_bwcv])
+        expect(case_rejected.other_rejected_reason).to eq("")
+      end
+    end
+  end
+
   describe "#set_number" do
     let(:case_rejected) { create(:offender_sar_case, :rejected) }
     let(:kase) { create(:offender_sar_case) }


### PR DESCRIPTION
## Description
1. Ensure that the other rejected reason format is inline, rather than on seperate lines (see image)
2. Fix bug - if the "other" checkbox is deselected but an other reason was given, remove the other reason (see image)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots

Before this PR the other option and its reason aren't on the same line
<img width="1022" alt="Screenshot 2024-03-20 at 09 55 12" src="https://github.com/ministryofjustice/correspondence_tool_staff/assets/129938801/e55d9135-8fc0-4a57-a834-310295de7157">

Before this PR the other rejected reason still has a value
<img width="1022" alt="Screenshot 2024-03-20 at 09 56 05" src="https://github.com/ministryofjustice/correspondence_tool_staff/assets/129938801/2b85dec1-5db4-42d6-88ed-fae27aa35891">



### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
