### PR TITLE
[CDPTKAN-1128] No longer validate mark_as_dirty and mark_as_clean

### DIFF
--- a/app/jobs/search_index_updater_job.rb
+++ b/app/jobs/search_index_updater_job.rb
@@ -6,7 +6,7 @@ class SearchIndexUpdaterJob < ApplicationJob
     kase = Case::Base.find(case_id)
     if kase
       kase.update_index
-      kase.mark_as_clean! if kase.dirty? && !kase.readonly?
+      kase.mark_as_clean if kase.dirty? && !kase.readonly?
     end
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -92,7 +92,7 @@ private
 
   def mark_case_as_dirty_for_responding_assignments
     if responding? && (new_record? || state_changed_to_rejected_or_bypassed?)
-      self.case.mark_as_dirty!
+      self.case.mark_as_dirty
       SearchIndexUpdaterJob.set(wait: 10.seconds).perform_later(self.case.id)
     end
   end

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -809,12 +809,14 @@ class Case::Base < ApplicationRecord
     update!(workflow: new_workflow_name)
   end
 
-  def mark_as_clean!
-    update!(dirty: false)
+  # `dirty` flag do does need to re-trigger all validations as it is only used by
+  # SearchIndexUpdaterJob to perform text indexing of the case.
+  def mark_as_clean
+    update_column(:dirty, false)
   end
 
-  def mark_as_dirty!
-    update!(dirty: true)
+  def mark_as_dirty
+    update_column(:dirty, true)
   end
 
   def clean?

--- a/spec/factories/case/fois.rb
+++ b/spec/factories/case/fois.rb
@@ -643,7 +643,7 @@ FactoryBot.define do
   end
 
   trait :clean do
-    after(:create, &:mark_as_clean!)
+    after(:create, &:mark_as_clean)
   end
 
   trait :indexed do

--- a/spec/models/assignment_spec.rb
+++ b/spec/models/assignment_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Assignment, type: :model do
         let(:assignment) { create :assignment, :responding, case_id: kase.id }
 
         before do
-          assignment.case.mark_as_clean!
+          assignment.case.mark_as_clean
         end
 
         context "and state changed to rejected" do
@@ -324,7 +324,7 @@ RSpec.describe Assignment, type: :model do
       context "and updated assignment" do
         it "does not mark the case as dirty" do
           assignment = create :assignment, :managing, case_id: kase.id
-          kase.mark_as_clean!
+          kase.mark_as_clean
           assignment.update!(state: "accepted")
           expect(kase.reload).to be_clean
         end
@@ -367,7 +367,7 @@ RSpec.describe Assignment, type: :model do
       context "and updated assignment" do
         it "does not mark the case as dirty" do
           assignment = create :assignment, :approving, case_id: kase.id
-          kase.mark_as_clean!
+          kase.mark_as_clean
           assignment.update!(state: "accepted")
           expect(kase.reload).to be_clean
         end

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -1438,10 +1438,64 @@ RSpec.describe Case::Base, type: :model do
     end
   end
 
-  describe "#mark_as_clean!" do
+  describe "#mark_as_clean" do
     it "update index and flag is clean afer creation" do
       kase = create :case
       expect(kase).not_to be_dirty
+    end
+
+    it "clears the dirty flag" do
+      kase = create :case
+      kase.mark_as_dirty
+      kase.mark_as_clean
+      expect(kase.reload).not_to be_dirty
+    end
+
+    context "when the case is otherwise invalid" do
+      # Mimics an auto-closed case left with a blank date_responded, which would
+      # fail ClosedCaseValidator if the dirty flag were saved with validations.
+      let(:kase) { create :sar_case, :clean }
+
+      before do
+        kase.assign_attributes(current_state: "closed", date_responded: nil)
+        kase.save!(validate: false)
+        kase.mark_as_dirty
+      end
+
+      it "is not valid" do
+        expect(kase.reload).not_to be_valid
+      end
+
+      it "persists the clean flag without running validations" do
+        expect { kase.mark_as_clean }.not_to raise_error
+        expect(kase.reload).not_to be_dirty
+      end
+    end
+  end
+
+  describe "#mark_as_dirty" do
+    it "sets the dirty flag" do
+      kase = create :case, :clean
+      kase.mark_as_dirty
+      expect(kase.reload).to be_dirty
+    end
+
+    context "when the case is otherwise invalid" do
+      let(:kase) { create :sar_case, :clean }
+
+      before do
+        kase.assign_attributes(current_state: "closed", date_responded: nil)
+        kase.save!(validate: false)
+      end
+
+      it "is not valid" do
+        expect(kase.reload).not_to be_valid
+      end
+
+      it "persists the dirty flag without running validations" do
+        expect { kase.mark_as_dirty }.not_to raise_error
+        expect(kase.reload).to be_dirty
+      end
     end
   end
 


### PR DESCRIPTION
## Description
Prevents `SearchIndexUpdaterJob` from failing and clogging up the background jobs queue unnecessarily. Main reason for failure is correctly auto-closed cases that will not have the `date_responded` field set, triggering validation error prior to this change.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1128

### Deployment
Clear out the background jobs queue (see CDPTKAN-1126).

### Manual testing instructions
Find a case and auto_close it via the auto close job `bundle exec rake sar:auto_close_paused`