### PR TITLE
CDPT-3012 Remove BAU letter templates from seeder script

### DIFF
--- a/db/seeders/letter_template_seeder.rb
+++ b/db/seeders/letter_template_seeder.rb
@@ -2,7 +2,6 @@ class LetterTemplateSeeder
   def seed!
     Rails.logger.debug "---- Seeding Letter Templates ----"
     intial_letters_seed
-    bau_disclosed_letter_seed
   end
 
   def intial_letters_seed
@@ -549,101 +548,6 @@ class LetterTemplateSeeder
                   <br>
                   <br>
                   <br>
-                  <br>
-                  <br>Yours sincerely
-                  <br>
-                  <br>
-                  <br>
-                  <br>
-                  <br>Business Support Team
-                  <br>Offender Subject Access Request Team
-                  <br>Ministry of Justice
-                  </p>
-                BODY
-               )
-    rec.update!(letter_address: <<~ADDRESS,
-      #{solictor_receiver}
-      <br>#{address}
-    ADDRESS
-               )
-  end
-
-  def bau_disclosed_letter_seed
-    prison_receiver = prison_receiver_string
-    solictor_receiver = solictor_receiver_string
-    address = address_string
-
-    rec = LetterTemplate.find_by(abbreviation: "bau-prisoner-disclosed-letter")
-    rec = LetterTemplate.new if rec.nil?
-    rec.update!(name: "BAU Prisoner disclosed letter Aug 2021",
-                abbreviation: "bau-prisoner-disclosed-letter",
-                template_type: "dispatch",
-                body: <<~BODY,
-                  <p>
-                  <br>
-                  <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
-                  <br>
-                  <br>I am writing in response to your request for information made under the Data Protection Act 2018 (DPA).
-                  <br>
-                  <br>Enclosed is all the information related to your request that I am able to release. Some information may have been withheld and this is because the information is exempt from disclosure under the DPA. The exemptions within the DPA include information which is processed for the prevention or detection of a crime or the apprehension or prosecution of offenders, and information that would identify third parties. Where we have withheld exempt information, you will see items redacted on the documents.
-                  <br>
-                  <br>I can confirm that the personal data contained within these documents is being processed by the Ministry of Justice for the purposes of the administration of justice and for the exercise of any functions of the Crown, a Minister of the Crown or a government department. As such we may share or exchange data with other Departments or organisations if it is lawful to do so, for example the Police or the Probation Service.
-                  <br>
-                  <br>I would like to remind you that His Majesty's Prison and Probation Service (HMPPS) holds routine information that can be disclosed to you as part of business as usual requests, without submitting a formal SAR. Please find enclosed a list of documents that can be provided by your keyworker in the prison or probation office. As some of the information requested can be disclosed directly, we have forwarded your request to the relevant business area to take forward and the documents listed will not be included in your SAR response.
-                  <br>
-                  <br>If you have any queries regarding your request please contact the Offender Subject Access Request Team, at the address above. It is also open to you to ask the Information Commissioner to look into the case. You can contact the Information Commissioner at this address:
-                  <br>
-                  <br>Information Commissioner's Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF
-                  <br>Internet: <a href="www.ico.gov.uk">www.ico.gov.uk</a>
-                  <br>
-                  <br>Please note that copies of the data provided to you will be retained for no longer than nine months. Once this period has passed, we will be unable to answer any questions you may have or provide duplicates of this information. It will not normally be disclosed in any future SARs.
-                  <br>
-                  <br>Finally I would like to suggest that you do not keep this information where it can be accessed by others. Once you have read through the information it can be placed in your stored property. When you no longer require this information it must be destroyed securely. If you are unsure how to do this please speak to a member of staff within the prison.#{' '}
-                  <br>
-                  <br>Yours sincerely
-                  <br>
-                  <br>
-                  <br>
-                  <br>
-                  <br>Business Support Team
-                  <br>Offender Subject Access Request Team
-                  <br>Ministry of Justice
-                  </p>
-                BODY
-               )
-    rec.update!(letter_address: <<~ADDRESS,
-      #{prison_receiver}
-      <br>#{address}
-    ADDRESS
-               )
-
-    rec = LetterTemplate.find_by(abbreviation: "bau-solicitor-disclosed-letter")
-    rec = LetterTemplate.new if rec.nil?
-    rec.update!(name: "BAU Solicitor disclosed letter Aug 2021",
-                abbreviation: "bau-solicitor-disclosed-letter",
-                template_type: "dispatch",
-                body: <<~BODY,
-                  <p>
-                  <br>
-                  <br><strong>DATA PROTECTION ACT 2018: SUBJECT ACCESS REQUEST</strong>
-                  <br><strong><%= values.subject_full_name&.upcase %><% if values.prison_number.present? %> - <%= values.first_prison_number %><% end %></strong>
-                  <br>
-                  <br>I am writing in response to your request for information made under the Data Protection Act 2018 (DPA) for the above person.
-                  <br>
-                  <br>Enclosed is all the information related to your request that I am able to release. Some information may have been withheld and this is because the information is exempt from disclosure under the DPA. The exemptions within the DPA include information which is processed for the prevention or detection of a crime or the apprehension or prosecution of offenders, and information that would identify third parties. Where we have withheld exempt information, you will see items redacted on the documents.
-                  <br>
-                  <br>I can confirm that the personal data contained within these documents is being processed by the Ministry of Justice for the purposes of the administration of justice and for the exercise of any functions of the Crown, a Minister of the Crown or a government department. As such we may share or exchange data with other Departments or organisations if it is lawful to do so, for example the Police or the Probation Service.
-                  <br>
-                  <br>I would like to remind you that His Majesty's Prison and Probation Service (HMPPS) holds routine information that can be disclosed to you or your client as part of business as usual requests, without submitting a formal SAR. Please find enclosed a list of documents that can be provided by your client's keyworker in the prison or probation office. As some of the information requested can be disclosed directly, we have forwarded your request to the relevant business area to take forward and the documents listed will not be included in your SAR response.
-                  <br>
-                  <br>If you have any queries regarding your request please contact the Offender Subject Access Request Team, at the address above. It is also open to you to ask the Information Commissioner to look into the case. You can contact the Information Commissioner at this address:
-                  <br>
-                  <br>Information Commissioner's Office, Wycliffe House, Water Lane, Wilmslow, Cheshire, SK9 5AF
-                  <br>Internet: <a href="www.ico.gov.uk">www.ico.gov.uk</a>
-                  <br>
-                  <br>Please note that copies of the data provided to you will be retained for no longer than nine months. Once this period has passed, we will be unable to answer any questions you may have or provide duplicates of this information. It will not normally be disclosed in any future SARs.
-                  <br>
-                  <br>Finally I would like to suggest that you do not keep this information where it can be accessed by others. It would be helpful to remind your client of this. In a prison establishment the information can be placed in stored property.#{' '}
                   <br>
                   <br>Yours sincerely
                   <br>


### PR DESCRIPTION
## Description
<!-- Description of the changes. High level overview of the requirements and the attempted solution -->
This PR will remove the following letter templates from the database seeder script:

- BAU Prisoner disclosed letter Aug 2021
- BAU Solicitor disclosed letter Aug 2021

This will prevent them from appearing as options in the future and new letters are added.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [x] (8) Data migration script is created if any of letter templates is changed

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->
https://dsdmoj.atlassian.net/browse/CDPT-3012

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
A dev can run run `rails db:seed:dev:letter_templates` in the rails console.  Then you should see that radio buttons for the removed forms will not re-appear.