### PR TITLE
CDPT-2506 Case history pagination

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -330,7 +330,7 @@ private
     @case = Case::Base
               .find(params[:case_id])
               .decorate
-    @case_transitions = @case.transitions.includes(:acting_user, :acting_team, :target_team).case_history.order(id: :desc).decorate
+    @case_transitions = @case.transitions.includes(:acting_user, :acting_team, :target_team).case_history.page(params[:page]).order(id: :desc).decorate
   end
 
   def set_assignment

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -86,7 +86,6 @@ class CasesController < ApplicationController
 
     authorize @case
 
-    @case_transitions = @case.transitions.case_history.order(id: :desc).decorate
     @s3_direct_post = S3Uploader.for(@case, "requests")
     @case = @case.decorate
     render "cases/edit"
@@ -118,7 +117,6 @@ class CasesController < ApplicationController
     end
 
     set_permitted_events
-    @case_transitions = @case.transitions.case_history.order(id: :desc).decorate
     redirect_to case_path(@case)
   end
 

--- a/app/controllers/concerns/setup_case.rb
+++ b/app/controllers/concerns/setup_case.rb
@@ -10,7 +10,7 @@ module SetupCase
       )
       .find(case_id)
 
-    @case_transitions = @case.transitions.includes(:acting_user, :acting_team, :target_team).case_history.order(id: :desc)
+    @case_transitions = @case.transitions.includes(:acting_user, :acting_team, :target_team).case_history.page(params[:page]).order(id: :desc)
     @correspondence_type_key = @case.type_abbreviation.downcase
   end
 

--- a/app/decorators/case_transition_decorator.rb
+++ b/app/decorators/case_transition_decorator.rb
@@ -1,6 +1,10 @@
 class CaseTransitionDecorator < Draper::Decorator
   delegate_all
 
+  def self.collection_decorator_class
+    PaginatingDecorator
+  end
+
   def action_date
     object.created_at.strftime("%d %b %Y<br>%H:%M").html_safe
   end

--- a/app/models/case_transition.rb
+++ b/app/models/case_transition.rb
@@ -37,6 +37,8 @@ class CaseTransition < ApplicationRecord
   ANNOTATE_RETENTION_CHANGES = "annotate_retention_changes".freeze
   ANNOTATE_SYSTEM_RETENTION_CHANGES = "annotate_system_retention_changes".freeze
 
+  paginates_per 10
+
   after_destroy :update_most_recent, if: :most_recent?
 
   validates :message, presence: true, if: :requires_message?

--- a/app/views/cases/_case_history.html.slim
+++ b/app/views/cases/_case_history.html.slim
@@ -8,9 +8,11 @@ table#case-history.report
       th Team
       th Action
   tbody
-    - @case_transitions.each do |ct|
+    - case_transitions.each do |ct|
       tr
         td = ct.action_date
         td = ct.user_name
         td = ct.user_team
         td = simple_format(ct.event_and_detail)
+
+= paginate case_transitions

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe CasesController, type: :controller do
     end
 
     it "decorates the collection of case transitions" do
-      expect(assigns(:case_transitions)).to be_an_instance_of(Draper::CollectionDecorator)
+      expect(assigns(:case_transitions)).to be_an_instance_of(PaginatingDecorator)
       expect(assigns(:case_transitions).map(&:class)).to eq [CaseTransitionDecorator, CaseTransitionDecorator]
     end
   end

--- a/spec/views/assignments/edit_page_spec.rb
+++ b/spec/views/assignments/edit_page_spec.rb
@@ -16,7 +16,7 @@ describe "assignments/edit.html.slim", type: :view do
 
   it "displays the edit assignment page" do
     assign(:case, awaiting_responder_case)
-    assign(:case_transitions, awaiting_responder_case.transitions.decorate)
+    assign(:case_transitions, awaiting_responder_case.transitions.case_history.page(1).decorate)
     assign(:correspondence_type_key, awaiting_responder_case.type_abbreviation.downcase)
     assign(:assignment, assignment)
 
@@ -75,7 +75,7 @@ describe "assignments/edit.html.slim", type: :view do
 
     it "displays page and sections for ICO cases" do
       assign(:case, awaiting_responder_case)
-      assign(:case_transitions, awaiting_responder_case.transitions.decorate)
+      assign(:case_transitions, awaiting_responder_case.transitions.case_history.page(1).decorate)
       assign(:correspondence_type_key, awaiting_responder_case.type_abbreviation.downcase)
       assign(:assignment, assignment_for_ico)
 
@@ -138,7 +138,7 @@ describe "assignments/edit.html.slim", type: :view do
 
     it "displays page and sections for ICO cases" do
       assign(:case, awaiting_responder_case)
-      assign(:case_transitions, awaiting_responder_case.transitions.decorate)
+      assign(:case_transitions, awaiting_responder_case.transitions.case_history.page(1).decorate)
       assign(:correspondence_type_key, awaiting_responder_case.type_abbreviation.downcase)
       assign(:assignment, assignment_for_overturned)
 
@@ -201,7 +201,7 @@ describe "assignments/edit.html.slim", type: :view do
 
     it "displays page and sections for ICO cases" do
       assign(:case, ovt_foi_case)
-      assign(:case_transitions, ovt_foi_case.transitions.decorate)
+      assign(:case_transitions, ovt_foi_case.transitions.case_history.page(1).decorate)
       assign(:correspondence_type_key, ovt_foi_case.type_abbreviation.downcase)
       assign(:assignment, assignment)
 


### PR DESCRIPTION
## Description
Recent additions have contributed to some cases having a large number of history logs which. Adding pagination means that older entries will be hidden by default, but still available to be seen if desired.
