### PR TITLE
Fix probation template bug

### DIFF
--- a/app/models/commissioning_document_template/prison.rb
+++ b/app/models/commissioning_document_template/prison.rb
@@ -18,7 +18,7 @@ module CommissioningDocumentTemplate
         aliases: kase.subject_aliases,
         date_range: data_request_area.request_dates,
         deadline:,
-        data_required: data_request_area.data_required || default_data_required,
+        data_required: data_request_area.data_request.decorate.data_required || default_data_required,
       )
     end
   end

--- a/app/models/commissioning_document_template/probation.rb
+++ b/app/models/commissioning_document_template/probation.rb
@@ -19,7 +19,7 @@ module CommissioningDocumentTemplate
         crn: kase.case_reference_number,
         date_range: data_request_area.request_dates,
         deadline:,
-        data_required: data_request_area.data_required || default_data_required,
+        data_required: data_request_area.data_request.decorate.data_required || default_data_required,
       )
     end
   end


### PR DESCRIPTION
## Description
When trying to download the probation template, an error occurred due to `data_required` not being a method of DataRequestAreaDecorator

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
