### PR TITLE
CDPT-2005 Reduce memory use when updating warehouse data

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -106,6 +106,8 @@ RSpec.configure do |config|
     config.include Rails::Controller::Testing::Integration, type:
   end
 
+  config.include ActiveJob::TestHelper
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/services/stats/warehouse/case_report_sync_spec.rb
+++ b/spec/services/stats/warehouse/case_report_sync_spec.rb
@@ -12,7 +12,7 @@ describe Stats::Warehouse::CaseReportSync do
   end
 
   describe ".affected_cases" do
-    it "returns a list of cases affected by the record" do
+    it "returns the result of the execute function" do
       record = Object.new
       kase = create :foi_case
 
@@ -26,33 +26,35 @@ describe Stats::Warehouse::CaseReportSync do
   end
 
   describe ".sync" do
-    let(:case1) { create :foi_case }
-    let(:case2) { create :sar_case }
+    let(:kase) { create :foi_case }
 
-    it "accepts a single case" do
-      expect(described_class.sync(case1).size).to eq 1
+    context "with a Case::Base" do
+      it "calls generate" do
+        expect(::Warehouse::CaseReport).to receive(:generate).with(kase)
+        described_class.sync(kase)
+      end
     end
 
-    it "accepts an array of cases" do
-      expect(described_class.sync([case1, case2]).size).to eq 2
-    end
-
-    it "handles nil values" do
-      expect(described_class.sync(nil).size).to eq 0
-      expect(described_class.sync([nil]).size).to eq 0
+    context "with a different type of object" do
+      it "does nothing" do
+        expect(::Warehouse::CaseReport).not_to receive(:generate)
+        described_class.sync(Object.new)
+      end
     end
   end
 
   describe ".find_cases" do
-    it "returns an Array of Case::Base related to CaseReport" do
-      record = create :foi_case
-      ::Warehouse::CaseReport.generate(record)
+    it "creates a job for every case related to update object" do
+      user = create(:foi_responder)
+      records = create_list(:foi_case, 3, creator: user)
 
-      query = "case_id = :param" # NOTE: param placeholder
-      result = described_class.find_cases(record, query)
+      records.each do |record|
+        ::Warehouse::CaseReport.generate(record)
+        expect(::Warehouse::CaseSyncJob).to receive(:perform_later).with("Case::Base", record.id)
+      end
 
-      expect(result).to respond_to :each
-      expect(result.size).to eq 1
+      query = "creator_id = :param"
+      described_class.find_cases(user, query)
     end
   end
 
@@ -113,7 +115,7 @@ describe Stats::Warehouse::CaseReportSync do
 
           function = described_class::MAPPINGS[:'Case::Base'][:execute]
           result = function.call(record, query)
-          expect(result).to eq [record]
+          expect(result).to eq record
         end
       end
     end
@@ -190,6 +192,8 @@ describe Stats::Warehouse::CaseReportSync do
           metdata.update!(name: new_name)
           described_class.new(metdata) # re-generate related CaseReports
         end
+
+        perform_enqueued_jobs
 
         all_cases.each(&:reload)
 
@@ -269,6 +273,9 @@ describe Stats::Warehouse::CaseReportSync do
 
           property.update!(value: new_name)
           described_class.new(property) # re-sync
+
+          perform_enqueued_jobs
+
           warehouse_case_report = kase.reload.warehouse_case_report
           expect(warehouse_case_report.send(case_report_field)).to eq new_name
         end
@@ -312,6 +319,9 @@ describe Stats::Warehouse::CaseReportSync do
 
           user.update!(full_name: new_name)
           described_class.new(user) # re-sync
+
+          perform_enqueued_jobs
+
           warehouse_case_report = kase.reload.warehouse_case_report
           expect(warehouse_case_report.send(case_report_field)).to eq new_name
         end


### PR DESCRIPTION
## Description
Currently when an object with a lot of associated cases is updated, all related cases are loaded into memory at the same time and then the Warehouse::CaseReports are updated for each one.
When a user logs in, their database record is updated. This would then trigger a warehouse update which for a very active user could cause hundreds of cases to be loaded into memory, which could cause OOM issues.

This change only loads the IDs for each associated case, then creates update jobs for each one to be done separately. So only one case is ever loaded per job.