### PR TITLE
[CDTPKAN-894] Allow Paused/Stopped Offender SARs to receive send_chase_email

### DIFF
--- a/app/services/commissioning_document_email_service.rb
+++ b/app/services/commissioning_document_email_service.rb
@@ -39,7 +39,7 @@ private
   def send_emails
     emails = data_request_area.recipient_emails
 
-    # NOTE: # must use deliver_later! method or Notify ID cannot be saved due to limitations of govuk_notify_rails gem
+    # NOTE: must use deliver_later! method or Notify ID cannot be saved due to limitations of govuk_notify_rails gem
     emails.map do |email|
       CommissioningDocumentMailer.commissioning_email(
         commissioning_document,

--- a/app/services/commissioning_document_email_service.rb
+++ b/app/services/commissioning_document_email_service.rb
@@ -39,12 +39,13 @@ private
   def send_emails
     emails = data_request_area.recipient_emails
 
+    # NOTE: # must use deliver_later! method or Notify ID cannot be saved due to limitations of govuk_notify_rails gem
     emails.map do |email|
       CommissioningDocumentMailer.commissioning_email(
         commissioning_document,
         data_request_area.offender_sar_case.number,
         email,
-      ).deliver_later! # must use deliver_later! method or Notify ID cannot be saved due to limitations of govuk_notify_rails gem
+      ).deliver_later!
     end
   end
 
@@ -52,12 +53,15 @@ private
     is_escalation_email = [DataRequestChase::OVERDUE_CHASE, DataRequestChase::ESCALATION_CHASE].include?(chase_type)
     emails = data_request_area.recipient_emails(escalated: is_escalation_email)
 
+    # NOTE: must use deliver_later! method or Notify ID cannot be saved due to limitations of govuk_notify_rails gem
     emails.map do |email|
-      CommissioningDocumentMailer.send(chase_type,
-                                       data_request_area.offender_sar_case,
-                                       commissioning_document,
-                                       email,
-                                       data_request_area.next_chase_number).deliver_later! # must use deliver_later! method or Notify ID cannot be saved due to limitations of govuk_notify_rails gem
+      CommissioningDocumentMailer.send(
+        chase_type,
+        data_request_area.offender_sar_case,
+        commissioning_document,
+        email,
+        data_request_area.next_chase_number,
+      ).deliver_later!
     end
   end
 

--- a/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
+++ b/config/state_machine/configs/00_moj/40_offender_sar/20_offender_sar_standard_workflow.yml
@@ -186,6 +186,7 @@
                 add_note_to_case:
                 add_data_received:
                 edit_case:
+                send_chase_email:
 
               closed:
                 add_note_to_case:

--- a/spec/services/commissioning_document_email_service_spec.rb
+++ b/spec/services/commissioning_document_email_service_spec.rb
@@ -120,5 +120,18 @@ RSpec.describe CommissioningDocumentEmailService do
         service.send_chase!(chase_type)
       end
     end
+
+    describe "when Offender SAR is stopped/paused" do
+      let(:chase_type) { DataRequestChase::STANDARD_CHASE }
+      let(:four_emails) { "test999@test.com\ntest998@test.com\ntest997@test.com\ntest996@test.com" }
+      let(:kase) { create(:offender_sar_case, :stopped, responder:) }
+      let(:contact) { create(:contact, data_request_emails: four_emails, escalation_emails: "escalation800@test.com") }
+
+      it "sends email" do
+        expect(CommissioningDocumentMailer).to receive(chase_type).exactly(4).times.and_return(mailer)
+        expect(mailer).to receive(:deliver_later!).exactly(4).times
+        service.send_chase!(chase_type)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
Allows Paused/Stopped Offender SARs to receive 'send_chase_email'

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-894

### Deployment
N/A

### Manual testing instructions
Allow scheduled `send_chase_emails` job to run at 9:00 AM