### PR TITLE
CDPT-2513 Add chase number to email subject

### DIFF
--- a/app/mailers/commissioning_document_mailer.rb
+++ b/app/mailers/commissioning_document_mailer.rb
@@ -25,7 +25,7 @@ class CommissioningDocumentMailer < GovukNotifyRails::Mailer
     file = StringIO.new(commissioning_document.document)
 
     set_personalisation(
-      email_subject: email_subject(kase),
+      email_subject: email_subject(kase, chase_number),
       email_address: recipient,
       deadline: commissioning_document.deadline,
       deadline_days: commissioning_document.deadline_days,
@@ -48,7 +48,7 @@ class CommissioningDocumentMailer < GovukNotifyRails::Mailer
     file = StringIO.new(commissioning_document.document)
 
     set_personalisation(
-      email_subject: email_subject(kase),
+      email_subject: email_subject(kase, chase_number),
       email_address: recipient,
       deadline: commissioning_document.deadline,
       deadline_days: commissioning_document.deadline_days,
@@ -71,7 +71,7 @@ class CommissioningDocumentMailer < GovukNotifyRails::Mailer
     file = StringIO.new(commissioning_document.document)
 
     set_personalisation(
-      email_subject: email_subject(kase),
+      email_subject: email_subject(kase, chase_number),
       email_address: recipient,
       deadline: commissioning_document.deadline,
       external_deadline: kase.external_deadline.strftime("%d/%m/%Y"),
@@ -95,8 +95,8 @@ private
     set_email_reply_to(Settings.commissioning_notify_reply_to)
   end
 
-  def email_subject(kase)
-    "Subject Access Request - #{kase.number} - #{kase.subject_full_name}"
+  def email_subject(kase, chase_number)
+    "Subject Access Request - #{kase.number} - #{kase.subject_full_name} - Chase #{chase_number}"
   end
 
   def set_notify_id

--- a/spec/mailers/commissioning_document_mailer_spec.rb
+++ b/spec/mailers/commissioning_document_mailer_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe CommissioningDocumentMailer, type: :mailer do
     let(:kase) { create(:offender_sar_case) }
     let(:commissioning_document) { create(:commissioning_document) }
     let(:email_address) { "test@test.com" }
-    let(:mail) { described_class.chase_email(kase, commissioning_document, email_address, 1) }
+    let(:chase_number) { 1 }
+    let(:mail) { described_class.chase_email(kase, commissioning_document, email_address, chase_number) }
 
     it "sets the template" do
       expect(mail.govuk_notify_template)
@@ -73,7 +74,7 @@ RSpec.describe CommissioningDocumentMailer, type: :mailer do
 
     it "personalises the email" do
       expect(mail.govuk_notify_personalisation[:email_address]).to eq email_address
-      expect(mail.govuk_notify_personalisation[:email_subject]).to eq "Subject Access Request - #{kase.number} - #{kase.subject_full_name}"
+      expect(mail.govuk_notify_personalisation[:email_subject]).to eq "Subject Access Request - #{kase.number} - #{kase.subject_full_name} - Chase #{chase_number}"
       expect(mail.govuk_notify_personalisation[:deadline]).to eq commissioning_document.deadline
       expect(mail.govuk_notify_personalisation[:deadline_days]).to eq commissioning_document.deadline_days
     end
@@ -122,7 +123,8 @@ RSpec.describe CommissioningDocumentMailer, type: :mailer do
     let(:kase) { create(:offender_sar_case) }
     let(:commissioning_document) { create(:commissioning_document) }
     let(:email_address) { "test@test.com" }
-    let(:mail) { described_class.chase_escalation_email(kase, commissioning_document, email_address, 1) }
+    let(:chase_number) { 3 }
+    let(:mail) { described_class.chase_escalation_email(kase, commissioning_document, email_address, chase_number) }
 
     it "sets the template" do
       expect(mail.govuk_notify_template)
@@ -131,7 +133,7 @@ RSpec.describe CommissioningDocumentMailer, type: :mailer do
 
     it "personalises the email" do
       expect(mail.govuk_notify_personalisation[:email_address]).to eq email_address
-      expect(mail.govuk_notify_personalisation[:email_subject]).to eq "Subject Access Request - #{kase.number} - #{kase.subject_full_name}"
+      expect(mail.govuk_notify_personalisation[:email_subject]).to eq "Subject Access Request - #{kase.number} - #{kase.subject_full_name} - Chase #{chase_number}"
       expect(mail.govuk_notify_personalisation[:deadline]).to eq commissioning_document.deadline
       expect(mail.govuk_notify_personalisation[:deadline_days]).to eq commissioning_document.deadline_days
     end
@@ -148,7 +150,7 @@ RSpec.describe CommissioningDocumentMailer, type: :mailer do
 
     context "when email is retried" do
       it "doesn't create a new data_request_email record" do
-        create(:data_request_email, email_address:, data_request_area: commissioning_document.data_request_area, email_type: "chase_escalation", chase_number: 1)
+        create(:data_request_email, email_address:, data_request_area: commissioning_document.data_request_area, email_type: "chase_escalation", chase_number:)
 
         expect {
           mail.deliver
@@ -161,7 +163,8 @@ RSpec.describe CommissioningDocumentMailer, type: :mailer do
     let(:kase) { create(:offender_sar_case) }
     let(:commissioning_document) { create(:commissioning_document) }
     let(:email_address) { "test@test.com" }
-    let(:mail) { described_class.chase_overdue_email(kase, commissioning_document, email_address, 1) }
+    let(:chase_number) { 8 }
+    let(:mail) { described_class.chase_overdue_email(kase, commissioning_document, email_address, chase_number) }
 
     it "sets the template" do
       expect(mail.govuk_notify_template)
@@ -170,7 +173,7 @@ RSpec.describe CommissioningDocumentMailer, type: :mailer do
 
     it "personalises the email" do
       expect(mail.govuk_notify_personalisation[:email_address]).to eq email_address
-      expect(mail.govuk_notify_personalisation[:email_subject]).to eq "Subject Access Request - #{kase.number} - #{kase.subject_full_name}"
+      expect(mail.govuk_notify_personalisation[:email_subject]).to eq "Subject Access Request - #{kase.number} - #{kase.subject_full_name} - Chase #{chase_number}"
       expect(mail.govuk_notify_personalisation[:deadline]).to eq commissioning_document.deadline
       expect(mail.govuk_notify_personalisation[:external_deadline]).to eq kase.external_deadline.strftime("%d/%m/%Y")
     end
@@ -187,7 +190,7 @@ RSpec.describe CommissioningDocumentMailer, type: :mailer do
 
     context "when email is retried" do
       it "doesn't create a new data_request_email record" do
-        create(:data_request_chase_email, email_address:, data_request_area: commissioning_document.data_request_area, email_type: "chase_overdue")
+        create(:data_request_chase_email, email_address:, data_request_area: commissioning_document.data_request_area, email_type: "chase_overdue", chase_number:)
 
         expect {
           mail.deliver


### PR DESCRIPTION
## Description
To help with auto-categorising of emails by the receiver, the chase number is being added to the email subject.
