### PR TITLE
Add missing event "assign_to_team_member"

### DIFF
--- a/config/locales/event.en.yml
+++ b/config/locales/event.en.yml
@@ -12,6 +12,7 @@ en:
     approve_and_bypass: Cleared - further clearance not required
     assign_responder: Assign responder
     assign_to_new_team: Assign to new team
+    assign_to_team_member: Assign responder
     close: Case closed
     create: Case created
     date_sent_to_sscl_removed: SSCL date sent removed


### PR DESCRIPTION
## Description
The event name was changed recently, but the old event name needs to be retained as it is used in multiple CaseTransitions in the database.