### PR TITLE
Fix tab appearance

### DIFF
--- a/app/assets/stylesheets/moj/_case_tabs.scss
+++ b/app/assets/stylesheets/moj/_case_tabs.scss
@@ -1,5 +1,6 @@
 .govuk-tabs {
-  margin-top: 5px;
+  margin-bottom: 0;
+  font-size: inherit;
 
   &__title {
     padding-top: $gutter;
@@ -65,7 +66,6 @@
       text-decoration: none;
 
       &.active {
-        margin-top: -5px;
         margin-bottom: -1px;
         padding: 14px 19px 16px 19px;
         border: 1px solid $border-colour;
@@ -85,4 +85,3 @@
     }
   }
 }
-


### PR DESCRIPTION
## Description
Additional CSS brought in with the crown change caused tabs to partially break. This fixes the issue.

Before:
<img width="999" alt="Screenshot 2024-03-21 at 17 17 19" src="https://github.com/ministryofjustice/correspondence_tool_staff/assets/1190196/1d568c35-bffb-42d9-910e-19ecec0ad799">

After:
<img width="1025" alt="Screenshot 2024-03-21 at 17 17 05" src="https://github.com/ministryofjustice/correspondence_tool_staff/assets/1190196/4cb2499c-0909-4ff5-9f64-b4a912eb4cc3">

