### PR TITLE
Add date of birth validation

### DIFF
--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -152,10 +152,8 @@ class Case::SAR::Offender < Case::Base
 
   validates :third_party,          inclusion: { in: [true, false], message: "cannot be blank" }
   validates :flag_as_high_profile, inclusion: { in: [true, false], message: "cannot be blank" }
-  validates :date_of_birth, presence: true
 
   validates :subject_address, presence: true
-
   validates :subject_full_name, presence: true
   validates :subject_type, presence: true
   validates :recipient, presence: true

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -224,7 +224,6 @@ class Case::SAR::Offender < Case::Base
         I18n.t("activerecord.errors.models.case.attributes.request_dated.not_in_future"),
       )
     end
-    errors[:request_dated].any?
   end
 
   def validate_third_party_names
@@ -238,7 +237,6 @@ class Case::SAR::Offender < Case::Base
         I18n.t("activerecord.errors.models.case/sar/offender.attributes.third_party_company_name.blank"),
       )
     end
-    errors[:third_party_name].any? || errors[:third_party_company_name].any?
   end
 
   def validate_recipient
@@ -252,7 +250,6 @@ class Case::SAR::Offender < Case::Base
         I18n.t("activerecord.errors.models.case/sar/offender.attributes.third_party_company_name.blank"),
       )
     end
-    errors[:third_party_name].any? || errors[:third_party_company_name].any?
   end
 
   def validate_third_party_relationship
@@ -262,7 +259,6 @@ class Case::SAR::Offender < Case::Base
         I18n.t("activerecord.errors.models.case/sar/offender.attributes.third_party_relationship.blank"),
       )
     end
-    errors[:third_party_relationship].any?
   end
 
   def validate_third_party_address
@@ -272,7 +268,6 @@ class Case::SAR::Offender < Case::Base
         I18n.t("activerecord.errors.models.case/sar/offender.attributes.third_party_address.blank"),
       )
     end
-    errors[:third_party_relationship].any?
   end
 
   def validate_third_party_email_format
@@ -300,7 +295,6 @@ class Case::SAR::Offender < Case::Base
         I18n.t("activerecord.errors.models.case.attributes.partial_case_letter_sent_dated.not_in_future"),
       )
     end
-    errors[:partial_case_letter_sent_dated].any?
   end
 
   def validate_sent_to_sscl_at

--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -208,6 +208,10 @@ class Case::SAR::Offender < Case::Base
   end
 
   def validate_date_of_birth
+    if date_of_birth.nil?
+      errors.add(:date_of_birth, :blank)
+    end
+
     if date_of_birth.present? && date_of_birth > Time.zone.today
       errors.add(
         :date_of_birth,

--- a/spec/models/case/sar/offender_spec.rb
+++ b/spec/models/case/sar/offender_spec.rb
@@ -248,20 +248,27 @@ describe Case::SAR::Offender do
   end
 
   describe "#date_of_birth" do
+    let(:kase) { build_stubbed :offender_sar_case }
+
     context "with valid values" do
       it "validates date of birth" do
-        kase = build_stubbed :offender_sar_case
-
         expect(kase).to validate_presence_of(:date_of_birth)
         expect(kase).to allow_values("01-01-1967").for(:date_of_birth)
+        expect { kase.validate_date_of_birth }.not_to change(kase.errors, :count)
       end
     end
 
     context "with invalid value" do
-      it "errors" do
-        expect {
-          build_stubbed(:offender_sar_case, date_of_birth: "wibble")
-        }.to raise_error ArgumentError
+      it "is not valid" do
+        kase[:date_of_birth] = "wibble"
+        expect { kase.validate_date_of_birth }.to change(kase.errors, :count)
+      end
+    end
+
+    context "with all zeroes value" do
+      it "is not valid" do
+        kase[:date_of_birth] = "0000-00-00"
+        expect { kase.validate_date_of_birth }.to change(kase.errors, :count)
       end
     end
 


### PR DESCRIPTION
## Description
Currently the immediate validation passes when an invalid date (e.g. 0000-00-00) is entered when creating a case because the date is converted to nil. The validation has changed to check for nil.

Also removes boolean returns from some validation methods, as this is no longer required since Rails 5

