### PR TITLE
[CDPTKAN-757] Change extended_times to months_extended

### DIFF
--- a/app/models/case/sar/offender.rb
+++ b/app/models/case/sar/offender.rb
@@ -148,7 +148,7 @@ class Case::SAR::Offender < Case::Base
                  probation_area: :string,
                  # Deadline extension properties
                  deadline_extended: [:boolean, { default: false }],
-                 extended_times: :integer
+                 months_extended: :integer
 
   attribute :number_final_pages, :integer, default: 0
   attribute :number_exempt_pages, :integer, default: 0
@@ -603,7 +603,7 @@ private
     elsif changed.include?("received_date") && !extended_for_pit?
       self.internal_deadline = @deadline_calculator.internal_deadline
       self.external_deadline = @deadline_calculator.external_deadline
-      self.extended_times = 0
+      self.months_extended = 0
       self.deadline_extended = false
     end
   end

--- a/app/models/case/sar/standard.rb
+++ b/app/models/case/sar/standard.rb
@@ -68,7 +68,7 @@ class Case::SAR::Standard < Case::Base
                  date_draft_compliant: :date,
                  # Deadline extension properties
                  deadline_extended: [:boolean, { default: false }],
-                 extended_times: :integer
+                 months_extended: :integer
 
   attr_accessor :missing_info
 
@@ -173,7 +173,7 @@ private
     if changed.include?("received_date") && !extended_for_pit?
       self.internal_deadline = @deadline_calculator.internal_deadline
       self.external_deadline = @deadline_calculator.external_deadline
-      self.extended_times = 0
+      self.months_extended = 0
       self.deadline_extended = false
     end
   end

--- a/app/models/concerns/extendable.rb
+++ b/app/models/concerns/extendable.rb
@@ -1,16 +1,8 @@
 module Extendable
   extend ActiveSupport::Concern
 
-  # NOTE: By using `extended_times` we are conflating the number of months a case can be extended e.g. 2
-  # with the number of times the case is extended. If the case is extended by 2 months, the extended_times == 2
-  # The `extended_times` value is also used for reporting. The actual number of months extended is not recorded
-  # explicitly in transitions, hence using `extended_times` instead.
   def deadline_extendable?
-    num_months_extended < extension_time_limit
-  end
-
-  def num_months_extended
-    extended_times.to_i
+    months_extended.to_i < extension_time_limit
   end
 
   def initial_deadline
@@ -25,11 +17,11 @@ module Extendable
     end
   end
 
-  def extend_deadline!(new_deadline, new_extended_times)
+  def extend_deadline!(new_deadline, new_months_extended)
     update!(
       external_deadline: new_deadline,
       deadline_extended: true,
-      extended_times: new_extended_times,
+      months_extended: new_months_extended,
     )
   end
 
@@ -37,7 +29,7 @@ module Extendable
     update!(
       external_deadline: calculate_old_deadline,
       deadline_extended: false,
-      extended_times: 0,
+      months_extended: 0,
     )
   end
 

--- a/app/services/case_extend_sar_deadline_service.rb
+++ b/app/services/case_extend_sar_deadline_service.rb
@@ -22,8 +22,8 @@ class CaseExtendSARDeadlineService
           message:,
         )
 
-        new_extended_times = @extension_period.to_i + (@case.extended_times || 0)
-        @case.extend_deadline!(@extension_deadline, new_extended_times)
+        new_months_extended = @extension_period.to_i + (@case.months_extended || 0)
+        @case.extend_deadline!(@extension_deadline, new_months_extended)
         @result = :ok
       else
         @result = :validation_error
@@ -43,7 +43,7 @@ private
     if @case.try(:restarted_at).present?
       @case.deadline_calculator.extension_deadline(extend_by) { @case.external_deadline }
     else
-      @case.deadline_calculator.extension_deadline((@case.extended_times || 0) + extend_by)
+      @case.deadline_calculator.extension_deadline((@case.months_extended || 0) + extend_by)
     end
   end
 
@@ -69,7 +69,7 @@ private
         :extension_period,
         "cannot be blank",
       )
