### PR TITLE
[CDPTKAN-576] Check file decryption format to prevent exception

### DIFF
--- a/app/services/request_personal_information/cryptography.rb
+++ b/app/services/request_personal_information/cryptography.rb
@@ -41,6 +41,7 @@ private
 
   attr_accessor :encryption_key, :encryption_iv
 
+  # rubocop:disable Naming/MethodParameterName
   def validate_key_iv!(key, iv)
     unless key.is_a?(String) && key.bytesize == 32
       raise ArgumentError, "Encryption key must be a 32-byte string for AES-256-CBC"
@@ -50,4 +51,5 @@ private
       raise ArgumentError, "Encryption IV must be a 16-byte string for AES-256-CBC"
     end
   end
+  # rubocop:enable Naming/MethodParameterName
 end


### PR DESCRIPTION
## Description
Very intermittent issue where a file is downloaded from S3, fails to decrypt, which then causes the 'Request for Information' Email NOT to be sent. That then creates mistrust in the system.

This PR adds some basic checks to the type of data being decrypted. Not sure if it fixes the problem at all.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-576

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Generate Request for Information. Wait for job to execute or execute manually via Rails Console?