### PR TITLE
[CDTPKAN-899] Allow Paused Offender SAR edit and add data

### DIFF
--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -184,6 +184,8 @@
                   if: Workflows::Predicates#can_auto_close_case?
                   transition_to: closed
                 add_note_to_case:
+                add_data_received:
+                edit_case:
 
               closed:
                 add_note_to_case:


### PR DESCRIPTION
## Description
Allows paused/stopped Offender SAR case to be edited and have data requests added.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
#### BEFORE
<img width="706" height="552" alt="Screenshot 2026-04-22 at 13 25 49" src="https://github.com/user-attachments/assets/c1c561c7-603f-4fdc-b66a-aade396fbd51" />


#### AFTER
<img width="939" height="962" alt="Screenshot 2026-04-22 at 13 31 31" src="https://github.com/user-attachments/assets/0a02f600-c9a6-4481-8c73-761326a7df7c" />

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-899

### Deployment
N/A

### Manual testing instructions
1. Create Offender SAR
2. Pause it
3. Should still be allowed to edit the case details and see data requests buttons
