### PR TITLE
Fix closed report bug

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bundle exec puma -C config/puma.rb
+web: bundle exec rails server -p 3000
 background_jobs: bundle exec sidekiq -C config/sidekiq-background-jobs.yml
 uploads: bundle exec sidekiq -C config/sidekiq-uploads.yml
 emails: bundle exec sidekiq -C config/sidekiq-quick-jobs.yml

--- a/README.md
+++ b/README.md
@@ -90,13 +90,26 @@ $ DEV_PASSWORD=correspondence bin/rake db:seed:dev
 
 #### Running locally:
 
+To just run the web server without any background jobs (usually sufficient):
+
 ```
 $ bin/rails server
+```
+
+If you need any of the background jobs running then start with:
+
+```
+$ bin/dev
 ```
 
 The site will be accessible at http://localhost:3000.
 You can login using one of the users created during the seeding process such as:
 `correspondence-staff-dev+brian.rix@digital.justice.gov.uk` or `correspondence-staff-dev+david.attenborough@digital.justice.gov.uk` with the password set as `DEV_PASSWORD`
+
+### Sidekiq
+
+When the server is running, you can view the sidekiq queues by going to http://localhost:3000/sidekiq.
+This path can also be used on the live site when you are logged in as an admin.
 
 ### Testing
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -35,7 +35,6 @@ class StatsController < ApplicationController
     @report = Report.new(create_custom_params)
 
     if @report.valid?
-
       @report.run_and_update!(
         user: current_user,
         period_start: @report.period_start,

--- a/app/services/stats/base_closed_cases_report.rb
+++ b/app/services/stats/base_closed_cases_report.rb
@@ -75,7 +75,7 @@ module Stats
 
     def report_details(report)
       redis = Redis.new
-      if redis.exists(report.guid)
+      if redis.exists?(report.guid)
         report.status = Stats::BaseReport::COMPLETE
         report.save!
         redis.get(report.guid)

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+exec foreman start -f Procfile.dev "$@"

--- a/spec/factories/reports.rb
+++ b/spec/factories/reports.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     period_start { 10.business_days.ago }
     period_end { 1.business_days.ago }
     report_data { Faker::Hipster.paragraph }
+    guid { SecureRandom.uuid }
   end
 
   factory :r003_report, parent: :report do


### PR DESCRIPTION
## Description
The `exists?` check for whether the report data has been created in Redis was missing the `?`. This meant that if the background job had not finished processing, the report download would produce an empty file.

The README has also been updated to give details of how to start sidekiq locally.