### PR TITLE
[CDPTKAN-900] Allow Standard SAR to have comments during pause

### DIFF
--- a/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/20_sar/20_sar_standard_workflow.yml
@@ -75,6 +75,7 @@
                 auto_close:
                   if: Workflows::Predicates#can_auto_close_case?
                   transition_to: closed
+                add_message_to_case:
 
               closed:
                 add_message_to_case:
@@ -140,6 +141,8 @@
                 auto_close:
                   if: Workflows::Predicates#can_auto_close_case?
                   transition_to: closed
+                add_message_to_case:
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
 
               closed:
                 add_message_to_case:
@@ -184,3 +187,5 @@
                 auto_close:
                   if: Workflows::Predicates#can_auto_close_case?
                   transition_to: closed
+                add_message_to_case:
+                  if: Workflows::Predicates#user_is_approver_on_case?

--- a/config/state_machine/configs/00_moj/20_sar/30_sar_trigger_workflow.yml
+++ b/config/state_machine/configs/00_moj/20_sar/30_sar_trigger_workflow.yml
@@ -103,6 +103,7 @@
                 auto_close:
                   if: Workflows::Predicates#can_auto_close_case?
                   transition_to: closed
+                add_message_to_case:
 
               closed:
                 add_message_to_case:
@@ -194,6 +195,8 @@
                 auto_close:
                   if: Workflows::Predicates#can_auto_close_case?
                   transition_to: closed
+                add_message_to_case:
+                  if: Workflows::Predicates#responder_is_member_of_assigned_team?
 
               closed:
                 add_message_to_case:
@@ -312,6 +315,8 @@
                 auto_close:
                   if: Workflows::Predicates#can_auto_close_case?
                   transition_to: closed
+                add_message_to_case:
+                  if: Workflows::Predicates#user_is_approver_on_case?
 
               closed:
                 add_message_to_case:

--- a/spec/features/cases/sar/case_viewing_spec.rb
+++ b/spec/features/cases/sar/case_viewing_spec.rb
@@ -5,8 +5,7 @@ feature "viewing SAR cases" do
   given(:manager)            { find_or_create :disclosure_bmt_user }
   given(:responder)          { find_or_create :sar_responder }
   given(:coworker_responder) do
-    create :responder,
-           responding_teams: responder.responding_teams
+    create :responder, responding_teams: responder.responding_teams
   end
   given(:another_responder) { create :responder }
 
@@ -19,6 +18,7 @@ feature "viewing SAR cases" do
       cases_show_page.load id: kase.id
 
       expect(cases_show_page).to be_displayed(id: kase.id)
+      expect(cases_show_page.new_message).to have_add_button
     end
 
     scenario "viewing as a responder" do
@@ -26,6 +26,7 @@ feature "viewing SAR cases" do
 
       cases_show_page.load id: kase.id
       expect(open_cases_page).to be_displayed
+      expect(open_cases_page.alert.text).to eq "You are not authorised to view this case."
     end
   end
 
@@ -38,6 +39,7 @@ feature "viewing SAR cases" do
       cases_show_page.load id: kase.id
 
       expect(cases_show_page).to be_displayed(id: kase.id)
+      expect(cases_show_page.new_message).to have_add_button
     end
 
     scenario "viewing as assigned responder" do
@@ -54,6 +56,7 @@ feature "viewing SAR cases" do
       cases_show_page.load id: kase.id
 
       expect(cases_show_page).to be_displayed(id: kase.id)
+      expect(cases_show_page.new_message).to have_add_button
     end
 
     scenario "viewing as another responder on different team" do
@@ -62,6 +65,7 @@ feature "viewing SAR cases" do
       cases_show_page.load id: kase.id
 
       expect(open_cases_page).to be_displayed
+      expect(open_cases_page.alert.text).to eq "You are not authorised to view this case."
     end
   end
 
@@ -78,13 +82,53 @@ feature "viewing SAR cases" do
       login_as responder
 
       cases_show_page.load id: kase.id
+
       expect(cases_show_page.request).to have_message
-      expect(cases_show_page.request.message.text)
-        .to eq kase.message
+      expect(cases_show_page.request.message.text).to eq kase.message
       expect(cases_show_page.request).to have_attachments
       expect(cases_show_page.request.attachments.count).to eq 1
-      expect(cases_show_page.request.attachments[0].collection[0].filename.text)
-        .to eq request_file
+      expect(cases_show_page.request.attachments[0].collection[0].filename.text).to eq request_file
+    end
+  end
+
+  describe "when stopped case" do
+    context "and allowed to restart the clock" do
+      given(:responder_and_team_admin) do
+        create :responder_and_team_admin, responding_teams: responder.responding_teams
+      end
+
+      given!(:kase) do
+        create :pending_dacu_clearance_sar, :stopped,
+               approving_team: approver.approving_team,
+               approver: approver,
+               responder: responder_and_team_admin
+      end
+
+      scenario "can restart as a manager, approver or responder_and_team_admin", aggregate_failures: true do
+        [manager, approver, responder_and_team_admin].each do |user|
+          login_as user
+
+          cases_show_page.load id: kase.id
+
+          expect(cases_show_page).to be_displayed(id: kase.id)
+          expect(cases_show_page).to have_restart_the_clock
+          expect(cases_show_page.new_message).to have_add_button
+        end
+      end
+    end
+
+    context "and not allowed to restart the clock" do
+      given!(:kase) { create :accepted_sar, :stopped, responder: responder }
+
+      scenario "cannot restart as a responder" do
+        login_as responder
+
+        cases_show_page.load id: kase.id
+
+        expect(cases_show_page).to be_displayed(id: kase.id)
+        expect(cases_show_page).not_to have_restart_the_clock
+        expect(cases_show_page.new_message).to have_add_button
+      end
     end
   end
 end

--- a/spec/site_prism/page_objects/pages/cases/open_cases_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/open_cases_page.rb
@@ -14,6 +14,8 @@ module PageObjects
         element :search_query, 'input[type="search"]'
         element :search_button, "input.button#search-button"
 
+        element :alert, ".error-summary-heading"
+
         section :case_filters, ".case-filters > details" do
           element :filter_cases_link, ".case-filters__summary--outer"
           element :filter_status_link, "#filter_status_content_btn"


### PR DESCRIPTION
## Description
Allow standard SAR to have comments when in paused/stopped state

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="354" height="879" alt="Screenshot 2026-04-21 at 00 47 07" src="https://github.com/user-attachments/assets/2f6999bd-ebcb-499d-a44c-6a35fb46ae78" />


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-900

### Deployment
N/A

### Manual testing instructions
1. Create standard SAR.
2. Pause case, notice conversation box is available to add new messages
