### PR TITLE
[CDPTKAN-904] Show error page when reassign user fails

### DIFF
--- a/app/controllers/assignments_controller.rb
+++ b/app/controllers/assignments_controller.rb
@@ -204,8 +204,8 @@ class AssignmentsController < ApplicationController
       redirect_to case_path(@case)
     else
       @case = @case.decorate
-      flash.now[:alert] = service.error_message
-      render :reassign_user
+      flash[:alert] = service.error_message
+      redirect_to action: "reassign_user"
     end
   end
 

--- a/app/views/assignments/reassign_user.html.slim
+++ b/app/views/assignments/reassign_user.html.slim
@@ -14,7 +14,7 @@
 = GovukElementsErrorsHelper.error_summary @case,
         "#{pluralize(@case.errors.count, t('common.error'))} #{ t('common.summary_error')}", ""
 
-= form_for [@case, @assignment], url: execute_reassign_user_case_assignment_path(@case,@assignment), method: :patch do |f|
+= form_for [@case, @assignment], url: execute_reassign_user_case_assignment_path(@case, @assignment), method: :patch do |f|
   = f.radio_button_fieldset :user_id , choices: @team_users, value_method: :id, text_method: :full_name_with_optional_load_html
 
   = f.submit t('.action'), class: 'button'

--- a/spec/controllers/assignments_controller/execute_reassign_user_spec.rb
+++ b/spec/controllers/assignments_controller/execute_reassign_user_spec.rb
@@ -122,8 +122,8 @@ RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSp
       it "shows warning" do
         patch(:execute_reassign_user, params:)
 
-        expect(flash.now[:alert]).to eq "A StandardError was raised"
-        expect(response).to render_template :reassign_user
+        expect(flash[:alert]).to eq "A StandardError was raised"
+        expect(response).to redirect_to reassign_user_case_assignment_path(case_id: accepted_case.id, id: assignment.id)
       end
     end
   end


### PR DESCRIPTION
## Description
Fixes bug in reassign case to new user page.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="804" height="811" alt="Screenshot 2026-04-13 at 17 53 39" src="https://github.com/user-attachments/assets/abe1c7cd-acad-4da4-8c17-609c7b3702be" />



### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-904

### Deployment
N/A

### Manual testing instructions
1. Create new SAR, assign to a team
2.  Log into Track a query as a member of the assigned team, accept case
3. Ensure logged in user is a manager, then reassign the case to a new team member