### PR TITLE
CDPT-971 Make admin users searchable and add deactivated users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,14 +1,18 @@
 class Admin::UsersController < AdminController
   def index
-    if @team.present?
-      @users = @team.users
+    @active_users_count = User.active_users.count
+
+    if params[:search_for].present?
+      search_string = "%#{params[:search_for].downcase}%"
+      @users = User.where("LOWER(full_name) like ? OR LOWER(email) like ?", search_string, search_string)
+                   .order(:full_name)
+                   .page(params[:page]).per(10)
+                   .decorate
     else
-      @users = User.all
+      @users = User.unscoped
                    .order(:full_name)
                    .page(params[:page]).per(100)
                    .decorate
-
-      @active_users_count = User.active_users.count
     end
   end
 end

--- a/app/services/user_creation_service.rb
+++ b/app/services/user_creation_service.rb
@@ -34,7 +34,7 @@ private
 
       @result = :existing_ok
     else
-      error_message = "An existing user with this email address already exists with the name: #{@user.full_name}"
+      error_message = "The user with that email address has a different name. To add them to the team, enter their full name as #{@user.full_name.strip}"
       @user = User.new(@params)
       @user.errors.add(:base, error_message)
     end

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -13,6 +13,11 @@
     = " #{ 'active user'.pluralize(@active_users_count)}"
 
 .grid-row
+  = form_with method: :get do |f|
+    = f.text_field :search_for, value: params[:search_for]
+    = f.submit "Search"
+
+.grid-row
   .column-full.table-container.container
     table.users.table-font-xsmall.report
       colgroup
@@ -24,6 +29,8 @@
         th scope='col'
           = t('.email')
         th scope='col'
+          = t('.deactivated')
+        th scope='col'
           = t('.teams')
         th scope='col'
           = t('.cases')
@@ -34,6 +41,8 @@
               = user.full_name
             td aria-label="#{t('.email')}"
               = user.email
+            td aria-label="#{t('.deactivated')}"
+              = user.deactivated? ? user.deleted_at.strftime("%d/%m/%Y") : "No"
             td aria-label="#{t('.teams')}"
               ul
                 - user.teams.each do |team|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1279,6 +1279,7 @@ en:
     users:
       index:
         cases: Cases
+        deactivated: Deactivated
         email: Email
         full_name: Name
         heading: Users

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -3,22 +3,31 @@ require "rails_helper"
 describe Admin::UsersController do
   describe "GET index" do
     let(:admin)   { create :admin }
-    let(:manager) { create :manager }
-    let(:dacu)    { find_or_create :team_dacu }
 
     context "when authenticated admin" do
-      before { sign_in admin }
+      before do
+        User.first.soft_delete
+        sign_in admin
+      end
 
-      it "retrieves all the users" do
+      it "retrieves all the users including soft deleted" do
         get :index
 
-        expect(assigns(:users)).to match_array User.all
+        expect(assigns(:users)).to match_array User.unscoped
       end
 
       it "renders the index view" do
         get :index
 
         expect(response).to have_rendered("admin/users/index")
+      end
+
+      context "when searching" do
+        it "retrieves users matching the search term" do
+          get :index, params: { search_for: "Branston" }
+
+          expect(assigns(:users)).to match_array User.where(full_name: "branston registry responding user")
+        end
       end
     end
   end

--- a/spec/services/user_creation_service_spec.rb
+++ b/spec/services/user_creation_service_spec.rb
@@ -162,7 +162,9 @@ describe UserCreationService do
 
         it "sets a base error on the user model" do
           service.call
-          expect(service.user.errors[:base]).to eq ["An existing user with this email address already exists with the name: Stephen Richards"]
+          expect(service.user.errors[:base]).to eq [
+            "The user with that email address has a different name. To add them to the team, enter their full name as Stephen Richards",
+          ]
         end
 
         it "returns :existing_user_name_mismatch" do


### PR DESCRIPTION
## Description
There are a lot of users, and it can be difficult for an admin to find if a user exists, and impossible to find a deactivated user.

This adds a search form to the admin user page, and also returns deactivated users with their deactivation date.