### PR TITLE
[CDPTKAN-895] Fix AssignmentsController#execute_reassign_user bad variable name errors

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -191,14 +191,11 @@ class AssignmentsController < ApplicationController
 
   def execute_reassign_user
     authorize @case, :assignments_execute_reassign_user?
-
     target_user = User.find(reassign_user_params[:user_id])
-    urs = UserReassignmentService
-              .new(target_user:,
-                   acting_user: current_user,
-                   assignment: @assignment)
 
-    case urs.call
+    service = UserReassignmentService.new(target_user:, acting_user: current_user, assignment: @assignment)
+
+    case service.call
     when :ok
       flash[:notice] = "Case re-assigned to #{@assignment.user.full_name}"
       redirect_to case_path(@case)

--- a/app/services/user_reassignment_service.rb
+++ b/app/services/user_reassignment_service.rb
@@ -37,7 +37,7 @@ class UserReassignmentService
   rescue StandardError => e
     Rails.logger.error e.to_s
     Rails.logger.error e.backtrace.join("\n\t")
-    @error_message = e
+    @error_message = e.message
     @result = :error
   end
 

--- a/app/services/user_reassignment_service.rb
+++ b/app/services/user_reassignment_service.rb
@@ -1,5 +1,5 @@
 class UserReassignmentService
