### PR TITLE
CDPT-2070 Fix edge case when case is made valid

### DIFF
--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -240,6 +240,7 @@ module Cases
         end
         render :accepted_date_received and return
       end
+
       case service.result
       when :ok
         flash[:notice] = t("cases.update.case_updated")

--- a/app/services/case_validate_rejected_offender_sar_service.rb
+++ b/app/services/case_validate_rejected_offender_sar_service.rb
@@ -13,6 +13,8 @@ class CaseValidateRejectedOffenderSARService
     ActiveRecord::Base.transaction do
       @case.assign_attributes(@params)
       @case.set_valid_case_number
+      # Ensure external deadline is updated
+      @case.external_deadline = @case.deadline_calculator.external_deadline
       @case.save!
       @case.state_machine.validate_rejected_case!(
         {

--- a/spec/services/case_validate_rejected_offender_sar_service_spec.rb
+++ b/spec/services/case_validate_rejected_offender_sar_service_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 describe CaseValidateRejectedOffenderSARService do
   describe "#call" do
-    let(:team)          { find_or_create :team_branston }
-    let(:user)          { find_or_create :branston_user }
-    let(:kase)          { create :offender_sar_case, :rejected, received_date: 1.day.ago.to_date }
-    let(:service)       do
+    let(:team) { find_or_create :team_branston }
+    let(:user) { find_or_create :branston_user }
+    let(:kase) { create :offender_sar_case, :rejected, received_date: 1.day.ago.to_date }
+    let(:service) do
       described_class.new(user:,
                           kase:,
                           params:)
     end
 
     context "when setting a valid date" do
-      let(:params)        { { received_date: Time.zone.today } }
+      let(:params) { { received_date: Time.zone.today } }
 
       it "changes the received date on the case" do
         service.call
@@ -39,6 +39,12 @@ describe CaseValidateRejectedOffenderSARService do
         expect(kase.number).to eq kase_number
       end
 
+      it "updates the deadline" do
+        expect {
+          service.call
+        }.to change(kase, :external_deadline)
+      end
+
       it "sets results to :ok" do
         service.call
         expect(service.result).to eq :ok
@@ -51,6 +57,16 @@ describe CaseValidateRejectedOffenderSARService do
       it "raises an error when it saves" do
         service.call
         expect(service.result).to eq :error
+      end
+    end
+
+    context "when received_date doesn't change" do
+      let(:params) { { received_date: kase.received_date } }
+
+      it "updates the deadline" do
+        expect {
+          service.call
+        }.to change(kase, :external_deadline)
       end
     end
   end


### PR DESCRIPTION
## Description
When a case was made valid, but the received date didn't change (e.g. when the case was made valid the same day it was created), the external deadline was not being updated.
This caused the external deadline to be wrong since the external deadline for rejected cases has been extended.

We now ensure the external deadline is updated when the case is made valid.
