### PR TITLE
Handle "no" case for sending to Branston archives

### DIFF
--- a/app/controllers/cases/data_requests_controller.rb
+++ b/app/controllers/cases/data_requests_controller.rb
@@ -66,7 +66,6 @@ module Cases
 
     def send_email
       @recipient_emails = @data_request.recipient_emails
-
       @no_email_present = @recipient_emails.empty?
 
       if @commissioning_document.probation? && !handled_sending_to_branston_archives?
@@ -88,6 +87,8 @@ module Cases
       if @email.email_branston_archives == "yes"
         @data_request.update!(email_branston_archives: true)
         @recipient_emails << CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL
+      else
+        @data_request.update!(email_branston_archives: false)
       end
 
       true

--- a/spec/controllers/cases/data_requests_controller_spec.rb
+++ b/spec/controllers/cases/data_requests_controller_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe Cases::DataRequestsController, type: :controller do
 
         it "updates the data_request" do
           post(:send_email, params:)
-          expect(data_request.reload.email_branston_archives).to be_truthy
+          expect(data_request.reload.email_branston_archives).to be true
         end
       end
 
@@ -316,9 +316,12 @@ RSpec.describe Cases::DataRequestsController, type: :controller do
         end
 
         it "doesnt add the branston probation email to recipients" do
+          data_request.update!(email_branston_archives: true)
+
           post(:send_email, params:)
           expect(response).to render_template(:send_email)
           expect(assigns(:recipient_emails)).not_to include(CommissioningDocumentTemplate::Probation::BRANSTON_ARCHIVES_EMAIL)
+          expect(data_request.reload.email_branston_archives).to be false
         end
       end
 


### PR DESCRIPTION
## Description
If a user selects "yes" for sending to Branston archives, the data_request object is updated. If they then go back and select "no", the object was not being updated again so the email would still be sent to Branston archives.

If the user selects "no", the object will now be updated, so this edge case is handled.
