### PR TITLE
Allow hidden files in CI upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,8 +93,8 @@ jobs:
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4
-        include-hidden-files: true
         with:
+          include-hidden-files: true
           name: coverage-${{env.CI_JOB_INDEX}}
           path: coverage/.resultset.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,10 +93,10 @@ jobs:
 
       - name: Upload coverage
         uses: actions/upload-artifact@v4
+        include-hidden-files: true
         with:
           name: coverage-${{env.CI_JOB_INDEX}}
           path: coverage/.resultset.json
-          include-hidden-files: true
 
   coverage:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
         with:
           name: coverage-${{env.CI_JOB_INDEX}}
           path: coverage/.resultset.json
+          include-hidden-files: true
 
   coverage:
     needs: test


### PR DESCRIPTION
## Description
Upload of test coverage files stopped working due to a security [change](https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/) in the github action.
Fixed by using [new option](https://github.com/actions/upload-artifact/issues/602).