### PR TITLE
Add area to chase case history message

### DIFF
--- a/app/decorators/data_request_email_decorator.rb
+++ b/app/decorators/data_request_email_decorator.rb
@@ -9,6 +9,11 @@ class DataRequestEmailDecorator < Draper::Decorator
     I18n.t("helpers.label.data_request_email.email_type.#{super}", chase_number:)
   end
 
+  def email_type_with_area
+    area = I18n.t("helpers.label.data_request_area.data_request_area_type.#{data_request_area.data_request_area_type}")
+    "#{area} - #{email_type}"
+  end
+
   def status
     super.humanize
   end

--- a/app/services/commissioning_document_email_service.rb
+++ b/app/services/commissioning_document_email_service.rb
@@ -76,7 +76,7 @@ private
     data_request_area.kase.state_machine.send_chase_email!(
       acting_user: User.system_admin,
       acting_team: BusinessUnit.dacu_branston,
-      message: email&.decorate&.email_type,
+      message: email&.decorate&.email_type_with_area,
     )
   end
 end

--- a/spec/services/commissioning_document_email_service_spec.rb
+++ b/spec/services/commissioning_document_email_service_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe CommissioningDocumentEmailService do
 
         transistion = kase.transitions.last
         expect(transistion.event).to eq "send_chase_email"
-        expect(transistion.metadata["message"]).to eq email.decorate.email_type
+        expect(transistion.metadata["message"]).to eq email.decorate.email_type_with_area
       end
     end
 


### PR DESCRIPTION
## Description
Distinguish case history messages for chase emails by adding data request area to the message.