### PR TITLE
CDPT-2512: Fix get_rejected bug

### DIFF
--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -63,7 +63,7 @@ module Cases
       @rejected =
         @case.rejected? ||
         params["rejected"] == "true" ||
-        (action_name == "create" && create_params["current_state"])
+        (action_name == "create" && create_params["current_state"] == "invalid_submission")
     end
 
     def edit_params

--- a/spec/controllers/cases/offender_sar_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_controller_spec.rb
@@ -306,6 +306,37 @@ RSpec.describe Cases::OffenderSARController, type: :controller do
         end
       end
     end
+
+    context "when rejected" do
+      context "when the case is rejected" do
+        let(:rejected_case) { create(:offender_sar_case, :rejected).decorate }
+
+        it "sets @rejected to true" do
+          allow(controller).to receive(:build_case_from_session).and_return(rejected_case)
+          post(:create, params:)
+          expect(assigns(:rejected)).to be(true)
+        end
+      end
+
+      context "when params include rejected: true" do
+        let(:rejected_params) { params.merge(rejected: true) }
+
+        it "sets @rejected to true" do
+          post(:create, params: rejected_params)
+          expect(assigns(:rejected)).to be(true)
+        end
+      end
+
+      context "when current_state is invalid_submission" do
+        let(:offender_sar_params) { params[:offender_sar].merge(current_state: "invalid_submission") }
+        let(:rejected_params) { params.merge(offender_sar: offender_sar_params) }
+
+        it "sets @rejected to true" do
+          post(:create, params: rejected_params)
+          expect(assigns(:rejected)).to be(true)
+        end
+      end
+    end
   end
 
   describe "transitions" do


### PR DESCRIPTION
## Description

Spotted a bug where the rejected flow was not being persisted correctly. Now looks for the correct state to determine rejection state.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
 N/A

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-2512

### Deployment
N/A

### Manual testing instructions
Repo steps for the bug:

1. Login in as a Branston user (Brian Rix)
2. Proceed to create a new offender SAR
3. On the 'Who is the subject?' page, fill out details but leave something out (eg DOB) to trigger validation and submit the form
4. Add the missing information and submit the form
5. Observe that the flow now correctly takes you to the correct (non rejected) SAR creation flow

Also worth checking a rejected SAR can still be created successfully.