### PR TITLE
Add rejected title to closed case

### DIFF
--- a/app/decorators/case/sar/offender_decorator.rb
+++ b/app/decorators/case/sar/offender_decorator.rb
@@ -2,7 +2,7 @@ class Case::SAR::OffenderDecorator < Case::SAR::OffenderBaseDecorator
   include OffenderSARCaseForm
 
   def pretty_type
-    if object.invalid_submission?
+    if object.rejected?
       I18n.t("helpers.label.correspondence_types.rejected_offender_sar")
     else
       I18n.t("helpers.label.correspondence_types.offender_sar")

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -459,7 +459,11 @@ class Case::SAR::Offender < Case::Base
   end
 
   def rejected?
-    number[0] == "R"
+    if persisted?
+      number[0] == "R"
+    else
+      current_state == "invalid_submission"
+    end
   end
 
   # Overwrites base method to allow case number to remove "R" when

--- a/spec/decorators/case/sar/offender_decorator_spec.rb
+++ b/spec/decorators/case/sar/offender_decorator_spec.rb
@@ -2,12 +2,14 @@ require "rails_helper"
 
 describe Case::SAR::OffenderDecorator do
   let(:offender_sar_case) do
-    build_stubbed(
+    create(
       :offender_sar_case,
       date_responded: Date.new(2020, 1, 10),
       received_date: Date.new(2020, 1, 1),
     ).decorate
   end
+
+  let(:rejected_offender_sar_case) { create(:offender_sar_case, :rejected).decorate }
 
   it "instantiates the correct decorator" do
     expect(Case::SAR::Offender.new.decorate).to be_instance_of described_class
@@ -108,6 +110,12 @@ describe Case::SAR::OffenderDecorator do
   describe "#type_printer" do
     it "pretty prints Case" do
       expect(offender_sar_case.pretty_type).to eq "Offender SAR"
+    end
+
+    context "when rejected" do
+      it "pretty prints Case" do
+        expect(rejected_offender_sar_case.pretty_type).to eq "Rejected Offender SAR"
+      end
     end
   end
 

--- a/spec/decorators/case/sar/offender_decorator_spec.rb
+++ b/spec/decorators/case/sar/offender_decorator_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Case::SAR::OffenderDecorator do
   let(:offender_sar_case) do
-    create(
+    build(
       :offender_sar_case,
       date_responded: Date.new(2020, 1, 10),
       received_date: Date.new(2020, 1, 1),

--- a/spec/models/case/sar/offender_spec.rb
+++ b/spec/models/case/sar/offender_spec.rb
@@ -924,6 +924,22 @@ describe Case::SAR::Offender do
   end
 
   describe "#rejected?" do
+    context "when case is unsaved" do
+      context "when case is rejected" do
+        it "returns true" do
+          kase = build(:offender_sar_case, :rejected)
+          expect(kase).to be_rejected
+        end
+      end
+
+      context "when case is not rejected" do
+        it "returns false" do
+          kase = build(:offender_sar_case)
+          expect(kase).not_to be_rejected
+        end
+      end
+    end
+
     context "when case is rejected" do
       it "returns true" do
         kase = create(:offender_sar_case, :rejected)


### PR DESCRIPTION
## Description
Update header on closed rejected Offender SAR cases to add "Rejected".

The decorated pretty_type method is updated to use the `rejected?` method which returns true for cases that are initially rejected and also for cases that were rejected, and have since been closed.

The `rejected?` method has been updated to handle new cases that have not yet been saved, so have not been assigned a number.
