### PR TITLE
[CDPTKAN-816] Tighten up email address rules for new contacts

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -18,8 +18,9 @@
 #  escalation_emails   :string
 #
 class Contact < ApplicationRecord
-  # Disallow commas, extra @s, whitespace, empty domain labels, and trailing dots
-  EMAIL_REGEX = /\A[^@,\s]+@[^@,\s.]+(?:\.[^@,\s.]+)*\z/
+  # Pragmatic email validation for staff-entered addresses.
+  # Rejects leading/trailing/repeated dots in the local part and invalid domain labels.
+  EMAIL_REGEX = /\A(?!\.)(?!.*\.\.)[A-Za-z0-9!#$%&'*+\/=?\^_`{|}~-]+(?:\.[A-Za-z0-9!#$%&'*+\/=?\^_`{|}~-]+)*@(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,}\z/
 
   before_validation :cleanse_emails
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -21,6 +21,8 @@ class Contact < ApplicationRecord
   # Disallow commas, extra @s, whitespace, empty domain labels, and trailing dots
   EMAIL_REGEX = /\A[^@,\s]+@[^@,\s.]+(?:\.[^@,\s.]+)*\z/
 
+  before_validation :cleanse_emails
+
   validates :name, presence: true
   validates :address_line_1, presence: true
   validates :postcode, presence: true
@@ -99,5 +101,16 @@ private
         :invalid,
       )
     end
+  end
+
+  def cleanse_emails
+    self.data_request_emails = strip(data_request_emails)
+    self.escalation_emails = strip(escalation_emails)
+  end
+
+  def strip(email_list)
+    return if email_list.blank?
+
+    email_list.split.join("\n")
   end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -18,7 +18,8 @@
 #  escalation_emails   :string
 #
 class Contact < ApplicationRecord
-  EMAIL_REGEX = /\A([^@,]+)@([^@,]+)\z/ # regex disallows commas and additional @s
+  # Disallow commas, extra @s, whitespace, empty domain labels, and trailing dots
+  EMAIL_REGEX = /\A[^@,\s]+@[^@,\s.]+(?:\.[^@,\s.]+)*\z/
 
   validates :name, presence: true
   validates :address_line_1, presence: true

--- a/app/views/cases/_case_request.html.slim
+++ b/app/views/cases/_case_request.html.slim
@@ -14,7 +14,7 @@
     - if case_details.message.present?
       p.message-body
         = show_hide_message(case_details)
-    - if case_details.message.empty? && case_details.type_of_offender_sar?
+    - if case_details.message.blank? && case_details.type_of_offender_sar?
       p.message-body
         = t('cases.offender_sar.request_info_hint')
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -78,6 +78,17 @@ RSpec.describe Contact, type: :model do
         expect(contact_2).to be_valid
       end
 
+      it "strips surrounding whitespace from email fields before persisting" do
+        contact = create(
+          :prison,
+          data_request_emails: "  oscar@thegrouch.com  \n  big@bird.com  ",
+          escalation_emails: "  governor@prison.com  ",
+        )
+
+        expect(contact.reload.data_request_emails).to eq("oscar@thegrouch.com\nbig@bird.com")
+        expect(contact.escalation_emails).to eq("governor@prison.com")
+      end
+
       it "is invalid if an email has a trailing dot in the domain" do
         contact_2.data_request_emails = "example@example.com."
         expect(contact_2).not_to be_valid

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -78,6 +78,11 @@ RSpec.describe Contact, type: :model do
         expect(contact_2).to be_valid
       end
 
+      it "is invalid if an email has a trailing dot in the domain" do
+        contact_2.data_request_emails = "example@example.com."
+        expect(contact_2).not_to be_valid
+      end
+
       it "is valid with multiple correctly formatted emails delimited by newline" do
         contact_2.data_request_emails = "oscar@grouch.com\nbig@bird.com"
         expect(contact_2).to be_valid

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -73,11 +73,6 @@ RSpec.describe Contact, type: :model do
     end
 
     describe "data_request_emails" do
-      it "is valid with one correctly formatted email" do
-        contact_2.data_request_emails = "oscar@thegrouch.com"
-        expect(contact_2).to be_valid
-      end
-
       it "strips surrounding whitespace from email fields before persisting" do
         contact = create(
           :prison,
@@ -89,29 +84,51 @@ RSpec.describe Contact, type: :model do
         expect(contact.escalation_emails).to eq("governor@prison.com")
       end
 
-      it "is invalid if an email has a trailing dot in the domain" do
-        contact_2.data_request_emails = "example@example.com."
-        expect(contact_2).not_to be_valid
+      it "is valid with correct emails" do
+        examples = [
+          "oscar@example.com",
+          "big@example.com",
+          "oscar@example.com\nbig@example.com",
+          "    someone@example.com   \n another@example.example.com",
+          "SOMEONE@example.gov.uk\n  SOMEONEelse+Alias2@example.gov.uk  ",
+        ]
+
+        examples.each do |example|
+          contact_prison.data_request_emails = example
+          expect(contact_prison).to be_valid
+
+          contact_prison.escalation_emails = example
+          expect(contact_prison).to be_valid
+        end
       end
 
-      it "is valid with multiple correctly formatted emails delimited by newline" do
-        contact_2.data_request_emails = "oscar@grouch.com\nbig@bird.com"
-        expect(contact_2).to be_valid
-      end
+      it "is invalid with incorrect emails" do
+        examples = [
+          "oscar@example.com,big@example.com",
+          "oscar@example.com\nbigexample.com",
+          "example.com",
+          "oscar@.com",
+          "example@com.",
+          "example@-example.com",
+          "example@example",
+          ".",
+          "example..example@example.com",
+          "example@.example.com",
+          ".example@example.com",
+          "example@example..com",
+          "example@example.com.",
+          "who?are-you!@example.com.",
+        ]
 
-      it "is invalid if the only email is incorrectly formatted" do
-        contact_2.data_request_emails = "bigbird.com"
-        expect(contact_2).not_to be_valid
-      end
+        examples.each do |example|
+          contact_prison.data_request_emails = example
+          expect(contact_prison).not_to be_valid
+          expect(contact_prison.errors.of_kind?(:data_request_emails, :invalid)).to eq(true)
 
-      it "is invalid if any email is incorrectly formatted" do
-        contact_2.data_request_emails = "oscar@grouch.com\nbigbird.com"
-        expect(contact_2).not_to be_valid
-      end
-
-      it "is invalid if the wrong delimiter is used with multiple emails" do
-        contact_2.data_request_emails = "oscar@grouch.com,big@bird.com"
-        expect(contact_2).not_to be_valid
+          contact_prison.escalation_emails = example
+          expect(contact_prison).not_to be_valid
+          expect(contact_prison.errors.of_kind?(:escalation_emails, :invalid)).to eq(true)
+        end
       end
     end
   end


### PR DESCRIPTION
## Description
Enhanced protection against dodgy email addresses when adding new contacts. Removes whitespace from email address entries.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="595" height="312" alt="Screenshot 2026-05-19 at 17 27 13" src="https://github.com/user-attachments/assets/78361e39-8390-473d-91ab-11739587cfaf" />


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-816

### Deployment
N/A

### Manual testing instructions
For Offender SAR, Record data request, select 'Find an address' -> Add or edit addresses -> Add new address
(`/contacts/new`)