-    elsif (@case.num_months_extended + @extension_period.to_i) > @case.extension_time_limit
+    elsif (@case.months_extended.to_i + @extension_period.to_i) > @case.extension_time_limit
       @case.errors.add(
         :extension_period,
         "cannot be more than #{@case.time_period_description(@case.extension_time_limit)} beyond the received date or last paused date",

--- a/spec/models/case/sar/internal_review_spec.rb
+++ b/spec/models/case/sar/internal_review_spec.rb
@@ -293,7 +293,7 @@ describe Case::SAR::InternalReview do
 
       it "is false when already extended equal or beyond satutory limit" do
         sar = freeze_time { create :approved_sar }
-        sar.extended_times = sar.extension_time_limit
+        sar.months_extended = sar.extension_time_limit
 
         expect(sar.deadline_extendable?).to eq false
       end
@@ -351,9 +351,9 @@ describe Case::SAR::InternalReview do
           .to(false)
       end
 
-      it "sets #extended_times to 0" do
+      it "sets #months_extended to 0" do
         expect { extended_sar.reset_deadline! }.to \
-          change(extended_sar, :extended_times)
+          change(extended_sar, :months_extended)
           .from(1)
           .to(0)
       end
@@ -375,7 +375,7 @@ describe Case::SAR::InternalReview do
           extended_sar.update!(received_date: new_received_date)
           expect(extended_sar.external_deadline).to eq get_expected_deadline(1.month.since(new_received_date))
           expect(extended_sar.deadline_extended).to eq false
-          expect(extended_sar.extended_times).to eq 0
+          expect(extended_sar.months_extended).to eq 0
         end
       end
     end
@@ -389,16 +389,16 @@ describe Case::SAR::InternalReview do
           extended_sar.update!(received_date: new_received_date)
           expect(extended_sar.external_deadline).to eq get_expected_deadline(1.month.since(new_received_date))
           expect(extended_sar.deadline_extended).to eq false
-          expect(extended_sar.extended_times).to eq 0
+          expect(extended_sar.months_extended).to eq 0
 
           extended_sar.extend_deadline!(get_expected_deadline(2.months.since(extended_sar.received_date)), 2)
           expect(extended_sar.deadline_extended).to eq true
-          expect(extended_sar.extended_times).to eq 2
+          expect(extended_sar.months_extended).to eq 2
 
           extended_sar.reset_deadline!
           expect(extended_sar.external_deadline).to eq get_expected_deadline(1.month.since(new_received_date))
           expect(extended_sar.deadline_extended).to eq false
-          expect(extended_sar.extended_times).to eq 0
+          expect(extended_sar.months_extended).to eq 0
         end
       end
     end

--- a/spec/models/case/sar/standard_spec.rb
+++ b/spec/models/case/sar/standard_spec.rb
@@ -303,7 +303,7 @@ describe Case::SAR::Standard do
 
       it "is false when already extended equal or beyond satutory limit" do
         sar = freeze_time { create :approved_sar }
-        sar.extended_times = sar.extension_time_limit
+        sar.months_extended = sar.extension_time_limit
 
         expect(sar.deadline_extendable?).to eq false
       end
@@ -361,9 +361,9 @@ describe Case::SAR::Standard do
           .to(false)
       end
 
-      it "sets #extended_times to 0" do
+      it "sets #months_extended to 0" do
         expect { extended_sar.reset_deadline! }.to \
-          change(extended_sar, :extended_times)
+          change(extended_sar, :months_extended)
           .from(1)
           .to(0)
       end
@@ -385,7 +385,7 @@ describe Case::SAR::Standard do
           extended_sar.update!(received_date: new_received_date)
           expect(extended_sar.external_deadline).to eq get_expected_deadline(1.month.since(new_received_date))
           expect(extended_sar.deadline_extended).to eq false
-          expect(extended_sar.extended_times).to eq 0
+          expect(extended_sar.months_extended).to eq 0
         end
       end
     end
@@ -399,16 +399,16 @@ describe Case::SAR::Standard do
           extended_sar.update!(received_date: new_received_date)
           expect(extended_sar.external_deadline).to eq get_expected_deadline(1.month.since(new_received_date))
           expect(extended_sar.deadline_extended).to eq false
-          expect(extended_sar.extended_times).to eq 0
+          expect(extended_sar.months_extended).to eq 0
 
           extended_sar.extend_deadline!(get_expected_deadline(2.months.since(extended_sar.received_date)), 2)
           expect(extended_sar.deadline_extended).to eq true
-          expect(extended_sar.extended_times).to eq 2
+          expect(extended_sar.months_extended).to eq 2
 
           extended_sar.reset_deadline!
           expect(extended_sar.external_deadline).to eq get_expected_deadline(1.month.since(new_received_date))
           expect(extended_sar.deadline_extended).to eq false
-          expect(extended_sar.extended_times).to eq 0
+          expect(extended_sar.months_extended).to eq 0
         end
       end
     end

--- a/spec/services/case_extend_sar_deadline_service_spec.rb
+++ b/spec/services/case_extend_sar_deadline_service_spec.rb
@@ -36,7 +36,7 @@ describe CaseExtendSARDeadlineService do
 
         it "sets new SAR deadline date" do
           expect(kase.external_deadline).to eq get_expected_deadline(2.months.since(kase.received_date))
-          expect(kase.extended_times).to eq 1
+          expect(kase.months_extended).to eq 1
         end
       end
 
@@ -55,7 +55,7 @@ describe CaseExtendSARDeadlineService do
             expect(kase.external_deadline)
               .to eq get_expected_deadline((max_extension_time_limit + 1).month.since(kase.received_date))
             expect(kase.external_deadline).to be < Time.zone.now
-            expect(kase.extended_times).to eq 2
+            expect(kase.months_extended).to eq 2
           end
         end
       end

--- a/spec/services/case_remove_sar_deadline_extension_service_spec.rb
+++ b/spec/services/case_remove_sar_deadline_extension_service_spec.rb
@@ -47,7 +47,7 @@ describe CaseRemoveSARDeadlineExtensionService do
       it "resets SAR deadline date" do
         expect(sar_case.external_deadline).to eq initial_deadline
         expect(sar_case.external_deadline).to eq Date.new(2025, 4, 1)
-        expect(sar_case.extended_times).to eq 0
+        expect(sar_case.months_extended).to eq 0
       end
     end
 
@@ -63,7 +63,7 @@ describe CaseRemoveSARDeadlineExtensionService do
           expect(sar_case.external_deadline).to eq initial_deadline
           expect(sar_case.external_deadline).to eq Date.new(2025, 4, 1) # Original deadline
           expect(sar_case.deadline_extended?).to be false
-          expect(sar_case.extended_times).to eq 0
+          expect(sar_case.months_extended).to eq 0
         end
       end
     end


### PR DESCRIPTION
## Description
Alters field name `extended_times` to `months_extended` to reflect actual purpose of the field and ensure upcoming alterations to SAR deadline extensions makes sense.

Relies on #2808 to be executed first.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-757

### Deployment
Depends on PR #2808 .

### Manual testing instructions
Try extend/remove SAR deadline
