### PR TITLE
CDPT-1958 Enable modsec in non-prod namespaces

### DIFF
--- a/config/kubernetes/development/ingress-live.yaml
+++ b/config/kubernetes/development/ingress-live.yaml
@@ -8,8 +8,12 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
     external-dns.alpha.kubernetes.io/set-identifier: track-a-query-ingress-track-a-query-development-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=track-a-query-development"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
     - hosts:
         - development.track-a-query.service.justice.gov.uk

--- a/config/kubernetes/qa/ingress-live.yaml
+++ b/config/kubernetes/qa/ingress-live.yaml
@@ -6,8 +6,12 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: track-a-query-ingress-track-a-query-qa-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=track-a-query-qa"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
     - hosts:
         - qa.track-a-query.service.justice.gov.uk

--- a/config/kubernetes/staging/ingress-live.yaml
+++ b/config/kubernetes/staging/ingress-live.yaml
@@ -8,8 +8,12 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: app-secrets
     external-dns.alpha.kubernetes.io/set-identifier: track-a-query-ingress-track-a-query-staging-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=track-a-query-staging"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
     - hosts:
       - staging.track-a-query.service.justice.gov.uk


### PR DESCRIPTION
## Description
[Modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) will stop malicious traffic going to the service.