### PR TITLE
[CDPTKAN-119] ld radio options not displaying in UI on case edit page

### DIFF
--- a/app/decorators/case/base_decorator.rb
+++ b/app/decorators/case/base_decorator.rb
@@ -97,11 +97,11 @@ class Case::BaseDecorator < Draper::Decorator
   end
 
   def requester_type
-    object.requester_type.humanize
+    object.requester_type
   end
 
   def subject_type
-    object.subject_type.humanize
+    object.subject_type
   end
 
   def requester_name_and_type

--- a/spec/decorators/case/base_decorator_spec.rb
+++ b/spec/decorators/case/base_decorator_spec.rb
@@ -228,12 +228,12 @@ describe Case::BaseDecorator, type: :model do
   describe "#requester_name_and_type" do
     it "returns name and requestor type" do
       kase = create(:case, name: "Stepriponikas Bonstart", requester_type: "member_of_the_public").decorate
-      expect(kase.requester_name_and_type).to eq "Stepriponikas Bonstart | Member of the public"
+      expect(kase.requester_name_and_type).to eq "Stepriponikas Bonstart | member_of_the_public"
     end
 
     it "returns the name and subject type" do
       kase = create(:sar_case, name: "Wade Wilson", subject_type: "staff").decorate
-      expect(kase.requester_name_and_type).to eq "Wade Wilson | Staff"
+      expect(kase.requester_name_and_type).to eq "Wade Wilson | staff"
     end
   end
 

--- a/spec/features/cases/foi/editing_case_spec.rb
+++ b/spec/features/cases/foi/editing_case_spec.rb
@@ -32,6 +32,16 @@ feature "Editing a case" do
     expect(cases_show_page.case_details.foi_basic_details.email.data.text).to eq "john.doe@moj.com"
   end
 
+  scenario "editing a case and requestor type is displayed" do
+    kase = create :case, received_date: 2.days.ago
+    open_cases_page.load
+    click_link kase.number
+    click_link "Edit case details"
+    expect(cases_edit_page).to be_displayed
+    expect(cases_edit_page).to have_checked_field("Member of the public")
+
+  end
+
   scenario "editing a case with no changes" do
     kase = create :accepted_case, received_date: 2.days.ago
     open_cases_page.load

--- a/spec/features/cases/foi/editing_case_spec.rb
+++ b/spec/features/cases/foi/editing_case_spec.rb
@@ -39,7 +39,6 @@ feature "Editing a case" do
     click_link "Edit case details"
     expect(cases_edit_page).to be_displayed
     expect(cases_edit_page).to have_checked_field("Member of the public")
-
   end
 
   scenario "editing a case with no changes" do

--- a/spec/features/cases/sar/editing_case_spec.rb
+++ b/spec/features/cases/sar/editing_case_spec.rb
@@ -34,6 +34,16 @@ feature "Editing a SAR case" do
     expect(cases_show_page.case_details.sar_basic_details.date_received.data.text).to eq Time.zone.today.strftime(Settings.default_date_format)
   end
 
+  scenario "editing a case and requestor type is displayed" do
+    kase = create :accepted_sar, received_date: 2.days.ago
+    open_cases_page.load
+    click_link kase.number
+    expect(cases_show_page).to be_displayed
+    click_link "Edit case details"
+    expect(cases_edit_page).to be_displayed
+    expect(cases_edit_page).to have_checked_field("Member of the public")
+  end
+
   scenario "Uploading new request files", js: true do
     kase = create :accepted_sar, :case_sent_by_post, received_date: 2.days.ago
     open_cases_page.load

--- a/spec/features/cases/sar/editing_case_spec.rb
+++ b/spec/features/cases/sar/editing_case_spec.rb
@@ -34,14 +34,14 @@ feature "Editing a SAR case" do
     expect(cases_show_page.case_details.sar_basic_details.date_received.data.text).to eq Time.zone.today.strftime(Settings.default_date_format)
   end
 
-  scenario "editing a case and requestor type is displayed" do
+  scenario "editing a case and subject type is displayed" do
     kase = create :accepted_sar, received_date: 2.days.ago
     open_cases_page.load
     click_link kase.number
     expect(cases_show_page).to be_displayed
     click_link "Edit case details"
     expect(cases_edit_page).to be_displayed
-    expect(cases_edit_page).to have_checked_field("Member of the public")
+    expect(cases_edit_page).to have_checked_field("Offender")
   end
 
   scenario "Uploading new request files", js: true do

--- a/spec/views/cases/filters/incoming_cases_html_slim_spec.rb
+++ b/spec/views/cases/filters/incoming_cases_html_slim_spec.rb
@@ -73,7 +73,7 @@ describe "cases/filters/incoming.html.slim", type: :view do
 
     second_case = incoming_cases_page.case_list[1]
     expect(second_case.number.text).to eq "Case number #{case2.number}"
-    expect(second_case.request.name.text).to eq "Jane Doe | Member of the public"
+    expect(second_case.request.name.text).to eq "Jane Doe | member_of_the_public"
     expect(second_case.request.subject.text).to eq "Court Reform"
     expect(second_case.request.message.text).to eq "message number 2"
     expect(second_case.actions.take_on_case.text).to eq "Take case on"
@@ -81,7 +81,7 @@ describe "cases/filters/incoming.html.slim", type: :view do
 
     third_case = incoming_cases_page.case_list[2]
     expect(third_case.number.text).to eq "Case number #{further_clearance_case.number}"
-    expect(third_case.request.name.text).to eq "Questioning Jim | Member of the public"
+    expect(third_case.request.name.text).to eq "Questioning Jim | member_of_the_public"
     expect(third_case.request.subject.text).to eq "Reform Reform"
     expect(third_case.request.message.text).to eq "message number 3"
     expect(third_case.actions.take_on_case.text).to eq "Take case on"

--- a/spec/views/cases/filters/incoming_cases_html_slim_spec.rb
+++ b/spec/views/cases/filters/incoming_cases_html_slim_spec.rb
@@ -65,7 +65,7 @@ describe "cases/filters/incoming.html.slim", type: :view do
 
     first_case = incoming_cases_page.case_list[0]
     expect(first_case.number.text).to eq "Case number #{case1.number}"
-    expect(first_case.request.name.text).to eq "Joe Smith | Member of the public"
+    expect(first_case.request.name.text).to eq "Joe Smith | member_of_the_public"
     expect(first_case.request.subject.text).to eq "Prison Reform"
     expect(first_case.request.message.text).to eq "message number 1"
     expect(first_case.actions.take_on_case.text).to eq "Take case on"


### PR DESCRIPTION
## Description
During a regression test, it was identified that previously selected radio options were not displaying in the UI when editing the case details.

Question = Who is the person the information is being requested about?

For eg:
Create an FOI case.
Select `Edit case details'
When user views the question Requestor type, no option is selected
The UI should retain and display the option selected during case build.

The fix this PR provides displays the enum option for requester_type or subject_type that has been saved to the db.
The user will see the version of the selected requester_type or subject_type without underscores.  For e.g. member_of_the_public would be displayed as Member of the public.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-119

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
