### PR TITLE
CDPT-1535 Change default mailer queue

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -59,6 +59,9 @@ module CorrespondencePlatform
     # Use MailDeliveryJob
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
+    # Set default queue name
+    config.action_mailer.deliver_later_queue_name = "mailers"
+
     config.after_initialize do
       # instantiate a ConfigurableStateMachine::Machine on start up. This will
       # force the validation of all state machine configuration file.

--- a/spec/services/commissioning_document_email_service_spec.rb
+++ b/spec/services/commissioning_document_email_service_spec.rb
@@ -35,6 +35,14 @@ describe CommissioningDocumentEmailService do
       service.send!
     end
 
+    it "uses the expected queue" do
+      expect {
+        service.send!
+      }.to(
+        have_enqueued_job.on_queue("correspondence_tool_staff_mailers").at_least(2).times,
+      )
+    end
+
     it "sets commissioning document as sent" do
       service.send!
       expect(commissioning_document.sent).to be_truthy


### PR DESCRIPTION
## Description
Rails 7 has changed the name of the mailer queue from "mailers" to "default"
Sidekiq is monitoring the "mailers" queue, so this config will update the queue name to be "mailers" again.
