### PR TITLE
[CDPTKAN-756] Offender SAR R901 report use translation for case status output

### DIFF
--- a/app/services/stats/r901_offender_sar_cases_report.rb
+++ b/app/services/stats/r901_offender_sar_cases_report.rb
@@ -56,7 +56,7 @@ module Stats
         I18n.t("helpers.label.offender_sar.subject_type.#{kase.subject_type}"),
         kase.page_count,
         kase.already_late? ? "out of time" : "in time",
-        kase.current_state.humanize,
+        case_status(kase),
         kase.num_days_taken,
         kase.data_requests_completed? ? "Yes" : "No",
         kase.case_originally_rejected ? "Yes" : "No",
@@ -85,6 +85,10 @@ module Stats
 
     def case_type(kase)
       kase.decorate.pretty_type
+    end
+
+    def case_status(kase)
+      kase.decorate.status
     end
   end
 end

--- a/spec/services/stats/r901_offender_sar_cases_report_spec.rb
+++ b/spec/services/stats/r901_offender_sar_cases_report_spec.rb
@@ -60,6 +60,7 @@ module Stats
                                             subject_type: "ex_probation_service_user",
                                             subject_full_name: "testing analyse_case"
         result = report.analyse_case(rejected_offender_sar_case)
+
         expect(result).to include(
           rejected_offender_sar_case.number,
           rejected_offender_sar_case.decorate.pretty_type,
@@ -74,7 +75,7 @@ module Stats
           "Ex-probation service user",
           0,
           "in time",
-          "Invalid submission",
+          "Rejected",
           rejected_offender_sar_case.num_days_taken,
           "No",
           "Yes",


### PR DESCRIPTION
## Description
Ensures the spreadsheet report R901 output for case status matches what the use sees in Case Details

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
#### BEFORE
<img width="565" height="192" alt="Screenshot 2026-03-09 at 17 12 22" src="https://github.com/user-attachments/assets/d04491f2-94db-4ded-ad34-737a2a6ee7a4" />


#### AFTER
<img width="509" height="251" alt="Screenshot 2026-03-09 at 17 12 27" src="https://github.com/user-attachments/assets/01933af0-36e4-46a4-8a3d-efaf0b1629a0" />


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-756

### Deployment
N/A
### Manual testing instructions
Log in as someone who has access to Offender SARS (Branston e.g. Basil Rathbone). Go to 'All Open Cases' and download (ensure it is the r901 report).
