### PR TITLE
Allow for no original case

### DIFF
--- a/app/models/case/ico/base.rb
+++ b/app/models/case/ico/base.rb
@@ -73,7 +73,7 @@ class Case::ICO::Base < Case::Base
     date_closed
   ]
 
-  delegate :subject, :name, to: :original_case
+  delegate :subject, :name, to: :original_case, allow_nil: true
 
   enum ico_decision: {
     upheld: "upheld",


### PR DESCRIPTION
## Description
Deleted ICO cases may not have been linked to an original case, which causes in error in the deleted cases report.
This stops an exception if there is no original case.