### PR TITLE
[CDTPKAN-1131] Updates rubocop namespace RSpec/FilePath to Rails/FilePath

### DIFF
--- a/spec/controllers/assignments_controller/accept_spec.rb
+++ b/spec/controllers/assignments_controller/accept_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSpec/FilePath
+RSpec.describe AssignmentsController, type: :controller do # rubocop:disable Rails/FilePath
   let(:awaiting_responder_case) { create :awaiting_responder_case }
   let(:assignment) { awaiting_responder_case.responder_assignment }
   let(:responding_team) { assignment.team }

--- a/spec/controllers/assignments_controller/assign_to_team_member_spec.rb
+++ b/spec/controllers/assignments_controller/assign_to_team_member_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSpec/FilePath
+RSpec.describe AssignmentsController, type: :controller do # rubocop:disable Rails/FilePath
   let(:responding_team) { unassigned_case.responding_team }
   let(:responder) { responding_team.responders.first }
   let(:unassigned_case) { create :offender_sar_complaint }

--- a/spec/controllers/assignments_controller/assign_to_team_spec.rb
+++ b/spec/controllers/assignments_controller/assign_to_team_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSpec/FilePath
+RSpec.describe AssignmentsController, type: :controller do # rubocop:disable Rails/FilePath
   let(:manager)           { create :manager }
   let(:unassigned_case)   { create :case }
   let(:responding_team)   { create :responding_team }

--- a/spec/controllers/assignments_controller/execute_assign_to_team_member_spec.rb
+++ b/spec/controllers/assignments_controller/execute_assign_to_team_member_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSpec/FilePath
+RSpec.describe AssignmentsController, type: :controller do # rubocop:disable Rails/FilePath
   let(:responding_team)       { unassigned_case.responding_team }
   let(:responder)             { responding_team.responders.first }
   let(:another_responder)     { create :responder, responding_teams: [responding_team] }

--- a/spec/controllers/assignments_controller/execute_reassign_user_spec.rb
+++ b/spec/controllers/assignments_controller/execute_reassign_user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSpec/FilePath
+RSpec.describe AssignmentsController, type: :controller do # rubocop:disable Rails/FilePath
   let(:responding_team)       { accepted_case.responding_team }
   let(:responder)             { responding_team.responders.first }
   let(:another_responder)     { create :responder, responding_teams: [responding_team] }

--- a/spec/controllers/assignments_controller/new_spec.rb
+++ b/spec/controllers/assignments_controller/new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSpec/FilePath
+RSpec.describe AssignmentsController, type: :controller do # rubocop:disable Rails/FilePath
   let(:responding_team_1)   { create :responding_team }
   let(:responding_team_2)   { create :responding_team }
   let(:responding_team_3)   { create :responding_team }

--- a/spec/controllers/assignments_controller/reassign_user_spec.rb
+++ b/spec/controllers/assignments_controller/reassign_user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AssignmentsController, type: :controller do # rubocop:disable RSpec/FilePath
+RSpec.describe AssignmentsController, type: :controller do # rubocop:disable Rails/FilePath
   let(:responding_team)   { accepted_case.responding_team }
   let(:responder)         { responding_team.responders.first }
   let(:approver)          { create :approver }

--- a/spec/controllers/cases/filters_controller/filters_controller_spec.rb
+++ b/spec/controllers/cases/filters_controller/filters_controller_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Cases::FiltersController, type: :controller do # rubocop:disable RSpec/FilePath
+describe Cases::FiltersController, type: :controller do # rubocop:disable Rails/FilePath
   let(:manager)               { find_or_create :disclosure_specialist_bmt }
   let(:responder)             { find_or_create :foi_responder }
   let(:disclosure_specialist) { find_or_create :disclosure_specialist }

--- a/spec/controllers/cases/filters_controller/open_spec.rb
+++ b/spec/controllers/cases/filters_controller/open_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Cases::FiltersController, type: :controller do # rubocop:disable RSpec/FilePath
+describe Cases::FiltersController, type: :controller do # rubocop:disable Rails/FilePath
   let(:user) { find_or_create :disclosure_bmt_user }
   let(:open_cases) { Case::Base.opened }
 

