### PR TITLE
[CDPTKAN-120] Remove download link for RRD destroyed case

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
 
+  class ContentGoneError < StandardError; end
+
   GLOBAL_NAV_EXCLUSION_PATHS    = %w[/cases/filter].freeze
   CSV_REQUEST_REGEX             = /\.csv$/
 
@@ -23,6 +25,10 @@ class ApplicationController < ActionController::Base
   before_action :set_hompepage_nav, if: -> { current_user.present? && global_nav_required? }
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  rescue_from ContentGoneError do
+    render file: Rails.root.join("public/410.html"), status: :gone, layout: false
+  end
 
   def set_user
     @user = current_user

--- a/app/controllers/cases/commissioning_documents_controller.rb
+++ b/app/controllers/cases/commissioning_documents_controller.rb
@@ -6,6 +6,7 @@ module Cases
 
     def download
       return unless @commissioning_document.persisted?
+      raise ActiveRecord::RecordNotFound if @case.readonly? # assume anonymised/destroyed case
 
       send_data(@commissioning_document.document,
                 filename: @commissioning_document.filename,

--- a/app/controllers/cases/commissioning_documents_controller.rb
+++ b/app/controllers/cases/commissioning_documents_controller.rb
@@ -6,7 +6,7 @@ module Cases
 
     def download
       return unless @commissioning_document.persisted?
-      raise ActiveRecord::RecordNotFound if @case.readonly? # assume anonymised/destroyed case
+      raise ContentGoneError if @case.readonly?
 
       send_data(@commissioning_document.document,
                 filename: @commissioning_document.filename,

--- a/app/decorators/commissioning_document_decorator.rb
+++ b/app/decorators/commissioning_document_decorator.rb
@@ -14,6 +14,10 @@ class CommissioningDocumentDecorator < Draper::Decorator
   end
 
   def download_link
-    link_to("Download", h.download_case_data_request_area_commissioning_documents_path(data_request_area.case_id, data_request_area, self))
+    if data_request_area.offender_sar_case.readonly?
+      I18n.t("cases.data_request_areas.show.document_deleted")
+    else
+      link_to("Download", h.download_case_data_request_area_commissioning_documents_path(data_request_area.case_id, data_request_area, self))
+    end
   end
 end

--- a/app/mailers/commissioning_document_mailer.rb
+++ b/app/mailers/commissioning_document_mailer.rb
@@ -29,7 +29,7 @@ class CommissioningDocumentMailer < GovukNotifyRails::Mailer
       email_address: recipient,
       deadline: commissioning_document.deadline,
       deadline_days: commissioning_document.deadline_days,
-      link_to_file: Notifications.prepare_upload(file, confirm_email_before_download: true, retention_period: "2 weeks"),
+      link_to_file: Notifications.prepare_upload(file, confirm_email_before_download: true, retention_period: "4 weeks"),
     )
 
     @data_request_email = DataRequestEmail.find_or_create_by!(

--- a/app/mailers/commissioning_document_mailer.rb
+++ b/app/mailers/commissioning_document_mailer.rb
@@ -29,7 +29,7 @@ class CommissioningDocumentMailer < GovukNotifyRails::Mailer
       email_address: recipient,
       deadline: commissioning_document.deadline,
       deadline_days: commissioning_document.deadline_days,
-      link_to_file: Notifications.prepare_upload(file, confirm_email_before_download: true),
+      link_to_file: Notifications.prepare_upload(file, confirm_email_before_download: true, retention_period: '2 weeks'),
     )
 
     @data_request_email = DataRequestEmail.find_or_create_by!(

--- a/app/mailers/commissioning_document_mailer.rb
+++ b/app/mailers/commissioning_document_mailer.rb
@@ -29,7 +29,7 @@ class CommissioningDocumentMailer < GovukNotifyRails::Mailer
       email_address: recipient,
       deadline: commissioning_document.deadline,
       deadline_days: commissioning_document.deadline_days,
-      link_to_file: Notifications.prepare_upload(file, confirm_email_before_download: true, retention_period: '2 weeks'),
+      link_to_file: Notifications.prepare_upload(file, confirm_email_before_download: true, retention_period: "2 weeks"),
     )
 
     @data_request_email = DataRequestEmail.find_or_create_by!(

--- a/app/models/commissioning_email_personalisation.rb
+++ b/app/models/commissioning_email_personalisation.rb
@@ -31,6 +31,6 @@ private
 
   def link_to_file
     file = StringIO.new(commissioning_document.document)
-    Notifications.prepare_upload(file, confirm_email_before_download: true)
+    Notifications.prepare_upload(file, confirm_email_before_download: true, retention_period: "4 weeks")
   end
 end

--- a/app/views/cases/data_request_areas/show.html.slim
+++ b/app/views/cases/data_request_areas/show.html.slim
@@ -43,8 +43,7 @@ div class="case"
               tr
                 td = @data_request_area.request_document
                 td = @commissioning_document&.updated_at
-                td
-                  span = @commissioning_document&.download_link
+                td = t('.document_deleted')
 
           - if !@data_request_area.commissioning_email_sent? && policy(@case).can_send_day_1_email?
             div.button-holder

--- a/app/views/cases/data_request_areas/show.html.slim
+++ b/app/views/cases/data_request_areas/show.html.slim
@@ -43,7 +43,8 @@ div class="case"
               tr
                 td = @data_request_area.request_document
                 td = @commissioning_document&.updated_at
-                td = t('.document_deleted')
+                td
+                  span = @commissioning_document&.download_link
 
           - if !@data_request_area.commissioning_email_sent? && policy(@case).can_send_day_1_email?
             div.button-holder

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1656,6 +1656,7 @@ en:
         link: View
         emails_header: Commissioning emails
         emails_history_header: Email history
+        document_deleted: Document has been deleted
       create:
         success: Data request area successfully recorded
       index:

--- a/lib/tasks/retention_schedules.rake
+++ b/lib/tasks/retention_schedules.rake
@@ -105,4 +105,9 @@ namespace :retention_schedules do
     puts "\n Case errors: \n--------------\n\n" if errors.any?
     errors.each { |error| puts error }
   end
+
+  desc "Removes Commissioning Documents uploaded to S3 that should be destroyed"
+  task remove_expired_documents: :environment do
+    # Get all
+  end
 end

--- a/public/410.html
+++ b/public/410.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Error - 408 - Request timeout - Track-a-query</title>
+
+        <link href="/assets/govuk-template.css" media="screen" rel="stylesheet" />
+        <link href="/assets/govuk-template-print.css" media="print" rel="stylesheet" />
+        <link href="/assets/fonts.css" media="all" rel="stylesheet" />
+        <link href="/assets/govuk-frontend.min.css" media="all" rel="stylesheet" />
+        <link rel="stylesheet" media="all" href="/assets/application.css" />
+
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta property="og:image" content="/assets/opengraph-image.png">
+        <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-K3ZF8NT');</script>
+        <!-- End Google Tag Manager -->
+    </head>
+
+    <body class="controller-sessions">
+
+        <div id="skiplink-container">
+            <div>
+                <a href="#content" class="skiplink">Skip to main content</a>
+            </div>
+        </div>
+
+        <header class="govuk-header with-proposition" role="banner" data-module="govuk-header" id="global-header">
+            <div class="header-wrapper">
+                <div class="govuk-header__container govuk-width-container">
+                <div class="govuk-header__logo">
+                    <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
+                        <svg
+                            focusable="false"
+                            role="img"
+                            class="govuk-header__logotype"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 148 30"
+                            height="30"
+                            width="148"
+                            aria-label="GOV.UK">
+                            <title>GOV.UK</title>
+                            <path d="M22.6 10.4c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m-5.9 6.7c-.9.4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4m10.8-3.7c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s0 2-1 2.4m3.3 4.8c-1 .4-2-.1-2.4-1-.4-.9.1-2 1-2.4.9-.4 2 .1 2.4 1s-.1 2-1 2.4M17 4.7l2.3 1.2V2.5l-2.3.7-.2-.2.9-3h-3.4l.9 3-.2.2c-.1.1-2.3-.7-2.3-.7v3.4L15 4.7c.1.1.1.2.2.2l-1.3 4c-.1.2-.1.4-.1.6 0 1.1.8 2 1.9 2.2h.7c1-.2 1.9-1.1 1.9-2.1 0-.2 0-.4-.1-.6l-1.3-4c-.1-.2 0-.2.1-.3m-7.6 5.7c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m-5 3c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s.1 2 1 2.4m-3.2 4.8c.9.4 2-.1 2.4-1 .4-.9-.1-2-1-2.4-.9-.4-2 .1-2.4 1s0 2 1 2.4m14.8 11c4.4 0 8.6.3 12.3.8 1.1-4.5 2.4-7 3.7-8.8l-2.5-.9c.2 1.3.3 1.9 0 2.7-.4-.4-.8-1.1-1.1-2.3l-1.2 4c.7-.5 1.3-.8 2-.9-1.1 2.5-2.6 3.1-3.5 3-1.1-.2-1.7-1.2-1.5-2.1.3-1.2 1.5-1.5 2.1-.1 1.1-2.3-.8-3-2-2.3 1.9-1.9 2.1-3.5.6-5.6-2.1 1.6-2.1 3.2-1.2 5.5-1.2-1.4-3.2-.6-2.5 1.6.9-1.4 2.1-.5 1.9.8-.2 1.1-1.7 2.1-3.5 1.9-2.7-.2-2.9-2.1-2.9-3.6.7-.1 1.9.5 2.9 1.9l.4-4.3c-1.1 1.1-2.1 1.4-3.2 1.4.4-1.2 2.1-3 2.1-3h-5.4s1.7 1.9 2.1 3c-1.1 0-2.1-.2-3.2-1.4l.4 4.3c1-1.4 2.2-2 2.9-1.9-.1 1.5-.2 3.4-2.9 3.6-1.9.2-3.4-.8-3.5-1.9-.2-1.3 1-2.2 1.9-.8.7-2.3-1.2-3-2.5-1.6.9-2.2.9-3.9-1.2-5.5-1.5 2-1.3 3.7.6 5.6-1.2-.7-3.1 0-2 2.3.6-1.4 1.8-1.1 2.1.1.2.9-.3 1.9-1.5 2.1-.9.2-2.4-.5-3.5-3 .6 0 1.2.3 2 .9l-1.2-4c-.3 1.1-.7 1.9-1.1 2.3-.3-.8-.2-1.4 0-2.7l-2.9.9C1.3 23 2.6 25.5 3.7 30c3.7-.5 7.9-.8 12.3-.8m28.3-11.6c0 .9.1 1.7.3 2.5.2.8.6 1.5 1 2.2.5.6 1 1.1 1.7 1.5.7.4 1.5.6 2.5.6.9 0 1.7-.1 2.3-.4s1.1-.7 1.5-1.1c.4-.4.6-.9.8-1.5.1-.5.2-1 .2-1.5v-.2h-5.3v-3.2h9.4V28H55v-2.5c-.3.4-.6.8-1 1.1-.4.3-.8.6-1.3.9-.5.2-1 .4-1.6.6s-1.2.2-1.8.2c-1.5 0-2.9-.3-4-.8-1.2-.6-2.2-1.3-3-2.3-.8-1-1.4-2.1-1.8-3.4-.3-1.4-.5-2.8-.5-4.3s.2-2.9.7-4.2c.5-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.6 2.6-.8 4.1-.8 1 0 1.9.1 2.8.3.9.2 1.7.6 2.4 1s1.4.9 1.9 1.5c.6.6 1 1.3 1.4 2l-3.7 2.1c-.2-.4-.5-.9-.8-1.2-.3-.4-.6-.7-1-1-.4-.3-.8-.5-1.3-.7-.5-.2-1.1-.2-1.7-.2-1 0-1.8.2-2.5.6-.7.4-1.3.9-1.7 1.5-.5.6-.8 1.4-1 2.2-.3.8-.4 1.9-.4 2.7zM71.5 6.8c1.5 0 2.9.3 4.2.8 1.2.6 2.3 1.3 3.1 2.3.9 1 1.5 2.1 2 3.4s.7 2.7.7 4.2-.2 2.9-.7 4.2c-.4 1.3-1.1 2.4-2 3.4-.9 1-1.9 1.7-3.1 2.3-1.2.6-2.6.8-4.2.8s-2.9-.3-4.2-.8c-1.2-.6-2.3-1.3-3.1-2.3-.9-1-1.5-2.1-2-3.4-.4-1.3-.7-2.7-.7-4.2s.2-2.9.7-4.2c.4-1.3 1.1-2.4 2-3.4.9-1 1.9-1.7 3.1-2.3 1.2-.5 2.6-.8 4.2-.8zm0 17.6c.9 0 1.7-.2 2.4-.5s1.3-.8 1.7-1.4c.5-.6.8-1.3 1.1-2.2.2-.8.4-1.7.4-2.7v-.1c0-1-.1-1.9-.4-2.7-.2-.8-.6-1.6-1.1-2.2-.5-.6-1.1-1.1-1.7-1.4-.7-.3-1.5-.5-2.4-.5s-1.7.2-2.4.5-1.3.8-1.7 1.4c-.5.6-.8 1.3-1.1 2.2-.2.8-.4 1.7-.4 2.7v.1c0 1 .1 1.9.4 2.7.2.8.6 1.6 1.1 2.2.5.6 1.1 1.1 1.7 1.4.6.3 1.4.5 2.4.5zM88.9 28 83 7h4.7l4 15.7h.1l4-15.7h4.7l-5.9 21h-5.7zm28.8-3.6c.6 0 1.2-.1 1.7-.3.5-.2 1-.4 1.4-.8.4-.4.7-.8.9-1.4.2-.6.3-1.2.3-2v-13h4.1v13.6c0 1.2-.2 2.2-.6 3.1s-1 1.7-1.8 2.4c-.7.7-1.6 1.2-2.7 1.5-1 .4-2.2.5-3.4.5-1.2 0-2.4-.2-3.4-.5-1-.4-1.9-.9-2.7-1.5-.8-.7-1.3-1.5-1.8-2.4-.4-.9-.6-2-.6-3.1V6.9h4.2v13c0 .8.1 1.4.3 2 .2.6.5 1 .9 1.4.4.4.8.6 1.4.8.6.2 1.1.3 1.8.3zm13-17.4h4.2v9.1l7.4-9.1h5.2l-7.2 8.4L148 28h-4.9l-5.5-9.4-2.7 3V28h-4.2V7zm-27.6 16.1c-1.5 0-2.7 1.2-2.7 2.7s1.2 2.7 2.7 2.7 2.7-1.2 2.7-2.7-1.2-2.7-2.7-2.7z"></path>
+                        </svg>
+                    </a>
+                </div>
+                <div class="govuk-header__content">
+                    <a class="govuk-header__link govuk-header__service-name" href="/">
+                        Track a query
+                    </a>
+                  </div>
+            </div>
+        </header>
+
+        <div id="global-header-bar"></div>
+
+        <div class="grid-row"><div class="column-full">
+            <main id='page-container' role='main'>
+                <div id="wrapper" class="group live">
+                    <section id="content" role="main">
+                        <header class="page-header group">
+                            <h1 class="heading-xlarge">The content or document you requested is not available</h1>
+                        </header>
+                        <p>Please contact <a href="mailto:correspondence-gg@justice.gov.uk?subject=408 error report">correspondence-gg@justice.gov.uk</a> with the details on how you got here to report this issue.</p>
+                    </section>
+                </div>
+
+            </main>
+
+        </div></div>
+
+        <footer class="govuk-footer">
+          <div class="govuk-width-container">
+            <div class="govuk-footer__meta">
+              <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                <svg
+                  aria-hidden="true"
+                  focusable="false"
+                  class="govuk-footer__licence-logo"
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 483.2 195.7"
+                  height="17"
+                  width="41">
+                  <path
+                      fill="currentColor"
+                      d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                </svg>
+                <span class="govuk-footer__licence-description">
+                All content is available under the
+                <a
+                    class="govuk-footer__link"
+                    href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                    rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+                </span>
+              </div>
+              <div class="govuk-footer__meta-item">
+                <a
+                  class="govuk-footer__link govuk-footer__copyright-logo"
+                  href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
+                  © Crown copyright
+                </a>
+              </div>
+            </div>
+          </div>
+        </footer>
+
+        <div id="global-app-error" class="app-error hidden"></div>
+
+
+    </body>
+</html>

--- a/spec/decorators/commissioning_document_decorator_spec.rb
+++ b/spec/decorators/commissioning_document_decorator_spec.rb
@@ -19,10 +19,26 @@ RSpec.describe CommissioningDocumentDecorator, type: :model do
   end
 
   describe ":download_link" do
-    it "returns a download link" do
-      path = "/cases/#{commissioning_document.data_request_area.case_id}/data_request_areas/#{commissioning_document.data_request_area_id}/commissioning_documents/download"
-      expect(commissioning_document.download_link).to include(path)
-      expect(commissioning_document.download_link).to include("<a href")
+    let(:path) do
+      "/cases/#{commissioning_document.data_request_area.case_id}/data_request_areas/#{commissioning_document.data_request_area_id}/commissioning_documents/download"
+    end
+
+    context "when case is not destroyed" do
+      it "returns a download link" do
+        expect(commissioning_document.download_link).to include(path)
+        expect(commissioning_document.download_link).to include("<a href")
+      end
+    end
+
+    # i.e. anonymised or destroyed case
+    context "when case is destroyed" do
+      before do
+        allow(commissioning_document.data_request_area.offender_sar_case).to receive(:readonly?).and_return(true)
+      end
+
+      it "returns a not found message" do
+        expect(commissioning_document.download_link).to eq "Document has been deleted"
+      end
     end
   end
 end


### PR DESCRIPTION
## Description
Prevents download of destroyed case

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
#### Message after SAR is 'destroyed' resulting in anonymisation:
<img width="758" height="134" alt="Screenshot 2025-10-02 at 21 50 46" src="https://github.com/user-attachments/assets/4410a037-c968-4b98-8ee8-bc05d78b9f25" />


#### 410 HTTP Status error message when an old document download link is clicked:
<img width="762" height="240" alt="Screenshot 2025-10-03 at 00 21 44" src="https://github.com/user-attachments/assets/6efd27e7-c31b-42e8-901c-8ae71818977b" />


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-120
https://dsdmoj.atlassian.net/browse/CDPT-492 (old)

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
1. Create an Offender SAR with dates around 10 years in the past. Add requested data sections. Transition the case until it is closed.
2. As a team_admin or similar role log in access the RRD Cases section.
3. Find the case and mark for deletion.
4. Now destroy the case from the RRD Cases section.
5. Requested data document links should not be visible.