### PR TITLE
Chromedriver race condition workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,16 @@ jobs:
           max_attempts: 3
           command: bin/rake 'parallel:drop' && bin/rake 'parallel:setup[4]'
 
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1.7.3
+        with:
+          chrome-version: 132
+          install-chromedriver: true
+          install-dependencies: true
+
       - name: Run unit and feature tests
         run: bundle exec parallel_rspec -n "${CI_TOTAL_JOBS}" --only-group "${CI_JOB_INDEX}" --group-by "runtime"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,13 +117,13 @@ jobs:
           max_attempts: 3
           command: bin/rake 'parallel:drop' && bin/rake 'parallel:setup[4]'
 
-      - name: Remove image-bundled Chrome
+            - name: Remove image-bundled Chrome
         run: sudo apt-get purge google-chrome-stable
 
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1.7.3
         with:
-          chrome-version: 130
+          chrome-version: 128
           install-chromedriver: true
           install-dependencies: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
           max_attempts: 3
           command: bin/rake 'parallel:drop' && bin/rake 'parallel:setup[4]'
 
-            - name: Remove image-bundled Chrome
+      - name: Remove image-bundled Chrome
         run: sudo apt-get purge google-chrome-stable
 
       - name: Setup Chrome

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,16 +117,6 @@ jobs:
           max_attempts: 3
           command: bin/rake 'parallel:drop' && bin/rake 'parallel:setup[4]'
 
-      # - name: Remove image-bundled Chrome
-      #   run: sudo apt-get purge google-chrome-stable
-
-      # - name: Setup Chrome
-      #   uses: browser-actions/setup-chrome@v1.7.3
-      #   with:
-      #     chrome-version: 128
-      #     install-chromedriver: true
-      #     install-dependencies: true
-
       - name: Run unit and feature tests
         run: bundle exec parallel_rspec -n "${CI_TOTAL_JOBS}" --only-group "${CI_JOB_INDEX}" --group-by "runtime"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,15 +117,15 @@ jobs:
           max_attempts: 3
           command: bin/rake 'parallel:drop' && bin/rake 'parallel:setup[4]'
 
-      - name: Remove image-bundled Chrome
-        run: sudo apt-get purge google-chrome-stable
+      # - name: Remove image-bundled Chrome
+      #   run: sudo apt-get purge google-chrome-stable
 
-      - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v1.7.3
-        with:
-          chrome-version: 128
-          install-chromedriver: true
-          install-dependencies: true
+      # - name: Setup Chrome
+      #   uses: browser-actions/setup-chrome@v1.7.3
+      #   with:
+      #     chrome-version: 128
+      #     install-chromedriver: true
+      #     install-dependencies: true
 
       - name: Run unit and feature tests
         run: bundle exec parallel_rspec -n "${CI_TOTAL_JOBS}" --only-group "${CI_JOB_INDEX}" --group-by "runtime"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1.7.3
         with:
-          chrome-version: 132
+          chrome-version: 130
           install-chromedriver: true
           install-dependencies: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem "tzinfo-data"
 
 group :test do
   gem "capybara", "~> 3.37"
+  gem "capybara-lockstep"
   gem "i18n-tasks"
   gem "rails-controller-testing", require: false
   gem "shoulda-matchers", "~> 5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-lockstep (2.2.3)
+      activesupport (>= 4.2)
+      capybara (>= 3.0)
+      ruby2_keywords
+      selenium-webdriver (>= 4.0)
     caxlsx (3.2.0)
       htmlentities (~> 4.3, >= 4.3.4)
       marcel (~> 1.0)
@@ -644,6 +649,7 @@ DEPENDENCIES
   bullet
   business_time
   capybara (~> 3.37)
+  capybara-lockstep
   caxlsx
   caxlsx_rails
   colorize

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -6,6 +6,8 @@
     <meta charset="utf-8" />
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 
+    <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
+
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag "govuk-template.css", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
     <!--[if IE 6]><%= stylesheet_link_tag "govuk-template-ie6.css" %><![endif]-->
     <!--[if IE 7]><%= stylesheet_link_tag "govuk-template-ie7.css" %><![endif]-->

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -137,4 +137,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.middleware.insert_before 0, Capybara::Lockstep::Middleware
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,13 +46,6 @@ Capybara.register_driver :headless_chrome do |app|
     options.add_argument("--no-sandbox")
     options.add_argument("--start-maximized")
     options.add_argument("--window-size=1980,2080")
-    # options.add_argument("--disable-background-timer-throttling")
-    # options.add_argument("--disable-backgrounding-occluded-windows")
-    # options.add_argument("--disable-dev-shm-usage")
-    # options.add_argument("--disable-renderer-backgrounding")
-    # options.add_argument("--disable-site-isolation-trials")
-    # options.add_option(:unhandled_prompt_behavior, "ignore")
-    # options.browser_version = "128"
   end
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,19 +40,19 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_preference(:download, { prompt_for_download: false, default_directory: DownloadHelpers::PATH.to_s })
 
   unless ENV["CHROME_DEBUG"]
+    options.add_argument("--disable-gpu")
     options.add_argument("--enable-features=NetworkService,NetworkServiceInProcess")
     options.add_argument("--headless")
     options.add_argument("--no-sandbox")
     options.add_argument("--start-maximized")
     options.add_argument("--window-size=1980,2080")
-    options.add_argument("--disable-background-timer-throttling")
-    options.add_argument("--disable-backgrounding-occluded-windows")
-    options.add_argument("--disable-dev-shm-usage")
-    options.add_argument("--disable-gpu")
-    options.add_argument("--disable-renderer-backgrounding")
-    options.add_argument("--disable-site-isolation-trials")
-    options.add_option(:unhandled_prompt_behavior, "ignore")
-    options.browser_version = "128"
+    # options.add_argument("--disable-background-timer-throttling")
+    # options.add_argument("--disable-backgrounding-occluded-windows")
+    # options.add_argument("--disable-dev-shm-usage")
+    # options.add_argument("--disable-renderer-backgrounding")
+    # options.add_argument("--disable-site-isolation-trials")
+    # options.add_option(:unhandled_prompt_behavior, "ignore")
+    # options.browser_version = "128"
   end
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,12 +40,19 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_preference(:download, { prompt_for_download: false, default_directory: DownloadHelpers::PATH.to_s })
 
   unless ENV["CHROME_DEBUG"]
+    options.add_argument("--enable-features=NetworkService,NetworkServiceInProcess")
     options.add_argument("--headless")
-    options.add_argument("--disable-gpu")
     options.add_argument("--no-sandbox")
     options.add_argument("--start-maximized")
     options.add_argument("--window-size=1980,2080")
-    options.add_argument("--enable-features=NetworkService,NetworkServiceInProcess")
+    options.add_argument("--disable-background-timer-throttling")
+    options.add_argument("--disable-backgrounding-occluded-windows")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--disable-renderer-backgrounding")
+    options.add_argument("--disable-site-isolation-trials")
+    options.add_option(:unhandled_prompt_behavior, "ignore")
+    options.browser_version = "128"
   end
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options:)


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
a recent change to the behavior of chromedriver is breaking our feature tests. This workaround pins the test browser to V128 and uses the capybara-lockstep gem (https://github.com/makandra/capybara-lockstep) to synchronise Capybara commands with client-side JavaScript and AJAX requests.

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
Just run bundle exec rspec locally.