--- a/spec/controllers/cases/filters_controller/state_filter_spec.rb
+++ b/spec/controllers/cases/filters_controller/state_filter_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Cases::FiltersController, type: :controller do # rubocop:disable RSpec/FilePath
+RSpec.describe Cases::FiltersController, type: :controller do # rubocop:disable Rails/FilePath
   let(:params) do
     {
       "state_selector" => {

--- a/spec/controllers/cases/responses_controller/upload_response_and_approve_spec.rb
+++ b/spec/controllers/cases/responses_controller/upload_response_and_approve_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Cases::ResponsesController, type: :controller do # rubocop:disable RSpec/FilePath
+describe Cases::ResponsesController, type: :controller do # rubocop:disable Rails/FilePath
   let(:responded_trigger_case) { create :pending_dacu_clearance_case }
   let(:approver)               { responded_trigger_case.approvers.first }
 

--- a/spec/controllers/cases/responses_controller/upload_response_and_return_for_redraft_spec.rb
+++ b/spec/controllers/cases/responses_controller/upload_response_and_return_for_redraft_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Cases::ResponsesController, type: :controller do # rubocop:disable RSpec/FilePath
+describe Cases::ResponsesController, type: :controller do # rubocop:disable Rails/FilePath
   let(:responded_trigger_case) { create :pending_dacu_clearance_case }
   let(:approver)               { responded_trigger_case.approvers.first }
 

--- a/spec/controllers/cases/responses_controller/upload_responses_spec.rb
+++ b/spec/controllers/cases/responses_controller/upload_responses_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Cases::ResponsesController, type: :controller do # rubocop:disable RSpec/FilePath
+describe Cases::ResponsesController, type: :controller do # rubocop:disable Rails/FilePath
   let(:responder)     { find_or_create :foi_responder }
   let(:accepted_case) { create(:accepted_case) }
 

--- a/spec/controllers/cases_controller/confirm_destroy_spec.rb
+++ b/spec/controllers/cases_controller/confirm_destroy_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe CasesController, type: :controller do # rubocop:disable RSpec/FilePath
+describe CasesController, type: :controller do # rubocop:disable Rails/FilePath
   describe "GET confirm_destroy" do
     let(:manager)           { create :manager }
     let(:unassigned_case)   { create :case }

--- a/spec/controllers/cases_controller/destroy_spec.rb
+++ b/spec/controllers/cases_controller/destroy_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe CasesController, type: :controller do # rubocop:disable RSpec/FilePath
+describe CasesController, type: :controller do # rubocop:disable Rails/FilePath
   describe "GET destroy_case" do
     let(:manager)           { create :manager }
     let(:params)            { { id: kase.id, case: { reason_for_deletion: "I was told to" } } }

--- a/spec/controllers/cases_controller/new_spec.rb
+++ b/spec/controllers/cases_controller/new_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe CasesController, type: :controller do # rubocop:disable RSpec/FilePath
+describe CasesController, type: :controller do # rubocop:disable Rails/FilePath
   describe "#select_type" do
     context "when a manager" do
       let(:manager) { find_or_create :disclosure_bmt_user }

--- a/spec/controllers/cases_controller/permitted_correspondence_types_spec.rb
+++ b/spec/controllers/cases_controller/permitted_correspondence_types_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe CasesController, type: :controller do # rubocop:disable RSpec/FilePath
+describe CasesController, type: :controller do # rubocop:disable Rails/FilePath
   let(:manager)       { find_or_create :disclosure_bmt_user }
   let(:responder)     { find_or_create :branston_user }
   let(:controller)    { described_class.new }

--- a/spec/controllers/cases_controller/show_spec.rb
+++ b/spec/controllers/cases_controller/show_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe CasesController, type: :controller do # rubocop:disable RSpec/FilePath
+describe CasesController, type: :controller do # rubocop:disable Rails/FilePath
   describe "#show" do
     let(:manager)            { create :manager }
     let(:responding_team)    { find_or_create :foi_responding_team }

--- a/spec/models/case/scopes_spec.rb
+++ b/spec/models/case/scopes_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 # rubocop:disable RSpec/InstanceVariable, RSpec/BeforeAfterAll
-RSpec.describe Case::Base, type: :model do # rubocop:disable RSpec/FilePath
+RSpec.describe Case::Base, type: :model do # rubocop:disable Rails/FilePath
   let(:responding_team) { find_or_create :foi_responding_team }
   let(:responder)       { responding_team.responders.first }
   let(:co_responder)    do

--- a/spec/policies/base_policy_scope_spec.rb
+++ b/spec/policies/base_policy_scope_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 # rubocop:disable RSpec/InstanceVariable, RSpec/BeforeAfterAll
-describe Case::BasePolicy::Scope do # rubocop:disable RSpec/FilePath
+describe Case::BasePolicy::Scope do # rubocop:disable Rails/FilePath
   describe "case scope policy" do
     before(:all) do
       @responding_team              = find_or_create :foi_responding_team

--- a/spec/policies/report_type_policy_spec.rb
+++ b/spec/policies/report_type_policy_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 # rubocop:disable RSpec/InstanceVariable, RSpec/BeforeAfterAll
-describe ReportTypePolicy::Scope do # rubocop:disable RSpec/FilePath
+describe ReportTypePolicy::Scope do # rubocop:disable Rails/FilePath
   describe "report type scope policy" do
     before(:all) do
       DbHousekeeping.clean(seed: true)

--- a/spec/state_machines/workflows/foi_permitted_events/full_approval_spec.rb
+++ b/spec/state_machines/workflows/foi_permitted_events/full_approval_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   let(:press_officer) { find_or_create :press_officer }
 
   describe "full_approval workflow" do

--- a/spec/state_machines/workflows/foi_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/foi_permitted_events/standard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "standard workflow" do
     ##################### MANAGER  ############################
 

--- a/spec/state_machines/workflows/foi_permitted_events/trigger_spec.rb
+++ b/spec/state_machines/workflows/foi_permitted_events/trigger_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "trigger workflow" do
     ##################### MANAGER FLAGGED ############################
 

--- a/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
+++ b/spec/state_machines/workflows/ico_permitted_events_spec/ico_appeal_trigger_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "trigger ico workflow" do
     ##################### MANAGER FLAGGED ############################
 

--- a/spec/state_machines/workflows/offender_sar_complaint_permitted_events/ico_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_complaint_permitted_events/ico_spec.rb
@@ -106,7 +106,7 @@ UNIVERSAL_EVENTS_ICO = %i[
   reassign_user
 ].freeze
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "with ico workflow Offender SAR Complaint case" do
     context "when responder" do
       let(:responder) { find_or_create :branston_user }

--- a/spec/state_machines/workflows/offender_sar_complaint_permitted_events/litigation_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_complaint_permitted_events/litigation_spec.rb
@@ -127,7 +127,7 @@ UNIVERSAL_EVENTS_LITIGATION = %i[
   reassign_user
 ].freeze
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "with litigation workflow Offender SAR Complaint case" do
     context "with responder" do
       let(:responder) { find_or_create :branston_user }

--- a/spec/state_machines/workflows/offender_sar_complaint_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_complaint_permitted_events/standard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "with standard workflow Offender SAR Complaint case" do
     def universal_events_standards
       %i[

--- a/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/offender_sar_permitted_events/standard_spec.rb
@@ -114,7 +114,7 @@ UNIVERSAL_EVENTS = %i[
   edit_case
 ].freeze
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "with standard workflow Offender SAR case" do
     def offender_sar_case(with_state:)
       create :offender_sar_case, with_state

--- a/spec/state_machines/workflows/overturned_foi_permitted_events/full_approval_spec.rb
+++ b/spec/state_machines/workflows/overturned_foi_permitted_events/full_approval_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "full_approval workflow" do
     ##################### MANAGER FLAGGED ############################
 

--- a/spec/state_machines/workflows/overturned_foi_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/overturned_foi_permitted_events/standard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "standard workflow" do
     ##################### MANAGER  ############################
 

--- a/spec/state_machines/workflows/overturned_foi_permitted_events/trigger_spec.rb
+++ b/spec/state_machines/workflows/overturned_foi_permitted_events/trigger_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "trigger workflow" do
     ##################### MANAGER  ############################
 

--- a/spec/state_machines/workflows/overturned_sar_permitted_events/standard_spec.rb
+++ b/spec/state_machines/workflows/overturned_sar_permitted_events/standard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   context "when non-flagged case" do
     context "and manager" do
       let(:manager) { create :manager }

--- a/spec/state_machines/workflows/overturned_sar_permitted_events/trigger_spec.rb
+++ b/spec/state_machines/workflows/overturned_sar_permitted_events/trigger_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   context "when flagged case" do
     context "and manager" do
       let(:manager) { find_or_create :disclosure_bmt_user }

--- a/spec/state_machines/workflows/sar_internal_review_permitted_events/sar_internal_review_trigger_spec.rb
+++ b/spec/state_machines/workflows/sar_internal_review_permitted_events/sar_internal_review_trigger_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   context "when flagged case" do
     context "and manager" do
       let(:manager) { find_or_create :disclosure_bmt_user }

--- a/spec/state_machines/workflows/sar_permitted_events/sar_standard_spec.rb
+++ b/spec/state_machines/workflows/sar_permitted_events/sar_standard_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   context "when non-flagged case" do
     context "and manager" do
       let(:manager) { create :manager }

--- a/spec/state_machines/workflows/sar_permitted_events/sar_trigger_spec.rb
+++ b/spec/state_machines/workflows/sar_permitted_events/sar_trigger_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe ConfigurableStateMachine::Machine do # rubocop:disable RSpec/FilePath
+describe ConfigurableStateMachine::Machine do # rubocop:disable Rails/FilePath
   describe "flagged case" do
     context "when manager" do
       let(:manager) { find_or_create :disclosure_bmt_user }


### PR DESCRIPTION
## Description
No change to functionality. Prevents rubocop warnings.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
#### BEFORE
![Uploading Screenshot 2026-06-18 at 10.20.43.png…]()


#### AFTER
<img width="1083" height="305" alt="Screenshot 2026-06-18 at 10 20 54" src="https://github.com/user-attachments/assets/0f676f72-8e4f-4d9b-8b72-4435c3806934" />



### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1131

### Deployment
N/A
### Manual testing instructions
N/A
