### PR TITLE
Use other github repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "pundit", "~>2.1"
 gem "rails", "~> 7.0"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false
-gem "rails-data-migrations", git: "https://github.com/hernanvicente/rails-data-migrations.git", branch: "rails-7.1-support"
+gem "rails-data-migrations", git: "https://github.com/anjlab/rails-data-migrations"
 gem "recursive-open-struct"
 gem "sablon"
 gem "sass-rails", "~> 6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "pundit", "~>2.1"
 gem "rails", "~> 7.0"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false
-gem "rails-data-migrations", git: "https://github.com/anjlab/rails-data-migrations"
+gem "rails-data-migrations"
 gem "recursive-open-struct"
 gem "sablon"
 gem "sass-rails", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 GIT
-  remote: https://github.com/hernanvicente/rails-data-migrations.git
-  revision: 1447e4b30cbb96c392477fa7b205a77d25e86ecd
-  branch: rails-7.1-support
+  remote: https://github.com/anjlab/rails-data-migrations
+  revision: 727f933eec032a8f8e53364c5134d16d4bef1d75
   specs:
-    rails-data-migrations (1.2.1)
+    rails-data-migrations (1.3.0)
       rails (>= 4.0.0)
 
 GIT

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: https://github.com/anjlab/rails-data-migrations
-  revision: 727f933eec032a8f8e53364c5134d16d4bef1d75
-  specs:
-    rails-data-migrations (1.3.0)
-      rails (>= 4.0.0)
-
-GIT
   remote: https://github.com/ministryofjustice/bank_holiday.git
   revision: 16d511a1d1628eece8d61ade9223b10caccbcea3
   branch: bundler-fix
@@ -427,6 +420,8 @@ GEM
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
+    rails-data-migrations (1.3.0)
+      rails (>= 4.0.0)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -679,7 +674,7 @@ DEPENDENCIES
   pundit (~> 2.1)
   rails (~> 7.0)
   rails-controller-testing
-  rails-data-migrations!
+  rails-data-migrations
   recursive-open-struct
   rspec-collection_matchers
   rspec-rails (~> 6.0)

--- a/README.docker.md
+++ b/README.docker.md
@@ -380,7 +380,7 @@ Continuous integration is carried out by SemaphoreCI.
 
 ### Data Migrations
 
-The app uses the `rails-data-migrations` gem https://github.com/OffgridElectric/rails-data-migrations
+The app uses the `rails-data-migrations` gem https://github.com/anjlab/rails-data-migrations
 
 Data migrations work like regular migrations but for data; they're found in `db/data_migrations`.
 

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Continuous integration is carried out by SemaphoreCI.
 
 ### Data Migrations
 
-The app uses the `rails-data-migrations` gem https://github.com/OffgridElectric/rails-data-migrations
+The app uses the `rails-data-migrations` gem https://github.com/anjlab/rails-data-migrations
 
 Data migrations work like regular migrations but for data; they're found in `db/data_migrations`.
 


### PR DESCRIPTION
## Description
CI build was failing to build as https://github.com/hernanvicente/rails-data-migrations.git appears to have been removed. So changed the data migrations Gem to use https://github.com/anjlab/rails-data-migrations.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
