### PR TITLE
[CDPTKAN-892] Skip report analysis for cases without responding team

### DIFF
--- a/app/services/stats/base_appeals_performance_report.rb
+++ b/app/services/stats/base_appeals_performance_report.rb
@@ -32,7 +32,11 @@ module Stats
     end
 
     def run(*)
-      Case::Base.find(case_ids).reject(&:unassigned?).each { |kase| analyse_case(kase) }
+      Case::Base.find(case_ids)
+        .reject(&:unassigned?)
+        .reject { |kase| kase.responding_team.nil? }
+        .each { |kase| analyse_case(kase) }
+
       @stats.finalise
     end
 

--- a/app/services/stats/base_business_unit_performance_report.rb
+++ b/app/services/stats/base_business_unit_performance_report.rb
@@ -84,9 +84,10 @@ module Stats
     def run(*)
       CaseSelector.new(case_scope)
         .cases_received_in_period(@period_start, @period_end)
-        .reject(&:unassigned?).each do |kase|
-        analyse_case(kase)
-      end
+        .reject(&:unassigned?)
+        .reject { |kase| kase.responding_team.nil? }
+        .each { |kase| analyse_case(kase) }
+
       @stats.finalise
     end
 

--- a/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
+++ b/spec/services/stats/r103_sar_business_unit_performace_report_spec.rb
@@ -49,6 +49,9 @@ module Stats
       create(:sar_internal_review, original_case: case_1)
       create(:closed_sar_internal_review, original_case: case_2)
 
+      # create Stopped SAR case that is not assigned which should be ignored
+      create_case(factory_and_trait: %i[sar_case stopped], received: "20170606", responded: nil, deadline: "20170630", team: nil, responder: nil, ident: "Paused and unassigned to responding team")
+
       # create some FOI cases which should be ignored
       create :closed_case
       create :closed_case
@@ -100,10 +103,9 @@ module Stats
     describe "data" do
       context "without business unit columns" do
         # We only test that the correct cases are being selected for analysis.  The
-        # analysis work, rolling up of business group and directorate toatls and calcualtion
-        # of percentages is carried out in BasePerformanceUnitReport, and is fully testing
+        # analysis work, rolling up of business group and directorate totals and calculation
+        # of percentages is carried out in BasePerformanceUnitReport, and is fully tested
         # by the R003PerfomanceReport spec.
-        #
         describe "#scope" do
           before do
             Timecop.freeze Time.zone.local(2017, 6, 30, 12, 0, 0) do
@@ -115,12 +117,16 @@ module Stats
           end
 
           it "selects only SAR cases" do
-            expect(@scope.size).to eq 12
+            expect(@scope.size).to eq 13
             expect(@scope.map(&:type).uniq).to eq ["Case::SAR::Standard"]
           end
 
           it "excludes TMM cases" do
             expect(@scope.map(&:refusal_reason_id)).not_to include(@sar_tmm.id)
+          end
+
+          it "includes Stopped case" do
+            expect(@scope.map(&:current_state)).to include("stopped")
           end
         end
       end
@@ -308,13 +314,13 @@ module Stats
       end
     end
 
-    def create_case(received:, responded:, deadline:, team:, responder:, ident:, flagged: false, type: nil)
+    def create_case(received:, responded:, deadline:, team:, responder:, ident:, flagged: false, type: nil, factory_and_trait: [:accepted_sar])
       received_date = Date.parse(received)
       responded_date = responded.nil? ? nil : Date.parse(responded)
       kase = nil
       Timecop.freeze(received_date + 10.hours) do
-        factory = :accepted_sar
-        kase = create(factory, responding_team: team, responder:, identifier: ident, received_date:)
+        factory_and_trait ||= :accepted_sar
+        kase = create(*factory_and_trait, responding_team: team, responder:, identifier: ident, received_date:)
         kase.external_deadline = Date.parse(deadline)
         if flagged
           CaseFlagForClearanceService.new(user: kase.managing_team.users.first, kase:, team: @team_dacu_disclosure).call


### PR DESCRIPTION
## Description
Users are placing SARs into a 'stopped' state and then unassigning a responding team, causing Custom Report generation to fail.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-892

### Deployment
N/A
### Manual testing instructions
Create SAR received 2026-02-01, assign to a team but do not accept. Pause the case. 
Now generate a Custom Report by going to:
1. Reports
2. Custom Report
3. Select SAR, Business Unit report type, period 2026-01-01 to 2026-03-31