### PR TITLE
CDPT-2767: Update driver for JS tests

### DIFF
--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -16,6 +16,17 @@ Teaspoon.configure do |config|
   # be rendered as fixtures.
   config.fixture_paths = ["spec/javascripts/fixtures"]
 
+  # Default phantomjs driver is no longer working in the pipeline and appears to be deprecated, switch to selenium
+  config.driver = :selenium
+
+  # Use Chrome - the default is Firefox which has known memory issues
+  config.driver_options = {
+    client_driver: :chrome,
+    selenium_options: {
+      options: Selenium::WebDriver::Chrome::Options.new(args: %w[headless disable-gpu]),
+    },
+  }
+
   # SUITES
   #
   # You can modify the default suite configuration and create new suites here. Suites are isolated from one another.


### PR DESCRIPTION
## Description

The JS tests are broken and it looks like it is because the default driver for teaspoon is deprecated and no longer installing correctly.

Switch to use selenium with Chrome, which is already installed for our Capybara tests.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
