### PR TITLE
Increase memory limit for webapp

### DIFF
--- a/config/kubernetes/production/deployment.yaml
+++ b/config/kubernetes/production/deployment.yaml
@@ -24,6 +24,11 @@ spec:
           ports:
             - containerPort: 3000
           command: ["./config/docker/entrypoint-webapp.sh"]
+          resources:
+            limits:
+              memory: 3Gi
+            requests:
+              memory: 1Gi
           env:
             - name: DATABASE_URL
               valueFrom:


### PR DESCRIPTION
## Description
Large reports are failing because of an Out Of Memory error when data is retrieved from Redis
