### PR TITLE
Show upload button when there are not already uploads

### DIFF
--- a/app/views/cases/_case_request.html.slim
+++ b/app/views/cases/_case_request.html.slim
@@ -31,5 +31,5 @@
           = render partial: 'cases/attachment_report',
             locals: { attachments: ug.collection,
               case_details: case_details }
-      - if policy(case_details).can_upload_request_attachment?
-        = action_button_for(:upload_request_files)
+    - if policy(case_details).can_upload_request_attachment?
+      = action_button_for(:upload_request_files)


### PR DESCRIPTION
## Description
Currently the "upload request files" button will only show on the case page when there is already a file uploaded.
This shows it at all times if the user is allowed to upload files.
