### PR TITLE
CDPT-1694 Enable filesystem uploads for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ config/environments/*.local.yml
 env.sh
 .env.sh
 
+#Ignore local upload and attachments
+/uploads
+public/uploads
 
 # Ignore .DS_Store in all directories
 .DS_Store

--- a/app/controllers/dev_s3_uploader_controller.rb
+++ b/app/controllers/dev_s3_uploader_controller.rb
@@ -1,0 +1,24 @@
+class DevS3UploaderController < ActionController::Base # rubocop:disable Rails/ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    FileUtils.mkdir_p(directory)
+    File.rename(file.path, path)
+
+    render xml: { "Key": path }, status: :created
+  end
+
+private
+
+  def directory
+    params[:key].gsub("/${filename}", "")
+  end
+
+  def path
+    "#{directory}/#{file.original_filename}"
+  end
+
+  def file
+    params[:file]
+  end
+end

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,4 +1,9 @@
 # London
 Aws.config.update region: "eu-west-2" # rubocop:disable Rails/SaveBang
 
-CASE_UPLOADS_S3_BUCKET = Aws::S3::Resource.new.bucket(Settings.case_uploads_s3_bucket)
+CASE_UPLOADS_S3_BUCKET = if Rails.env.development?
+                           require_relative "../../lib/dev_aws_s3"
+                           DevAWSS3::Bucket.new(Settings.case_uploads_s3_bucket)
+                         else
+                           Aws::S3::Resource.new.bucket(Settings.case_uploads_s3_bucket)
+                         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -318,6 +318,10 @@ Rails.application.routes.draw do
 
   get "rpi/:target/:id" => "rpi#download", as: :rpi_file_download
 
+  if Rails.env.development?
+    post "dev_s3_uploader" => "dev_s3_uploader#create"
+  end
+
   get "ping", to: "heartbeat#ping", format: :json
   get "healthcheck", to: "heartbeat#healthcheck", as: "healthcheck", format: :json
   post "/feedback" => "feedback#create"

--- a/lib/dev_aws_s3.rb
+++ b/lib/dev_aws_s3.rb
@@ -1,0 +1,101 @@
+class DevAWSS3
+  class Bucket
+    attr_accessor :name
+
+    def initialize(name)
+      @name = name
+      @objects = {}
+    end
+
+    def delete(key)
+      @objects.delete(key)
+    end
+
+    def object(key)
+      @objects[key] = Object.new(key, self)
+    end
+
+    def objects(options = {})
+      if options.key? :prefix
+        @objects
+          .select { |path, _obj| path.start_with? options[:prefix] }
+          .values
+      else
+        @objects.values
+      end
+    end
+
+    def presigned_post(options = {})
+      S3DirectPost.new(self, options)
+    end
+  end
+
+  class Object
+    attr_accessor :key
+
+    INTERNAL_DIR_WITHOUT_BUCKET = "public/uploads/".freeze
+    INTERNAL_DIR = "public/uploads/#{Settings.case_uploads_s3_bucket}/".freeze
+    EXTERNAL_DIR = "uploads/#{Settings.case_uploads_s3_bucket}/".freeze
+
+    def initialize(key, bucket)
+      @key = key
+      @bucket = bucket
+    end
+
+    def move_to(path)
+      directory = "#{INTERNAL_DIR_WITHOUT_BUCKET}#{Pathname.new(path).dirname}"
+      FileUtils.mkdir_p directory
+      File.rename(key, "#{INTERNAL_DIR_WITHOUT_BUCKET}#{path}")
+    end
+
+    def delete
+      file_path = "#{INTERNAL_DIR}#{key}"
+      File.delete(file_path) if File.exist?(file_path)
+    end
+
+    def upload_file(_)
+      nil
+    end
+
+    def presigned_url(*)
+      "http://localhost:3000/#{EXTERNAL_DIR}#{key}"
+    end
+
+    def get
+      OpenStruct.new(
+        body: OpenStruct.new(
+          read: IO.read("#{INTERNAL_DIR}#{key}"),
+        ),
+      )
+    end
+  end
+
+  class S3DirectPost
+    attr_accessor :bucket, :key, :options
+
+    def initialize(bucket, options = {})
+      @bucket = bucket
+      @key = options.fetch(:key)
+      options.delete(:key)
+      @options = options
+    end
+
+    def fields
+      {
+        key:,
+      }.merge(options)
+    end
+
+    def url
+      "http://localhost:3000/dev_s3_uploader"
+    end
+  end
+
+  def initialize
+    @buckets = {}
+  end
+
+  def bucket(name)
+    @buckets[name] = Bucket.new(name)
+  end
+end


### PR DESCRIPTION
## Description
It is not possible to access AWS S3 buckets when running the application locally. This means that file uploads have not been working.

An implementation that only works when running in a development environment will save and download files to/from the local filesystem. This allows all attachment functionality to work when developing locally.