### PR TITLE
[CDPTKAN-812] Prevent nil exception for validation of related cases

### DIFF
--- a/app/controllers/concerns/ico_cases_params.rb
+++ b/app/controllers/concerns/ico_cases_params.rb
@@ -176,6 +176,11 @@ private
       number: params.fetch(:original_case_number),
     )
 
+    if original_case.nil?
+      @linked_case_error = ico_error("related_case_number", :missing)
+      return false
+    end
+
     if related_case == original_case
       @linked_case_error = ico_error("related_case_number", :already_linked)
       return false


### PR DESCRIPTION
## Description
When creating a new ICO case, and pressing 'Link Related Case', the validation check could fail if the `original_case` is not found. Existing spec already covers this code.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-812

### Deployment
N/A

### Manual testing instructions
N/A