-  attr_reader :result, :error
+  attr_reader :result, :error_message
 
   def initialize(assignment:,
                  target_user:, acting_user:,
@@ -13,6 +13,7 @@ class UserReassignmentService
     @target_team            = target_team || get_team_for_user_and_case_with_role(@assignment.team.role, @target_user)
     @acting_team            = acting_team || get_user_team(@acting_user)
     @result = :incomplete
+    @error_message = ""
   end
 
   def call
@@ -36,7 +37,7 @@ class UserReassignmentService
   rescue StandardError => e
     Rails.logger.error e.to_s
     Rails.logger.error e.backtrace.join("\n\t")
-    @error = e
+    @error_message = e
     @result = :error
   end
 

--- a/spec/controllers/assignments_controller/execute_reassign_user_spec.rb
+++ b/spec/controllers/assignments_controller/execute_reassign_user_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSp
           expect(service).to have_received(:call)
         end
 
-        it "redirects to new_user_session_path" do
+        it "redirects to case page" do
           patch(:execute_reassign_user, params:)
           expect(response).to redirect_to case_path(id: accepted_case.id)
         end
@@ -73,7 +73,7 @@ RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSp
           expect(service).to have_received(:call)
         end
 
-        it "redirects to new_user_session_path" do
+        it "redirects to case page" do
           patch(:execute_reassign_user, params:)
           expect(response).to redirect_to case_path(id: accepted_ico_foi_case.id)
         end
@@ -103,7 +103,7 @@ RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSp
           expect(service).to have_received(:call)
         end
 
-        it "redirects to new_user_session_path" do
+        it "redirects to case page" do
           patch(:execute_reassign_user, params:)
           expect(response).to redirect_to case_path(id: accepted_complaint_case.id)
         end

--- a/spec/controllers/assignments_controller/execute_reassign_user_spec.rb
+++ b/spec/controllers/assignments_controller/execute_reassign_user_spec.rb
@@ -20,91 +20,110 @@ RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSp
   end
 
   describe "PATCH execute_reassign_user" do
-    before do
-      sign_in responder
+    context "with valid params" do
+      before do
+        sign_in responder
 
-      allow(UserReassignmentService).to receive(:new).and_return(service)
-      allow(service).to receive(:call).and_return(:ok)
+        allow(UserReassignmentService).to receive(:new).and_return(service)
+        allow(service).to receive(:call).and_return(:ok)
+      end
+
+      it "authorises" do
+        expect {
+          patch :execute_reassign_user, params:
+        }.to require_permission(:assignments_execute_reassign_user?)
+                .with_args(responder, accepted_case)
+      end
+
+      context "with foi case" do
+        it "calls UserReassignmentService" do
+          patch(:execute_reassign_user, params:)
+          expect(UserReassignmentService).to have_received(:new).with(
+            acting_user: responder,
+            target_user: another_responder,
+            assignment:,
+          )
+          expect(service).to have_received(:call)
+        end
+
+        it "redirects to new_user_session_path" do
+          patch(:execute_reassign_user, params:)
+          expect(response).to redirect_to case_path(id: accepted_case.id)
+        end
+      end
+
+      context "with foi ico case" do
+        let(:accepted_ico_foi_case) { create :accepted_ico_foi_case, responding_team: }
+        let(:assignment)            { accepted_ico_foi_case.responder_assignment }
+        let(:params)                do
+          { case_id: accepted_ico_foi_case.id,
+            id: assignment.id,
+            assignment: {
+              user_id: another_responder.id,
+            } }
+        end
+
+        it "calls UserReassignmentService" do
+          patch(:execute_reassign_user, params:)
+          expect(UserReassignmentService).to have_received(:new).with(
+            acting_user: responder,
+            target_user: another_responder,
+            assignment:,
+          )
+          expect(service).to have_received(:call)
+        end
+
+        it "redirects to new_user_session_path" do
+          patch(:execute_reassign_user, params:)
+          expect(response).to redirect_to case_path(id: accepted_ico_foi_case.id)
+        end
+      end
+
+      context "with offender sar complaint case" do
+        let(:accepted_complaint_case) { create :accepted_complaint_case }
+        let(:responding_team)         { accepted_complaint_case.responding_team }
+        let(:responder)               { responding_team.responders.first }
+        let(:another_responder)       { create :responder, responding_teams: [responding_team] }
+        let(:assignment)              { accepted_complaint_case.responder_assignment }
+        let(:params)                  do
+          { case_id: accepted_complaint_case.id,
+            id: assignment.id,
+            assignment: {
+              user_id: another_responder.id,
+            } }
+        end
+
+        it "calls UserReassignmentService" do
+          patch(:execute_reassign_user, params:)
+          expect(UserReassignmentService).to have_received(:new).with(
+            acting_user: responder,
+            target_user: another_responder,
+            assignment:,
+          )
+          expect(service).to have_received(:call)
+        end
+
+        it "redirects to new_user_session_path" do
+          patch(:execute_reassign_user, params:)
+          expect(response).to redirect_to case_path(id: accepted_complaint_case.id)
+        end
+      end
     end
 
-    it "authorises" do
-      expect {
-        patch :execute_reassign_user, params:
-      }.to require_permission(:assignments_execute_reassign_user?)
-              .with_args(responder, accepted_case)
-    end
+    context "with invalid params" do
+      before do
+        allow(UserReassignmentService).to receive(:new).and_return(service)
+        allow(service).to receive(:call).and_return(:error)
+        allow(service).to receive(:error_message).and_return("A StandardError was raised")
 
-    context "with foi case" do
-      it "calls UserReassignmentService" do
+        sign_in responder
+      end
+
+      it "shows warning" do
         patch(:execute_reassign_user, params:)
-        expect(UserReassignmentService).to have_received(:new).with(
-          acting_user: responder,
-          target_user: another_responder,
-          assignment:,
-        )
-        expect(service).to have_received(:call)
-      end
 
-      it "redirects to new_user_session_path" do
-        patch(:execute_reassign_user, params:)
-        expect(response).to redirect_to case_path(id: accepted_case.id)
-      end
-    end
-
-    context "with foi ico case" do
-      let(:accepted_ico_foi_case) { create :accepted_ico_foi_case, responding_team: }
-      let(:assignment)            { accepted_ico_foi_case.responder_assignment }
-      let(:params)                do
-        { case_id: accepted_ico_foi_case.id,
-          id: assignment.id,
-          assignment: {
-            user_id: another_responder.id,
-          } }
-      end
-
-      it "calls UserReassignmentService" do
-        patch(:execute_reassign_user, params:)
-        expect(UserReassignmentService).to have_received(:new).with(
-          acting_user: responder,
-          target_user: another_responder,
-          assignment:,
-        )
-        expect(service).to have_received(:call)
-      end
-
-      it "redirects to new_user_session_path" do
-        patch(:execute_reassign_user, params:)
-        expect(response).to redirect_to case_path(id: accepted_ico_foi_case.id)
-      end
-    end
-
-    context "with offender sar complaint case" do
-      let(:accepted_complaint_case) { create :accepted_complaint_case }
-      let(:responding_team)         { accepted_complaint_case.responding_team }
-      let(:responder)               { responding_team.responders.first }
-      let(:another_responder)       { create :responder, responding_teams: [responding_team] }
-      let(:assignment)              { accepted_complaint_case.responder_assignment }
-      let(:params)                  do
-        { case_id: accepted_complaint_case.id,
-          id: assignment.id,
-          assignment: {
-            user_id: another_responder.id,
-          } }
-      end
-
-      it "calls UserReassignmentService" do
-        patch(:execute_reassign_user, params:)
-        expect(UserReassignmentService).to have_received(:new).with(
-          acting_user: responder,
-          target_user: another_responder,
-          assignment:,
-        )
-        expect(service).to have_received(:call)
-      end
-
-      it "redirects to new_user_session_path" do
-        patch(:execute_reassign_user, params:)
-        expect(response).to redirect_to case_path(id: accepted_complaint_case.id)
+        expect(flash.now[:alert]).to eq "A StandardError was raised"
+        expect(response).to render_template :reassign_user
       end
     end
   end


### PR DESCRIPTION
## Description
AssignmentsController#execute_reassign_user had multiple errors - the `service` variable didn't exist and `UserReassignmentService` did not have an `error` method. As a result, when a user was supposed to be shown an error message with the form re-rendered, they instead saw a generic 500 'sorry' error page. This was a bad UX.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-895

### Deployment
N/A
### Manual testing instructions
N/A