### PR TITLE
CDPT-1399 Hide feedback form

### DIFF
--- a/app/views/feedback/_new.html.slim
+++ b/app/views/feedback/_new.html.slim
@@ -1,8 +1,13 @@
 hr
-.grid-row
-  .column-two-thirds
-    .feedback
-      .feedback-notification
-      = form_for Feedback.new, url: feedback_path, remote: true do|f|
-        = f.text_area :comment, {rows: 4}
-        = f.submit t('button.feedback'), {class: 'button-secondary'}
+details
+  summary
+    span.summary
+      = "Help make this service better"
+
+  .grid-row
+    .column-two-thirds
+      .feedback
+        .feedback-notification
+        = form_for Feedback.new, url: feedback_path, remote: true do|f|
+          = f.text_area :comment, {rows: 4, label: nil}
+          = f.submit t('button.feedback'), {class: 'button-secondary'}

--- a/app/views/feedback/_new.html.slim
+++ b/app/views/feedback/_new.html.slim
@@ -1,5 +1,5 @@
 hr
-details
+details#feedback
   summary
     span.summary
       = "Help make this service better"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -651,9 +651,6 @@ en:
         escalation_emails: Add multiple email addresses on separate lines
       data_request:
         location: Where is the data held?
-      feedback:
-        comment: |
-          Let us know what you were doing and what could be improved or fixed.
       ico:
         original_case_number_html: |
           Enter original case  reference number to link to.  For example 170131001.<br>
@@ -955,7 +952,7 @@ en:
           timeliness: Timeliness
           not_applicable: Not applicable
       feedback:
-        comment: Help make this service better
+        comment: Let us know what you were doing and what could be improved or fixed.
       search_query:
         business_unit_name_filter: Business unit
       business_group:

--- a/spec/features/common/feedback_spec.rb
+++ b/spec/features/common/feedback_spec.rb
@@ -12,6 +12,8 @@ feature "Submitting feedback" do
     login_as responder
     cases_page.load
     expect(cases_page).to have_service_feedback
+
+    cases_page.service_feedback.details_button.click
     expect(cases_page.service_feedback).to have_feedback_form
     expect(cases_page.service_feedback).to have_send_button
 
@@ -27,6 +29,8 @@ feature "Submitting feedback" do
     cases_page.load
 
     expect(cases_page).to have_service_feedback
+    cases_page.service_feedback.details_button.click
+
     expect(cases_page.service_feedback).to have_feedback_form
     expect(cases_page.service_feedback).to have_send_button
 

--- a/spec/site_prism/page_objects/pages/admin/cases_page.rb
+++ b/spec/site_prism/page_objects/pages/admin/cases_page.rb
@@ -29,7 +29,7 @@ module PageObjects
           element :who_its_with, 'td[aria-label="With"]'
         end
 
-        section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, ".feedback"
+        section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, "#feedback"
         section :primary_navigation, PageObjects::Sections::PrimaryNavigationSection, ".global-nav"
 
         section :pagination, PageObjects::Sections::PaginationSection, ".pagination"

--- a/spec/site_prism/page_objects/pages/cases/incoming_cases_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/incoming_cases_page.rb
@@ -25,7 +25,7 @@ module PageObjects
           end
         end
 
-        section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, ".feedback"
+        section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, "#feedback"
         section :primary_navigation, PageObjects::Sections::PrimaryNavigationSection, ".global-nav"
         section :homepage_navigation, PageObjects::Sections::HomepageNavigationSection, "#homepage-navigation"
 

--- a/spec/site_prism/page_objects/pages/cases_page.rb
+++ b/spec/site_prism/page_objects/pages/cases_page.rb
@@ -41,7 +41,7 @@ module PageObjects
 
       element :remove_original_link, ".js-remove-original"
       element :new_case_button, 'a.button[href="/cases/new"]'
-      section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, ".feedback"
+      section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, "#feedback"
       section :primary_navigation, PageObjects::Sections::PrimaryNavigationSection, ".global-nav"
 
       section :pagination, PageObjects::Sections::PaginationSection, ".pagination"

--- a/spec/site_prism/page_objects/pages/login_page.rb
+++ b/spec/site_prism/page_objects/pages/login_page.rb
@@ -8,7 +8,7 @@ module PageObjects
       element :error_message, ".error-summary"
       element :notice, ".notice-summary"
       section :user_card, PageObjects::Sections::UserCardSection, ".user-card"
-      section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, ".feedback"
+      section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, "#feedback"
       section :primary_navigation, PageObjects::Sections::PrimaryNavigationSection, ".global-nav"
 
       def log_in(username, password)

--- a/spec/site_prism/page_objects/pages/password_page.rb
+++ b/spec/site_prism/page_objects/pages/password_page.rb
@@ -5,7 +5,7 @@ module PageObjects
       element :email_field, "#user_email"
       element :send, 'input[type="submit"][value="Send me password reset instructions"]'
       element :error_message, ".error-summary"
-      section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, ".feedback"
+      section :service_feedback, PageObjects::Sections::ServiceFeedbackSection, "#feedback"
       section :primary_navigation, PageObjects::Sections::PrimaryNavigationSection, ".global-nav"
 
       def send_reset_instructions(email)

--- a/spec/site_prism/page_objects/sections/service_feedback_section.rb
+++ b/spec/site_prism/page_objects/sections/service_feedback_section.rb
@@ -1,6 +1,8 @@
 module PageObjects
   module Sections
     class ServiceFeedbackSection < SitePrism::Section
+      element :details_button, "summary"
+
       element :feedback_form, "#new_feedback"
       element :feedback_textarea, "#new_feedback textarea"
 


### PR DESCRIPTION
## Description
In order to stop the feedback form being used by mistake to record details about a case, it is being hidden behind a [details component](https://design-system.service.gov.uk/components/details/).
