### PR TITLE
CDPT-1759 Remove court data request option

### DIFF
--- a/app/views/cases/data_requests/_form.html.slim
+++ b/app/views/cases/data_requests/_form.html.slim
@@ -14,7 +14,6 @@
         - fieldset.radio_input('all_prison_records')
         - fieldset.radio_input('cat_a')
         - fieldset.radio_input('cctv_and_bwcf')
-        - fieldset.radio_input('court')
         - fieldset.radio_input('cross_borders')
         - fieldset.radio_input('dps')
         - fieldset.radio_input('mappa')


### PR DESCRIPTION
## Description
The "court" option is no longer used for data requests so is being removed from the selectable options.
It is being retained in the request_type enum to handle existing data requests that are using that option.
