### PR TITLE
CDPT-3065: DPS Flag data migration rake task

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -132,6 +132,22 @@ namespace :data do
           puts e.backtrace.join("\n\t")
         end
       end
+
+      desc "Add missing flag_as_dps_missing_data property to cases"
+      task add_dps_missing_data_flag: :environment do
+        sql = <<-SQL
+          WITH updated AS (
+            UPDATE cases
+            SET
+              properties = jsonb_set(properties, '{flag_as_dps_missing_data}', 'false'::jsonb),
+              updated_at = NOW()
+            WHERE
+              properties ? 'flag_as_dps_missing_data' = FALSE
+            RETURNING *
+          )
+          SELECT * FROM updated;
+        SQL
+      end
     end
 
     desc "Fix invalid Offender SAR cases"

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -155,10 +155,10 @@ namespace :data do
         ActiveRecord::Base.transaction do
           result = ActiveRecord::Base.connection.execute(sql)
           if result.any?
-            puts "| %-6s | %-25s |" % ["ID", "Updated At"]
-            puts "|%s|%s|" % ["-"*8, "-"*27]
+            puts sprintf("| %-6s | %-25s |", "ID", "Updated At")
+            puts sprintf("|%s|%s|", "-" * 8, "-" * 27)
             result.each do |row|
-              puts "| %-6s | %-25s |" % [row["id"], row["updated_at"]]
+              puts sprintf("| %-6s | %-25s |", row["id"], row["updated_at"])
             end
 
             puts "DONE --- flag_as_dps_missing_data migration completed."


### PR DESCRIPTION
## Description
Ensures all `SAR` and `OffenderSAR` type `cases` have the `properties->flag_as_dps_missing_data` key where it does not currently exist. This is to improve data quality and consistency preventing odd bugs/workarounds going forward.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="766" height="577" alt="Screenshot 2025-09-23 at 12 16 29" src="https://github.com/user-attachments/assets/8cde4827-1b1d-4940-945b-cf5901b95d7c" />


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPT-3065

### Deployment
Run from terminal:

```
bundle exec rake data:migrate:add_dps_missing_data_flag
```

### Manual testing instructions
Run against a k8s pod from your local terminal.