### PR TITLE
Allow multiple warehouseable attributes

### DIFF
--- a/app/models/concerns/warehousable.rb
+++ b/app/models/concerns/warehousable.rb
@@ -9,7 +9,7 @@ module Warehousable
     attr_accessor :warehousable
 
     def warehousable_attributes(attributes)
-      self.warehousable = attributes
+      self.warehousable = attributes.to_s
     end
   end
 

--- a/app/models/concerns/warehousable.rb
+++ b/app/models/concerns/warehousable.rb
@@ -8,14 +8,14 @@ module Warehousable
   class_methods do
     attr_accessor :warehousable
 
-    def warehousable_attributes(attributes)
-      self.warehousable = attributes.to_s
+    def warehousable_attributes(*attributes)
+      self.warehousable = attributes.map(&:to_s)
     end
   end
 
   def update_warehouse?
     self.class.warehousable.nil? ||
-      previous_changes.keys.include?(self.class.warehousable)
+      previous_changes.keys.intersect?(self.class.warehousable)
   end
 
   # Add any further warehousing operations here, ideally async

--- a/spec/models/concerns/warehousable_spec.rb
+++ b/spec/models/concerns/warehousable_spec.rb
@@ -10,6 +10,10 @@ class DummyRestrictedUserClass < DummyUserClass
   warehousable_attributes :full_name
 end
 
+class DummyMultipleRestrictedUserClass < DummyUserClass
+  warehousable_attributes :full_name, :email
+end
+
 RSpec.describe Warehousable do
   context "when class doesn't restrict warehousable attributes" do
     let(:object) { DummyUserClass.create(full_name: "Dummy Class") }
@@ -37,6 +41,24 @@ RSpec.describe Warehousable do
     it "doesn't create a job when the object is saved with a non-warehousable attribute" do
       expect(::Warehouse::CaseSyncJob).not_to receive(:perform_later)
       object.email = "dummy@user.com"
+      object.save!
+    end
+  end
+
+  context "when class restricts multiple warehousable attributes" do
+    let(:object) { DummyMultipleRestrictedUserClass.create(full_name: "Dummy Class", email: "email@email.com") }
+
+    before { object.reload }
+
+    it "creates a job when the object is saved with a warehousable attribute" do
+      expect(::Warehouse::CaseSyncJob).to receive(:perform_later).with("DummyMultipleRestrictedUserClass", object.id)
+      object.full_name = "Updated name"
+      object.save!
+    end
+
+    it "doesn't create a job when the object is saved with a non-warehousable attribute" do
+      expect(::Warehouse::CaseSyncJob).not_to receive(:perform_later)
+      object.sign_in_count = 3
       object.save!
     end
   end

--- a/spec/models/concerns/warehousable_spec.rb
+++ b/spec/models/concerns/warehousable_spec.rb
@@ -7,7 +7,7 @@ class DummyUserClass < ApplicationRecord
 end
 
 class DummyRestrictedUserClass < DummyUserClass
-  warehousable_attributes "full_name"
+  warehousable_attributes :full_name
 end
 
 RSpec.describe Warehousable do
@@ -29,7 +29,7 @@ RSpec.describe Warehousable do
     before { object.reload }
 
     it "creates a job when the object is saved with a warehousable attribute" do
-      expect(::Warehouse::CaseSyncJob).to receive(:perform_later)
+      expect(::Warehouse::CaseSyncJob).to receive(:perform_later).with("DummyRestrictedUserClass", object.id)
       object.full_name = "Updated name"
       object.save!
     end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -53,6 +53,30 @@ RSpec.describe Team, type: :model do
     end
   end
 
+  describe "warehousable" do
+    let(:team) { create(:team) }
+
+    before do
+      team.reload
+    end
+
+    context "when updating team name" do
+      it "creates sync job" do
+        team.name = "new name"
+        expect(::Warehouse::CaseSyncJob).to receive(:perform_later).with("Team", team.id)
+        team.save!
+      end
+    end
+
+    context "when updating another attribute" do
+      it "doesn't create sync job" do
+        team.email = "new@email.com"
+        expect(::Warehouse::CaseSyncJob).not_to receive(:perform_later)
+        team.save!
+      end
+    end
+  end
+
   context "when multiple teams created" do
     let!(:managing_team)       { find_or_create :team_disclosure_bmt }
     let!(:branston_team)       { find_or_create :team_branston }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -437,4 +437,28 @@ RSpec.describe User, type: :model do
       expect(team1_other_team_names).not_to include(team1.name)
     end
   end
+
+  describe "warehousable" do
+    let(:user) { create(:user) }
+
+    before do
+      user.reload
+    end
+
+    context "when updating team name" do
+      it "creates sync job" do
+        user.full_name = "new name"
+        expect(::Warehouse::CaseSyncJob).to receive(:perform_later).with("User", user.id)
+        user.save!
+      end
+    end
+
+    context "when updating another attribute" do
+      it "doesn't create sync job" do
+        user.email = "new@email.com"
+        expect(::Warehouse::CaseSyncJob).not_to receive(:perform_later)
+        user.save!
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -106,8 +106,6 @@ RSpec.configure do |config|
     config.include Rails::Controller::Testing::Integration, type:
   end
 
-  config.include ActiveJob::TestHelper
-
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/services/stats/warehouse/case_report_sync_spec.rb
+++ b/spec/services/stats/warehouse/case_report_sync_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe Stats::Warehouse::CaseReportSync do
+  include ActiveJob::TestHelper
+
   describe "#initialize" do
     it "requires a warehousable ActiveRecord instance" do
       not_activerecord = String.new


### PR DESCRIPTION
## Description
Extends warehousable_attributes so it can handle multiple attributes. Also stores the value as a string.