### PR TITLE
Limit which attributes cause warehouse update

### DIFF
--- a/app/models/case_closure/metadatum.rb
+++ b/app/models/case_closure/metadatum.rb
@@ -28,6 +28,8 @@ class CaseClosure::Metadatum < ApplicationRecord
   validates :name, :abbreviation, :sequence_id, presence: true
   validates :name, :abbreviation, uniqueness: { scope: :type }
 
+  warehousable_attributes :name
+
   def self.id_from_name(name)
     where(name:).first&.id
   end

--- a/app/models/concerns/warehousable.rb
+++ b/app/models/concerns/warehousable.rb
@@ -2,7 +2,20 @@ module Warehousable
   extend ActiveSupport::Concern
 
   included do
-    after_commit :warehouse
+    after_commit :warehouse, if: :update_warehouse?
+  end
+
+  class_methods do
+    attr_accessor :warehousable
+
+    def warehousable_attributes(attributes)
+      self.warehousable = attributes
+    end
+  end
+
+  def update_warehouse?
+    self.class.warehousable.nil? ||
+      previous_changes.keys.include?(self.class.warehousable)
   end
 
   # Add any further warehousing operations here, ideally async

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -47,6 +47,8 @@ class Team < ApplicationRecord
 
   scope :active, -> { where(deleted_at: nil) }
 
+  warehousable_attributes :name
+
   def self.hierarchy
     result_set = []
     BusinessGroup.order(:name).each do |bg|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,8 @@ class User < ApplicationRecord
     "responder" => 300,
   }.freeze
 
+  warehousable_attributes :full_name
+
   class << self
     def system_admin
       user = User.find_or_initialize_by(full_name: "System update")

--- a/spec/models/concerns/warehousable_spec.rb
+++ b/spec/models/concerns/warehousable_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+class DummyUserClass < ApplicationRecord
+  include Warehousable
+
+  self.table_name = "users"
+end
+
+class DummyRestrictedUserClass < ApplicationRecord
+  include Warehousable
+
+  self.table_name = "users"
+  warehousable_attributes "full_name"
+end
+
+RSpec.describe Warehousable do
+  context "when class doesn't restrict warehousable attributes" do
+    let(:object) { DummyUserClass.create(full_name: "Dummy Class") }
+
+    it "creates a job when the object is saved" do
+      object.reload
+      expect(::Warehouse::CaseSyncJob).to receive(:perform_later).with("DummyUserClass", object.id)
+      object.full_name = "Updated name"
+      object.save!
+    end
+  end
+
+  context "when class does restrict warehousable attributes" do
+    let(:object) { DummyRestrictedUserClass.create(full_name: "Dummy Class") }
+
+    it "creates a job when the object is saved" do
+      object.reload
+      expect(::Warehouse::CaseSyncJob).not_to receive(:perform_later)
+      object.email = "dummy@user.com"
+      object.save!
+    end
+  end
+end

--- a/spec/models/concerns/warehousable_spec.rb
+++ b/spec/models/concerns/warehousable_spec.rb
@@ -6,10 +6,7 @@ class DummyUserClass < ApplicationRecord
   self.table_name = "users"
 end
 
-class DummyRestrictedUserClass < ApplicationRecord
-  include Warehousable
-
-  self.table_name = "users"
+class DummyRestrictedUserClass < DummyUserClass
   warehousable_attributes "full_name"
 end
 
@@ -17,8 +14,9 @@ RSpec.describe Warehousable do
   context "when class doesn't restrict warehousable attributes" do
     let(:object) { DummyUserClass.create(full_name: "Dummy Class") }
 
+    before { object.reload }
+
     it "creates a job when the object is saved" do
-      object.reload
       expect(::Warehouse::CaseSyncJob).to receive(:perform_later).with("DummyUserClass", object.id)
       object.full_name = "Updated name"
       object.save!
@@ -28,8 +26,15 @@ RSpec.describe Warehousable do
   context "when class does restrict warehousable attributes" do
     let(:object) { DummyRestrictedUserClass.create(full_name: "Dummy Class") }
 
-    it "creates a job when the object is saved" do
-      object.reload
+    before { object.reload }
+
+    it "creates a job when the object is saved with a warehousable attribute" do
+      expect(::Warehouse::CaseSyncJob).to receive(:perform_later)
+      object.full_name = "Updated name"
+      object.save!
+    end
+
+    it "doesn't create a job when the object is saved with a non-warehousable attribute" do
       expect(::Warehouse::CaseSyncJob).not_to receive(:perform_later)
       object.email = "dummy@user.com"
       object.save!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -163,7 +163,7 @@ RSpec.configure do |config|
                        TestAWSS3.new.bucket(Settings.case_uploads_s3_bucket))
 
   config.before(:suite) do
-    DbHousekeeping.clean(seed: false)
+    DbHousekeeping.clean(seed: true)
   end
 
   config.after(:suite) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -161,7 +161,7 @@ RSpec.configure do |config|
                        TestAWSS3.new.bucket(Settings.case_uploads_s3_bucket))
 
   config.before(:suite) do
-    DbHousekeeping.clean(seed: true)
+    DbHousekeeping.clean(seed: false)
   end
 
   config.after(:suite) do


### PR DESCRIPTION
## Description
Currently when objects that include the Warehousable concern are updated, a job is triggered that will cause all associated cases to be updated in the warehouse table. This needs to happen because the case data is denormalised in that table.

However, what is being updated in the object is often not relevant to the case so the warehouse update is unnecessary. e.g. updating a user's last login data.

A new `warehousable_attributes` class method is now available to specify which updated fields should cause the warehouse sync to take place. If the method is not defined on a model then any update will still cause a sync.
