### PR TITLE
Create temporary RPI files in tmp folder

### DIFF
--- a/app/services/request_personal_information/file_builder.rb
+++ b/app/services/request_personal_information/file_builder.rb
@@ -45,10 +45,10 @@ private
   end
 
   def pdf_filename
-    "#{@rpi.submission_id}.pdf"
+    "tmp/#{@rpi.submission_id}.pdf"
   end
 
   def zip_filename
-    "#{@rpi.submission_id}.zip"
+    "tmp/#{@rpi.submission_id}.zip"
   end
 end


### PR DESCRIPTION
## Description
Files were being created in the root folder which no longer has the correct permissions.