### PR TITLE
[CDTPKAN-867] Add ingress proxy-read-timeout arbitrary value for production

### DIFF
--- a/config/kubernetes/production/ingress-live.yaml
+++ b/config/kubernetes/production/ingress-live.yaml
@@ -11,6 +11,7 @@ metadata:
       SecAuditEngine On
       SecRuleEngine DetectionOnly
       SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=track-a-query-production"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600" # adds 600 to 30 seconds from elsewhere
 spec:
   ingressClassName: modsec
   tls:

--- a/config/kubernetes/staging/ingress-live.yaml
+++ b/config/kubernetes/staging/ingress-live.yaml
@@ -12,6 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
       SecRuleEngine On
       SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=track-a-query-staging"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600" # adds 600 to 30 seconds from elsewhere
 spec:
   ingressClassName: modsec
   tls:


### PR DESCRIPTION
## Description
Increases nginx timeout to 10 minutes to allow 'all open cases' and 'deleted cases' download to complete. 

- arbitrary 10 minute timeout - may require revision pending further advice
-  the 10 minutes setting seems to allow long requests, but the value is ADDED to another existing value configured in a server somwhere which we are not aware of or this new ingress annotation does not work in the way we think it does.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-867

### Deployment
From local machine:

```
kubectl -n track-a-query-production apply -f config/kubernetes/production/ingress-live.yaml
kubectl -n track-a-query-production describe ingress
```

### Manual testing instructions
N/A