### PR TITLE
Send overdue chase emails and add dryrun option

### DIFF
--- a/app/models/data_request_area.rb
+++ b/app/models/data_request_area.rb
@@ -89,7 +89,7 @@ class DataRequestArea < ApplicationRecord
   end
 
   def chase_due?
-    next_chase_date.to_date == Date.current
+    next_chase_date.to_date <= Date.current
   end
 
   def last_chase_email

--- a/app/services/data_request_chase_service.rb
+++ b/app/services/data_request_chase_service.rb
@@ -1,9 +1,14 @@
 class DataRequestChaseService
-  def self.call
+  def self.call(dryrun: true)
+    Rails.logger.info("Chases due:") if dryrun
     DataRequestArea.where(id: DataRequestArea.sent_and_in_progress_ids).find_each do |dra|
       if dra.chase_due?
-        service = CommissioningDocumentEmailService.new(data_request_area: dra, commissioning_document: dra.commissioning_document, current_user: dra.kase.creator)
-        service.send_chase!(dra.next_chase_type)
+        if dryrun
+          Rails.logger.info("Case ID: #{dra.case_id} Data Request Area ID: #{dra.id}")
+        else
+          service = CommissioningDocumentEmailService.new(data_request_area: dra, commissioning_document: dra.commissioning_document, current_user: dra.kase.creator)
+          service.send_chase!(dra.next_chase_type)
+        end
       end
     end
   end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -8,6 +8,6 @@ namespace :email do
 
   desc "Send daily data request chase emails"
   task send_data_request_chase_emails: :environment do
-    DataRequestChaseService.call
+    DataRequestChaseService.call(dryrun: false)
   end
 end

--- a/spec/models/data_request_area_spec.rb
+++ b/spec/models/data_request_area_spec.rb
@@ -360,10 +360,17 @@ RSpec.describe DataRequestArea, type: :model do
       end
     end
 
-    context "when next chase is not today" do
+    context "when next chase is in the future" do
       it "returns false" do
         allow(data_request_area).to receive(:next_chase_date).and_return(Date.current + 1.day)
         expect(data_request_area.chase_due?).to be false
+      end
+    end
+
+    context "when next chase is in the past" do
+      it "returns false" do
+        allow(data_request_area).to receive(:next_chase_date).and_return(Date.current - 1.day)
+        expect(data_request_area.chase_due?).to be true
       end
     end
   end

--- a/spec/services/data_request_chase_service_spec.rb
+++ b/spec/services/data_request_chase_service_spec.rb
@@ -20,7 +20,7 @@ describe DataRequestChaseService do
         end
 
         it "doesn't send request to email service" do
-          expect(service).to_not receive(:send_chase!)
+          expect(service).not_to receive(:send_chase!)
           described_class.call
         end
 


### PR DESCRIPTION
## Description
Fix bug where overdue chase emails were not sent.
Defaults to dry run option where no emails are sent, and it just prints the details of due chases.