### PR TITLE
Cant add data request type once email is sent

### DIFF
--- a/app/controllers/cases/commissioning_documents_controller.rb
+++ b/app/controllers/cases/commissioning_documents_controller.rb
@@ -20,7 +20,7 @@ module Cases
       )
       service.send!
 
-      redirect_to case_data_request_area_path(@case, @data_request_area), flash: { notice: "Day 1 commissioning email sent" }
+      redirect_to case_path(@case), flash: { notice: "Day 1 commissioning email sent" }
     end
 
   private

--- a/app/views/cases/offender_sar/_data_requests.html.slim
+++ b/app/views/cases/offender_sar/_data_requests.html.slim
@@ -45,4 +45,4 @@
         - if data_request_area.data_request_emails.none?
           = action_button_for(:record_data_request)
           = link_to t('button.delete'), case_data_request_area_path(case_id: @case.id, id: @data_request_area.id), type: 'button', class: 'govuk-button--warning', id: "action--delete-data-request-area", data: { confirm: t('common.case/offender_sar.delete_data_request_area') }, method: :delete
-      hr
+          hr

--- a/app/views/cases/offender_sar/_data_requests.html.slim
+++ b/app/views/cases/offender_sar/_data_requests.html.slim
@@ -42,7 +42,7 @@
             = render partial: 'shared/table_total_row', locals: { total: data_request_area.data_requests.sum(:cached_num_pages), label_span: '2', value_span: '5' }
     .button-holder
       - if policy(case_details).can_record_data_request? && allow_editing
-        = action_button_for(:record_data_request)
         - if data_request_area.data_request_emails.none?
+          = action_button_for(:record_data_request)
           = link_to t('button.delete'), case_data_request_area_path(case_id: @case.id, id: @data_request_area.id), type: 'button', class: 'govuk-button--warning', id: "action--delete-data-request-area", data: { confirm: t('common.case/offender_sar.delete_data_request_area') }, method: :delete
       hr

--- a/spec/controllers/cases/commissioning_documents_controller_spec.rb
+++ b/spec/controllers/cases/commissioning_documents_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Cases::CommissioningDocumentsController, type: :controller do
     end
 
     it "redirects to the case page" do
-      expect(response).to redirect_to(case_data_request_area_path(offender_sar_case, data_request_area))
+      expect(response).to redirect_to(case_path(offender_sar_case))
     end
   end
 end

--- a/spec/views/cases/data_request_areas/show_html_slim_spec.rb
+++ b/spec/views/cases/data_request_areas/show_html_slim_spec.rb
@@ -158,6 +158,10 @@ describe "cases/data_request_areas/show", type: :view do
         expect { page.commissioning_document.button_send_email }.to raise_error(Capybara::ElementNotFound)
       end
 
+      it "does not display add data request type button" do
+        expect(page).to have_no_link("Add data request type", href: new_case_data_request_area_data_request_path(data_request_area.kase, data_request_area))
+      end
+
       it "does not display delete button" do
         expect(page).to have_no_link("Delete", href: case_data_request_area_path(data_request_area.kase, data_request_area))
       end
@@ -185,6 +189,10 @@ describe "cases/data_request_areas/show", type: :view do
       it "displays send email button" do
         expect(page.commissioning_document.button_send_email.text).to eq "Send commissioning email"
         expect(page).to have_selector(".data_request_area_send_email")
+      end
+
+      it "displays add data request type button" do
+        expect(page).to have_link("Add data request type", href: new_case_data_request_area_data_request_path(data_request_area.kase, data_request_area))
       end
 
       it "displays delete button" do


### PR DESCRIPTION
## Description

- Remove add data request type button once the commissioning email has been sent
- User is redirected to the case page after email has been sent

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?selectedIssue=CDPT-2089

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
