### PR TITLE
CDPT-1943 Capture Offender SAR subject's email address

### DIFF
--- a/app/controllers/concerns/offender_form_validators.rb
+++ b/app/controllers/concerns/offender_form_validators.rb
@@ -9,6 +9,7 @@ private
     set_empty_value_if_unset(params, "flag_as_high_profile")
     object.assign_attributes(params)
     object.validate_date_of_birth
+    object.validate_email_format
   end
 
   def validate_complaint_type(params)

--- a/app/controllers/concerns/offender_sar_cases_params.rb
+++ b/app/controllers/concerns/offender_sar_cases_params.rb
@@ -8,6 +8,7 @@ module OffenderSARCasesParams
       :case_reference_number,
       :delivery_method,
       :date_of_birth_dd, :date_of_birth_mm, :date_of_birth_yyyy,
+      :email,
       :requester_reference,
       :flag_as_high_profile,
       :message,

--- a/app/controllers/concerns/offender_sar_complaint_cases_params.rb
+++ b/app/controllers/concerns/offender_sar_complaint_cases_params.rb
@@ -6,6 +6,7 @@ module OffenderSARComplaintCasesParams
       :case_reference_number,
       :complaint_type,
       :complaint_subtype,
+      :email,
       :requester_reference,
       :flag_as_high_profile,
       :gld_contact_name,

--- a/app/form_models/offender_sar_complaint_case_form.rb
+++ b/app/form_models/offender_sar_complaint_case_form.rb
@@ -70,6 +70,7 @@ private
       postal_address
       flag_as_high_profile
       date_of_birth
+      email
     ]
     fields_subject_details.each do |single_field|
       params[single_field] = object.original_case.send(single_field)

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -919,6 +919,15 @@ class Case::Base < ApplicationRecord
     BusinessUnit.dacu_bmt
   end
 
+  def validate_email_format
+    if email.present? && email !~ /\A.+@.+\z/
+      errors.add(
+        :email,
+        :invalid,
+      )
+    end
+  end
+
 private
 
   def create_deadline_calculator
@@ -966,15 +975,6 @@ private
       end
     end
     errors[:received_date].any?
-  end
-
-  def validate_email_format
-    if email.present? && email !~ /\A.+@.+\z/
-      errors.add(
-        :email,
-        :invalid,
-      )
-    end
   end
 
   def validate_date_draft_compliant

--- a/app/views/cases/offender_sar/_subject_details.html.slim
+++ b/app/views/cases/offender_sar/_subject_details.html.slim
@@ -9,6 +9,9 @@ tr.prison-number
 tr.subject-aliases
   th = t('common.case.subject_aliases')
   td = case_details.subject_aliases
+tr.subject-email
+  th = t('common.case/offender_sar.email')
+  td = case_details.email
 tr.previous-case-numbers
   th = t('common.case.previous_case_numbers')
   td = case_details.previous_case_numbers

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -13,7 +13,7 @@
 
   = f.text_field :subject_aliases
 
-  = f.text_field :email
+  = f.email_field :email
 
   = f.text_field :previous_case_numbers
 

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -13,6 +13,8 @@
 
   = f.text_field :subject_aliases
 
+  = f.text_field :email
+
   = f.text_field :previous_case_numbers
 
   = f.text_field :other_subject_ids
@@ -27,6 +29,7 @@
 
   = f.text_area :subject_address, rows: '4', class: 'address_input'
   = render partial: 'contacts/open_search_dialogue_button', locals: { search_filters: "prison,probation" }
+
 
   = f.radio_button_fieldset(:flag_as_high_profile) do |fieldset|
     - fieldset.radio_input(true, text_method: :humanize)

--- a/app/views/cases/offender_sar/_subject_details_step.html.slim
+++ b/app/views/cases/offender_sar/_subject_details_step.html.slim
@@ -39,4 +39,4 @@
 
   input name="current_step" type="hidden" value=@case.current_step
 
-  = f.submit 'Continue', class: 'button'
+  = f.submit 'Continue', class: 'button', formnovalidate: true

--- a/app/views/cases/offender_sar_complaint/_subject_details.html.slim
+++ b/app/views/cases/offender_sar_complaint/_subject_details.html.slim
@@ -8,6 +8,9 @@ tr.prison-number
 tr.subject-aliases
   th = t('common.case.subject_aliases')
   td = case_details.subject_aliases
+tr.subject-email
+  th = t('common.case/offender_sar.email')
+  td = case_details.email
 tr.previous-case-numbers
   th = t('common.case.previous_case_numbers')
   td = case_details.previous_case_numbers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -273,6 +273,8 @@ en:
             date_responded:
               before_received: "cannot be before date received"
               future: "cannot be in the future"
+            email:
+              invalid: not in the correct format, like name@example.com
             rejected_reasons:
               blank: Reason for rejecting the case cannot be blank
             other_rejected_reason:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -658,6 +658,7 @@ en:
         related_case_number:  Enter related case  reference number, for example 170131001.
       offender_sar:
         case_reference_number: "You can include multiple numbers separated by a comma or a space."
+        email: Enter the email address of the data subject
         message_hint: Include any details that will be useful for processing the case (optional)
         reason_for_lateness_note_hint: Please provide details to why this case is late
         number_exempt_pages: "Pages removed from the SAR as exemptions"
@@ -845,6 +846,7 @@ en:
         request_method: How was the request received by MOJ?
       offender_sar:
         case_reference_number: Case reference number (CRN)
+        email: Email address (optional)
         external_reference: Requester reference (optional)
         high_profile: High profile
         message: Additional case information
@@ -1071,7 +1073,7 @@ en:
       draft_timeliness: Draft timeliness
       download_link_html: |
         Download <span class="visuallyhidden">file %{filename}.</span>
-      email: "Requester’s email"
+      email: "Requester's email"
       exemptions_heading: Exemptions
       extend_for_pit: Extend for Public Interest Test
       extend_sar_deadline: Extend deadline
@@ -1102,7 +1104,7 @@ en:
         status: Retention status
         anonymised_at: Anonymised on
       pnc_acronym_html: '<abbr title="Police national computer">PNC</abbr> number'
-      postal_address: "Requester’s postal address"
+      postal_address: "Requester's postal address"
       previous_case_numbers: Previous SAR cases
       prison_number: "Prison number"
       progress_for_clearance: "Ready for Disclosure clearance"
@@ -1166,6 +1168,7 @@ en:
     case/ico_foi:
       record_further_action: Start further ICO request
     case/offender_sar:
+      email: "Subject's email"
       start_complaint: Start complaint
       complaint_case_link_message: Complaint received for this case on %{received_date}
       move_case_back: Move case back


### PR DESCRIPTION
## Description
Branston will be sending SAR’s to ex-offenders / probationers electronically as part of the digital despatch initiative. This will allow data subjects to receive their requested data quickly and securely via sharepoint rather than it being sent in the post.

To keep all information / detail in one place, and for simple, quick reference we will include a field to capture data subjects email address.