### PR TITLE
[CDPTKAN-393] Correct sentry error message to display role

### DIFF
--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -103,9 +103,9 @@ private
 
   def unique_pending_responder
     if self.case && (state == "pending" && role == "responding")
-      num_existing = self.case&.assignments&.responding&.pending&.size
+      num_existing = self.case.assignments&.responding&.pending&.size
       if num_existing > 1
-        errors.add(:state, "responding not unique")
+        errors.add(:role, "responding not unique")
       end
     end
   end


### PR DESCRIPTION
## Description
The changes made are to allow accurate reporting message to be output to SENTRY for the error 
ActiveRecord::RecordInvalid
Validation failed: State responding not unique (ActiveRecord::RecordInvalid)

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="981" height="568" alt="Screenshot 2025-11-28 at 10 20 41" src="https://github.com/user-attachments/assets/004a89c1-908e-4b12-9677-28b1275cca8d" />

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-393


### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
