### PR TITLE
CDPT-2340 Remove empty scroll bar gutter from tables.

### DIFF
--- a/app/assets/stylesheets/moj/_govuk_overrides.scss
+++ b/app/assets/stylesheets/moj/_govuk_overrides.scss
@@ -163,7 +163,7 @@ td {
 
 // Open case list table scrollable to support large fonts
 .cases-table-container {
-  overflow: scroll;
+  overflow: auto;
 }
 
 // Fix mobile view issue on table long strings


### PR DESCRIPTION
## Description
If the width of tabulated data exceeds the width of the page the table becomes scrollable.  Currently empty scroll bar gutters appear when the table fits the page width.  To stop this behaviour the CSS overflow attribute should be changed to 'auto'.   

### Screenshots
Before:

![before](https://github.com/user-attachments/assets/dccce4c5-d85e-4bcb-b579-ba315a177619)

After:

![after](https://github.com/user-attachments/assets/934f029e-bfb1-442b-9f95-33af51f9f4ff)

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-2340
