### PR TITLE
CDPT-1781 Assignment bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,7 @@ jobs:
         uses: joshmfrankel/simplecov-check-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          minimum_suite_coverage: 92
+          minimum_suite_coverage: 93
           minimum_file_coverage: 100
 
   build-and-deploy:

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -304,7 +304,7 @@ private
     set_case
     set_assignment
 
-    @assignment = nil unless current_user.responding_teams.include?(@assignment.team)
+    @assignment = nil unless current_user.teams_for_case(@case).include?(@assignment.team)
   end
 
   def redirect_on_deleted_case!

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -313,6 +313,7 @@ private
               .find(params[:case_id])
               .decorate
     @case_transitions = @case.transitions.decorate
+    @case_transitions = @case.transitions.case_history.order(id: :desc).decorate
   end
 
   def set_team_users

--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -309,11 +309,9 @@ private
 
   def set_case
     @case = Case::Base
-              .includes(transitions: %i[target_team acting_team acting_user])
               .find(params[:case_id])
               .decorate
-    @case_transitions = @case.transitions.decorate
-    @case_transitions = @case.transitions.case_history.order(id: :desc).decorate
+    @case_transitions = @case.transitions.includes(:acting_user, :acting_team, :target_team).case_history.order(id: :desc).decorate
   end
 
   def set_team_users

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -246,10 +246,6 @@ class Case::Base < ApplicationRecord
           through: :managing_assignment,
           source: :team
 
-  has_one :responder,
-          through: :responder_assignment,
-          source: :user
-
   has_one :responder_assignment,
           -> { last_responding },
           class_name: "Assignment",

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -255,6 +255,10 @@ class Case::Base < ApplicationRecord
           class_name: "Assignment",
           foreign_key: :case_id
 
+  has_one :responder,
+          through: :responder_assignment,
+          source: :user
+
   has_one :responding_team,
           through: :responder_assignment,
           source: :team

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -246,14 +246,14 @@ class Case::Base < ApplicationRecord
           through: :managing_assignment,
           source: :team
 
+  has_one :responder,
+          through: :responder_assignment,
+          source: :user
+
   has_one :responder_assignment,
           -> { last_responding },
           class_name: "Assignment",
           foreign_key: :case_id
-
-  has_one :responder,
-          through: :responder_assignment,
-          source: :user
 
   has_one :responding_team,
           through: :responder_assignment,

--- a/spec/controllers/assignments_controller/accept_spec.rb
+++ b/spec/controllers/assignments_controller/accept_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+
+RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSpec/FilePath
+  let(:awaiting_responder_case) { create :awaiting_responder_case }
+  let(:assignment) { awaiting_responder_case.responder_assignment }
+  let(:responding_team) { assignment.team }
+  let(:responder) { responding_team.responders.first }
+  let(:params) { { case_id: awaiting_responder_case.id, id: assignment.id } }
+
+  describe "GET edit" do
+    before do
+      sign_in responder
+    end
+
+    it "sets @assignment" do
+      get(:edit, params:)
+      expect(assigns(:assignment)).to eq assignment
+    end
+
+    context "when responder is from the wrong team" do
+      let(:responding_team) { create :responding_team }
+      let(:responder)       { responding_team.responders.first }
+
+      it "does not set @assignment" do
+        get(:edit, params:)
+        expect(assigns(:assignment)).to eq nil
+      end
+
+      it "redirects to the case list view" do
+        get(:edit, params:)
+        expect(response).to redirect_to case_path(id: params[:case_id])
+      end
+    end
+  end
+
+  describe "PATCH accept_or_reject" do
+    let(:accept_or_reject) { "accept" }
+    let(:params) { { case_id: awaiting_responder_case.id, id: assignment.id, assignment: { state: "accepted" } } }
+
+    before do
+      sign_in responder
+    end
+
+    it "sets @assignment" do
+      patch(:accept_or_reject, params:)
+      expect(assigns(:assignment)).to eq assignment
+    end
+
+    context "when accepting" do
+      it "accepts the assigment" do
+        patch(:accept_or_reject, params:)
+        expect(assignment.reload).to be_accepted
+      end
+
+      it "redirects to the case list view" do
+        patch(:accept_or_reject, params:)
+        expect(response).to redirect_to case_path(id: params[:case_id], accepted_now: true)
+      end
+    end
+
+    context "when rejecting" do
+      let(:params) { { case_id: awaiting_responder_case.id, id: assignment.id, assignment: { state: "rejected", reasons_for_rejection: "some reason" } } }
+
+      it "rejects the assigment" do
+        patch(:accept_or_reject, params:)
+        expect(assignment.reload).to be_rejected
+      end
+
+      it "redirects to the case list view" do
+        patch(:accept_or_reject, params:)
+        expect(response).to redirect_to case_path(id: params[:case_id])
+      end
+    end
+
+    context "when responder is from the wrong team" do
+      let(:responding_team) { create :responding_team }
+      let(:responder)       { responding_team.responders.first }
+
+      it "does not set @assignment" do
+        patch(:accept_or_reject, params:)
+        expect(assigns(:assignment)).to eq nil
+      end
+
+      it "redirects to the case list view" do
+        patch(:accept_or_reject, params:)
+        expect(response).to redirect_to case_path(id: params[:case_id])
+      end
+    end
+  end
+end

--- a/spec/services/stats/r003_business_unit_performance_report_spec.rb
+++ b/spec/services/stats/r003_business_unit_performance_report_spec.rb
@@ -19,7 +19,8 @@ module Stats
 
         @team_a = create :business_unit, name: "RTA", directorate: @dir_a
         @team_b = create :business_unit, name: "RTB", directorate: @dir_b
-        @team_c = create :business_unit, name: "RTC", directorate: @dir_cd, moved_to_unit_id: 45
+        @team_new_c = create :business_unit, name: "RTC", directorate: @dir_cd
+        @team_c = create :business_unit, name: "RTC", directorate: @dir_cd, moved_to_unit_id: 4545
         @team_d = create :business_unit, name: "RTD", directorate: @dir_cd
         @team_dacu_disclosure = find_or_create :team_dacu_disclosure
 


### PR DESCRIPTION
## Description
When a case has been accepted, there have been a couple of instances when the case history shows it being assigned to the wrong team, and this also causes it to show up in their open cases list.

It's not clear exactly how this happens, but this change adds a check so that a user cannot accept an assignment that belongs to a team they are not a member of.

---
Also fixes a sporadic test failure on a reporting spec