### PR TITLE
CDPT-2324: Fix checkbox typo and migrate data for offender SAR rejected reasons

### DIFF
--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -85,7 +85,7 @@ class Case::SAR::Offender < Case::Base
   REJECTED_AUTO_CLOSURE_DEADLINE = 90
 
   REJECTED_REASONS = {
-    "cctv_bwcv" => "CCTV / BWCV request",
+    "cctv_bwcf" => "CCTV / BWCF request",
     "change_of_name_certificate" => "Change of name certificate",
     "court_data_request" => "Court data request",
     "data_previously_requested" => "Data previously provided",

--- a/db/data_migrations/20250226173258_update_rejected_reasons_data.rb
+++ b/db/data_migrations/20250226173258_update_rejected_reasons_data.rb
@@ -10,7 +10,13 @@ class UpdateRejectedReasonsData < ActiveRecord::DataMigration
       end
 
       offender_sar_case.properties.merge!("rejected_reasons" => reasons)
-      offender_sar_case.save!
+      # rubocop:disable Rails/SaveBang
+      offender_sar_case.save(validate: false)
+      # rubocop:enable Rails/SaveBang
     end
+  end
+
+  def down
+    # enables rollback
   end
 end

--- a/db/data_migrations/20250226173258_update_rejected_reasons_data.rb
+++ b/db/data_migrations/20250226173258_update_rejected_reasons_data.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class UpdateRejectedReasonsData < ActiveRecord::DataMigration
+  disable_ddl_transaction!
+
+  def up
+    cases = Case::Base.offender_sar.where("properties -> 'rejected_reasons' @> ?", %w[cctv_bwcv].to_json)
+
+    cases.find_each do |offender_sar_case|
+      reasons = offender_sar_case.properties["rejected_reasons"].map do |reason|
+        reason == "cctv_bwcv" ? "cctv_bwcf" : reason
+      end
+
+      offender_sar_case.properties.merge!("rejected_reasons" => reasons)
+      offender_sar_case.save!
+    end
+  end
+end

--- a/db/data_migrations/20250226173258_update_rejected_reasons_data.rb
+++ b/db/data_migrations/20250226173258_update_rejected_reasons_data.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class UpdateRejectedReasonsData < ActiveRecord::DataMigration
-  disable_ddl_transaction!
-
   def up
     cases = Case::Base.offender_sar.where("properties -> 'rejected_reasons' @> ?", %w[cctv_bwcv].to_json)
 

--- a/spec/features/cases/offender_sar/case_creating_spec.rb
+++ b/spec/features/cases/offender_sar/case_creating_spec.rb
@@ -201,7 +201,7 @@ feature "Offender SAR Case creation by a manager", js: true do
   end
 
   def and_fill_in_reason_rejected_page
-    cases_new_offender_sar_reason_rejected_page.choose_rejected_reason("cctv_bwcv")
+    cases_new_offender_sar_reason_rejected_page.choose_rejected_reason("cctv_bwcf")
     click_on "Continue"
     expect(cases_new_offender_sar_recipient_details_page).to be_displayed
   end

--- a/spec/features/cases/offender_sar/rejected_case_editing_spec.rb
+++ b/spec/features/cases/offender_sar/rejected_case_editing_spec.rb
@@ -4,7 +4,7 @@ require Rails.root.join("db/seeders/case_category_reference_seeder")
 feature "Offender SAR Case editing by a manager", :js do
   given(:manager)         { find_or_create :branston_user }
   given(:managing_team)   { create :managing_team, managers: [manager] }
-  given(:offender_sar_case) { create :offender_sar_case, :rejected, :third_party, received_date: Time.zone.today.to_date, rejected_reasons: %w[cctv_bwcv change_of_name_certificate court_data_request] }
+  given(:offender_sar_case) { create :offender_sar_case, :rejected, :third_party, received_date: Time.zone.today.to_date, rejected_reasons: %w[cctv_bwcf change_of_name_certificate court_data_request] }
 
   background do
     find_or_create :team_branston
@@ -27,7 +27,7 @@ feature "Offender SAR Case editing by a manager", :js do
     expect(cases_show_page).to be_displayed
     expect(cases_show_page.case_history).to have_content "Valid case created"
 
-    expect(cases_show_page).to have_content "CCTV / BWCV request"
+    expect(cases_show_page).to have_content "CCTV / BWCF request"
     expect(cases_show_page).to have_content "Change of name certificate"
     expect(cases_show_page).to have_content "Court data request"
 

--- a/spec/models/case/sar/offender_spec.rb
+++ b/spec/models/case/sar/offender_spec.rb
@@ -115,9 +115,9 @@ describe Case::SAR::Offender do
       let(:case_rejected) { create(:offender_sar_case, :rejected, rejected_reasons: %w[other], other_rejected_reason: "More information") }
 
       it "sets the other rejected reason to blank" do
-        case_rejected.update!(rejected_reasons: %w[cctv_bwcv])
+        case_rejected.update!(rejected_reasons: %w[cctv_bwcf])
 
-        expect(case_rejected.rejected_reasons).to eq(%w[cctv_bwcv])
+        expect(case_rejected.rejected_reasons).to eq(%w[cctv_bwcf])
         expect(case_rejected.other_rejected_reason).to eq("")
       end
     end

--- a/spec/models/warehouse/case_report_spec.rb
+++ b/spec/models/warehouse/case_report_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe ::Warehouse::CaseReport, type: :model do
   describe "#rejected_reasons_selection" do
     it "returns hash with selection" do
       rejected_case = create(:offender_sar_case, :rejected)
-      expect(described_class.rejected_reasons_selection(rejected_case)).to match({ "cctv_bwcv" => "No",
+      expect(described_class.rejected_reasons_selection(rejected_case)).to match({ "cctv_bwcf" => "No",
                                                                                    "change_of_name_certificate" => "No",
                                                                                    "court_data_request" => "Yes",
                                                                                    "data_previously_requested" => "No",

--- a/spec/support/standard_setup.rb
+++ b/spec/support/standard_setup.rb
@@ -305,7 +305,7 @@ class StandardSetup
       },
       std_rejected_sar: lambda { |attributes = {}|
         create(:offender_sar_case,
-               { identifier: "std_rejected_sar", current_state: "invalid_submission", rejected_reasons: %w[cctv_bwcv] }.merge(attributes))
+               { identifier: "std_rejected_sar", current_state: "invalid_submission", rejected_reasons: %w[cctv_bwcf] }.merge(attributes))
       },
       ot_ico_sar_noff_unassigned: lambda { |attributes = {}|
         create(:ot_ico_sar_noff_unassigned,


### PR DESCRIPTION
## Description

Have manually tested on development with updating one record (there were 9, now 8). Would like to run migration on development and check back in on the numbers.

All being well will collect the counts for staging and test the before and after.

Before counts for `Case::Base.offender_sar.where("properties -> 'rejected_reasons' @> ?", %w[cctv_bwcv].to_json).size`:

Dev: 8
Staging: 2 
Prod: 184

Small content update to correct the checkbox.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [x] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots

![Screenshot 2025-02-27 at 09 21 28](https://github.com/user-attachments/assets/ce583b4f-66e2-4417-b546-608e1e6fb4a8)

![Screenshot 2025-02-27 at 09 22 02](https://github.com/user-attachments/assets/6a262e09-a60c-4772-b7fc-5ab7e074f806)

### Related JIRA tickets

https://dsdmoj.atlassian.net/browse/CDPT-2324

### Deployment

Include data migration

### Manual testing instructions

- View rejected reason checkboxes and the case show page, observe correct content
- Run migration, observe no errors 