### PR TITLE
[CDPTKAN-1083] Introduce Remove SAR Deadline Extension UI (part 3)

### DIFF
--- a/app/controllers/cases/sar_extensions_controller.rb
+++ b/app/controllers/cases/sar_extensions_controller.rb
@@ -21,7 +21,7 @@ module Cases
 
       case service.result
       when :ok
-        flash[:notice] = t(".success", case_type: @case.correspondence_type.shortname)
+        flash[:notice] = t(".success")
         redirect_to case_path(@case.id)
       when :validation_error
         @case = CaseExtendSARDeadlineDecorator.decorate @case

--- a/app/controllers/cases/sar_extensions_controller.rb
+++ b/app/controllers/cases/sar_extensions_controller.rb
@@ -2,7 +2,7 @@ module Cases
   class SARExtensionsController < ApplicationController
     include SetupCase
 
-    before_action :set_case, only: %i[new create destroy]
+    before_action :set_case, only: %i[new create edit destroy]
 
     def new
       authorize @case, :extend_sar_deadline?
@@ -33,18 +33,33 @@ module Cases
       end
     end
 
+    def edit
+      authorize @case, :remove_sar_deadline_extension?
+      @case = CaseRemoveSARDeadlineExtensionDecorator.decorate @case
+    end
+
     def destroy
       authorize @case, :remove_sar_deadline_extension?
 
-      service = CaseRemoveSARDeadlineExtensionService.new(current_user, @case)
+      service = CaseRemoveSARDeadlineExtensionService.new(
+        current_user,
+        @case,
+        reason: params.dig(:case, :reason_for_removing_extension),
+      )
       service.call
 
-      if service.result == :ok
+      case service.result
+      when :ok
         flash[:notice] = t(".success", case_type: @case.correspondence_type.shortname)
+        redirect_to case_path(@case.id)
+      when :validation_error
+        @case = CaseRemoveSARDeadlineExtensionDecorator.decorate @case
+        @case.reason_for_removing_extension = params.dig(:case, :reason_for_removing_extension)
+        render :edit
       else
         flash[:alert] = t(".error", case_type: @case.correspondence_type.shortname)
+        redirect_to case_path(@case.id)
       end
-      redirect_to case_path(@case.id)
     end
   end
 end

--- a/app/decorators/case_remove_sar_deadline_extension_decorator.rb
+++ b/app/decorators/case_remove_sar_deadline_extension_decorator.rb
@@ -1,0 +1,6 @@
+class CaseRemoveSARDeadlineExtensionDecorator < Draper::Decorator
+  decorates Case::Base
+  delegate_all
+
+  attr_accessor :reason_for_removing_extension
+end

--- a/app/decorators/case_remove_sar_deadline_extension_decorator.rb
+++ b/app/decorators/case_remove_sar_deadline_extension_decorator.rb
@@ -3,4 +3,15 @@ class CaseRemoveSARDeadlineExtensionDecorator < Draper::Decorator
   delegate_all
 
   attr_accessor :reason_for_removing_extension
+
+  # The external deadline the case reverts to once the extension is removed.
+  def reverted_deadline
+    @reverted_deadline ||= object.recalculate_deadline_without_extensions
+  end
+
+  # True when removing the extension would put the deadline in the past,
+  # i.e. completing the journey makes the case late.
+  def removal_makes_case_late?
+    reverted_deadline.past?
+  end
 end

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -206,9 +206,9 @@ module CasesHelper
               class: "govuk-button moj-button-menu__item govuk-button--secondary"
     when :remove_sar_deadline_extension
       link_to I18n.t("common.case.remove_sar_deadline_extension"),
-              case_sar_extensions_path(@case),
+              edit_case_sar_extensions_path(@case),
               id: "action--remove-extended-deadline-for-sar",
-              class: "govuk-button moj-button-menu__item govuk-button--secondary", method: :delete
+              class: "govuk-button moj-button-menu__item govuk-button--secondary"
     when :record_data_request_area
       link_to "Record data request",
               new_case_data_request_area_path(@case),

--- a/app/services/case_extend_sar_deadline_service.rb
+++ b/app/services/case_extend_sar_deadline_service.rb
@@ -41,10 +41,9 @@ private
 
   def message
     [
-      @reason,
-      "Deadline extended by #{@case.time_period_description(@extension_period.to_i)}\n",
-      "Old final deadline: #{I18n.localize(@case.external_deadline, format: :long)}",
-      "New final deadline: #{I18n.localize(@extension_deadline, format: :long)}",
+      "Previous deadline: #{I18n.localize(@case.external_deadline, format: :long)}",
+      "New deadline: #{I18n.localize(@extension_deadline, format: :long)}",
+      "Reason: #{@reason}",
     ].join("\n")
   end
 

--- a/app/services/case_remove_sar_deadline_extension_service.rb
+++ b/app/services/case_remove_sar_deadline_extension_service.rb
@@ -1,22 +1,27 @@
 class CaseRemoveSARDeadlineExtensionService
   attr_reader :result, :error
 
-  def initialize(user, kase)
+  def initialize(user, kase, reason: nil)
     @user = user
-    @case = kase
+    @case = CaseRemoveSARDeadlineExtensionDecorator.decorate kase
+    @reason = reason
     @result = :incomplete
   end
 
   def call
     ActiveRecord::Base.transaction do
-      @case.state_machine.remove_sar_deadline_extension!(
-        acting_user: @user,
-        acting_team: @user.case_team(@case),
-        message:,
-      )
+      if valid?
+        @case.state_machine.remove_sar_deadline_extension!(
+          acting_user: @user,
+          acting_team: @user.case_team(@case),
+          message:,
+        )
 
-      @case.reset_deadline!
-      @result = :ok
+        @case.reset_deadline!
+        @result = :ok
+      else
+        @result = :validation_error
+      end
     end
     @result
   rescue StandardError => e
@@ -28,9 +33,21 @@ class CaseRemoveSARDeadlineExtensionService
 
 private
 
+  def valid?
+    if @reason.blank?
+      @case.errors.add(
+        :reason_for_removing_extension,
+        "cannot be blank",
+      )
+    end
+
+    @case.errors.empty?
+  end
+
   # TODO: Refactor as this is confusing
   def message
     [
+      @reason,
       "Old final deadline: #{I18n.localize(@case.external_deadline, format: :long)}",
       "New final deadline: #{I18n.localize(@case.recalculate_deadline_without_extensions, format: :long)}",
     ].join("\n")

--- a/app/services/case_remove_sar_deadline_extension_service.rb
+++ b/app/services/case_remove_sar_deadline_extension_service.rb
@@ -44,12 +44,11 @@ private
     @case.errors.empty?
   end
 
-  # TODO: Refactor as this is confusing
   def message
     [
-      @reason,
-      "Old final deadline: #{I18n.localize(@case.external_deadline, format: :long)}",
-      "New final deadline: #{I18n.localize(@case.recalculate_deadline_without_extensions, format: :long)}",
+      "Previous deadline: #{I18n.localize(@case.external_deadline, format: :long)}",
+      "New deadline: #{I18n.localize(@case.recalculate_deadline_without_extensions, format: :long)}",
+      "Reason: #{@reason}",
     ].join("\n")
   end
 end

--- a/app/views/cases/sar_extensions/edit.html.slim
+++ b/app/views/cases/sar_extensions/edit.html.slim
@@ -28,8 +28,8 @@ p
 
   - if @case.removal_makes_case_late?
     .govuk-warning-text
-      .govuk-warning-text__icon, aria-hidden="true" !
-      strong.govuk-warning-text__text
+      .govuk-warning-text__icon aria-hidden="true" !
+      strong.govuk-warning-text__text.govuk-body-l
         .govuk-visually-hidden Warning
         = t('.late_notice')
 

--- a/app/views/cases/sar_extensions/edit.html.slim
+++ b/app/views/cases/sar_extensions/edit.html.slim
@@ -1,0 +1,36 @@
+- content_for :page_title do
+  = t('page_title.remove_sar_deadline_extension', case_type: @case.correspondence_type.shortname, case_number: @case.number)
+
+- content_for :heading
+  = t('common.case.remove_sar_deadline_extension')
+
+- content_for :sub_heading
+  span.visually-hidden
+    = t('common.case.header_case_number')
+  = @case.number
+
+= render partial: 'layouts/header'
+
+= GovukElementsErrorsHelper.error_summary @case.object,
+    "#{pluralize(@case.errors.count, t('common.error'))} #{ t('common.summary_error')}",
+    ""
+
+p
+    = t('.summary')
+
+= form_for @case, as: :case, url: case_sar_extensions_path(@case), method: :delete do |f|
+
+  div.govuk-inset-text
+    p
+      = t('.current_deadline_html', date: l(@case.external_deadline, format: :long))
+    p
+      = t('.new_deadline_html', date: l(@case.recalculate_deadline_without_extensions, format: :long))
+
+  .form-group
+    = f.text_area :reason_for_removing_extension
+
+  .button-holder
+    = submit_tag 'Remove extension', class: 'button'
+    = link_to('Cancel',
+        case_path(@case),
+        class: 'acts-like-button button-left-spacing')

--- a/app/views/cases/sar_extensions/edit.html.slim
+++ b/app/views/cases/sar_extensions/edit.html.slim
@@ -24,7 +24,14 @@ p
     p
       = t('.current_deadline_html', date: l(@case.external_deadline, format: :long))
     p
-      = t('.new_deadline_html', date: l(@case.recalculate_deadline_without_extensions, format: :long))
+      = t('.new_deadline_html', date: l(@case.reverted_deadline, format: :long))
+
+  - if @case.removal_makes_case_late?
+    .govuk-warning-text
+      .govuk-warning-text__icon, aria-hidden="true" !
+      strong.govuk-warning-text__text
+        .govuk-visually-hidden Warning
+        = t('.late_notice')
 
   .form-group
     = f.text_area :reason_for_removing_extension

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1628,10 +1628,10 @@ en:
         close_date:  Date response sent
     sar_extensions:
       create:
-        success: Case extended for %{case_type}
+        success: The deadline has been extended by 2 months.
         error: Unable to perform %{case_type} extension on case %{case_number}
       destroy:
-        success: Deadline extension removed
+        success: The deadline extension has been removed.
         error: Unable to remove %{case_type} deadline extension
       edit:
         summary: This will take 2 calendar months off the deadline.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1637,6 +1637,7 @@ en:
         summary: This will take 2 calendar months off the deadline.
         current_deadline_html: "<strong>Current deadline:</strong> %{date}"
         new_deadline_html: "<strong>New deadline:</strong> %{date}"
+        late_notice: This will make the case late as the new deadline is in the past.
       new:
         extension_period: How long would you like to extend by?
         extend_further: The deadline for this case will be extended by a further %{time_period_description}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -756,6 +756,7 @@ en:
         add_note: Add a note to this case
         linked_case_number: Case number For example 170131001
         reason_for_extending: Add your reasons for extending the deadline
+        reason_for_removing_extension: Add your reasons for removing the deadline extension
       contact:
         escalation_name: Prison governor
         escalation_emails: Prison governor email
@@ -1632,6 +1633,10 @@ en:
       destroy:
         success: Deadline extension removed
         error: Unable to remove %{case_type} deadline extension
+      edit:
+        summary: This will take 2 calendar months off the deadline.
+        current_deadline_html: "<strong>Current deadline:</strong> %{date}"
+        new_deadline_html: "<strong>New deadline:</strong> %{date}"
       new:
         extension_period: How long would you like to extend by?
         extend_further: The deadline for this case will be extended by a further %{time_period_description}.

--- a/config/locales/event.en.yml
+++ b/config/locales/event.en.yml
@@ -22,7 +22,7 @@ en:
     destroy: Destroyed
     edit_case: Case details edited
     extend_for_pit: Extended for Public Interest Test (PIT)
-    extend_sar_deadline: Extended SAR deadline
+    extend_sar_deadline: Deadline extended by 2 months
     flag_for_clearance: Clearance level added
     link_a_case: Case linked
     move_to_team_member: Assign responder

--- a/config/locales/page_titles.en.yml
+++ b/config/locales/page_titles.en.yml
@@ -55,6 +55,7 @@ en:
     edit_case_page: Editing a case - %{case_number} - Track-a-query
     edit_user_page: Edit team member - %{team_name} - Track-a-query
     extend_sar_deadline: Extend deadline for %{case_type} - %{case_number}
+    remove_sar_deadline_extension: Remove the deadline extension for %{case_type} - %{case_number}
     forgot_password: Forgot your password - Track-a-query
     accepted_date_received: Accepted date received - %{case_number} - Track-a-query
     join_team_page: Joining a business unit - %{team_name} - Track-a-query

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,7 +190,7 @@ Rails.application.routes.draw do
     resource :pit_extensions, only: [:destroy]
 
     resources :sar_extensions, only: %i[new create]
-    resource :sar_extensions, only: [:destroy]
+    resource :sar_extensions, only: %i[edit destroy]
 
     resources :stop_the_clocks, only: %i[new create]
     resources :restart_the_clocks, only: %i[new create]

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -7,7 +7,7 @@
 
 | Ticket | Description | Status | Last Updated | Branch |
 |--------|-------------|--------|--------------|--------|
-| CDPTKAN-1081 | Extend SAR deadline → single fixed 2-month extension (Standard + Offender SAR; Internal Review unchanged). See [ADR 001](../decisions/001-fixed-single-sar-deadline-extension.md). | Implemented, tests pass; awaiting PR | 2026-06-17 | cdptkan-1081-alter-extend-sar-deadline-ui |
+| CDPTKAN-1083 | SAR deadline extension UI overhaul (also covers CDPTKAN-1081 extend work): (1) single fixed 2-month extension for Standard + Offender SAR, Internal Review unchanged — see [ADR 001](../decisions/001-fixed-single-sar-deadline-extension.md); (2) extend interstitial — fixed copy, bold current/new deadlines, relabelled reason field; (3) new "Remove deadline extension" interstitial — confirm page with current/reverted deadlines + required reason. | Implemented, specs pass; awaiting PR | 2026-06-19 | cdptkan-1083-alter-remove-sar-deadline-ui |
 
 ## How to Use
 

--- a/spec/controllers/cases/sar_extensions_controller_spec.rb
+++ b/spec/controllers/cases/sar_extensions_controller_spec.rb
@@ -66,7 +66,7 @@ describe Cases::SARExtensionsController, type: :controller do
       end
 
       it "notifies the user of the success" do
-        expect(request.flash[:notice]).to eq "Case extended for SAR"
+        expect(request.flash[:notice]).to eq "The deadline has been extended by 2 months."
       end
     end
 
@@ -156,7 +156,7 @@ describe Cases::SARExtensionsController, type: :controller do
       end
 
       it "notifies the user of the success" do
-        expect(request.flash[:notice]).to eq "Deadline extension removed"
+        expect(request.flash[:notice]).to eq "The deadline extension has been removed."
       end
     end
 

--- a/spec/controllers/cases/sar_extensions_controller_spec.rb
+++ b/spec/controllers/cases/sar_extensions_controller_spec.rb
@@ -104,17 +104,91 @@ describe Cases::SARExtensionsController, type: :controller do
     end
   end
 
-  describe "#destroy" do
+  describe "#edit" do
     it "authorizes" do
       expect {
-        delete :destroy,
-               params: {
-                 case_id: extended_sar_case.id,
-               }
-      }.to require_permission(:remove_sar_deadline_extension?).with_args(
-        manager,
-        extended_sar_case,
-      )
+        get :edit, params: {
+          case_id: extended_sar_case.id,
+        }
+      }.to require_permission(:remove_sar_deadline_extension?).with_args(manager, extended_sar_case)
+      expect(assigns(:case)).to be_a CaseRemoveSARDeadlineExtensionDecorator
+    end
+  end
+
+  describe "#destroy" do
+    let(:remove_service) do
+      instance_double(CaseRemoveSARDeadlineExtensionService, call: :ok, result: :ok)
+    end
+
+    let(:delete_params) do
+      {
+        case_id: extended_sar_case.id,
+        case: {
+          reason_for_removing_extension: "no longer needed",
+        },
+      }
+    end
+
+    before do
+      allow(CaseRemoveSARDeadlineExtensionService).to receive(:new).and_return(remove_service)
+    end
+
+    it "authorizes" do
+      expect { delete :destroy, params: delete_params }
+        .to require_permission(:remove_sar_deadline_extension?).with_args(manager, extended_sar_case)
+    end
+
+    context "with valid params" do
+      before do
+        delete :destroy, params: delete_params
+      end
+
+      it "calls the CaseRemoveSARDeadlineExtensionService" do
+        expect(CaseRemoveSARDeadlineExtensionService).to(
+          have_received(:new).with(
+            manager,
+            extended_sar_case,
+            reason: "no longer needed",
+          ),
+        )
+
+        expect(remove_service).to have_received(:call)
+      end
+
+      it "notifies the user of the success" do
+        expect(request.flash[:notice]).to eq "Deadline extension removed"
+      end
+    end
+
+    context "with invalid params" do
+      let(:remove_service) do
+        instance_double(
+          CaseRemoveSARDeadlineExtensionService,
+          call: :validation_error,
+          result: :validation_error,
+        )
+      end
+
+      it "renders the edit page" do
+        delete :destroy, params: delete_params
+        expect(request).to have_rendered(:edit)
+      end
+    end
+
+    context "when failed request" do
+      let(:remove_service) do
+        instance_double(
+          CaseRemoveSARDeadlineExtensionService,
+          call: :error,
+          result: :error,
+        )
+      end
+
+      it "notifies the user of the failure" do
+        delete :destroy, params: delete_params
+        expect(request.flash[:alert]).to eq "Unable to remove SAR deadline extension"
+        expect(request).to redirect_to(case_path(extended_sar_case.id))
+      end
     end
   end
 end

--- a/spec/decorators/case_remove_sar_deadline_extension_decorator_spec.rb
+++ b/spec/decorators/case_remove_sar_deadline_extension_decorator_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe CaseRemoveSARDeadlineExtensionDecorator, type: :model do
+  describe "initialize" do
+    subject(:remove_extension_decorator) do
+      described_class.decorate(create(:sar_case, :extended_deadline_sar))
+    end
+
+    it { is_expected.to have_attributes reason_for_removing_extension: nil }
+  end
+
+  describe "#removal_makes_case_late?" do
+    it "is false when the reverted deadline is not in the past" do
+      freeze_time do
+        kase = create(:sar_case, :extended_deadline_sar)
+
+        expect(described_class.decorate(kase).removal_makes_case_late?).to be false
+      end
+    end
+
+    it "is true when the reverted deadline is in the past" do
+      freeze_time do
+        kase = create(:sar_case, :extended_deadline_sar, received_date: Date.new(2022, 6, 1))
+
+        expect(described_class.decorate(kase).removal_makes_case_late?).to be true
+      end
+    end
+  end
+end

--- a/spec/features/cases/offender_sar/case_extending_deadline_spec.rb
+++ b/spec/features/cases/offender_sar/case_extending_deadline_spec.rb
@@ -30,12 +30,12 @@ feature "when extending an Offender SAR case deadline" do
       end
 
       expected_case_history = [
-        "Extended SAR deadline",
-        "Offender SAR extension ",
-        "Deadline extended by two calendar months\n",
-        "Old final deadline: 7 November 2022 ",
-        "New final deadline: 5 January 2023",
+        "Deadline extended by 2 months",
+        "Previous deadline: 7 November 2022 ",
+        "New deadline: 5 January 2023 ",
+        "Reason: Offender SAR extension",
       ]
+
       expect(cases_show_page.case_history.rows.first.details.text).to include(expected_case_history.join)
       expect(cases_show_page.case_status.deadlines.final.text).to eq(expected_extension_date)
 
@@ -71,7 +71,7 @@ feature "when extending an Offender SAR case deadline" do
       # 7. Submitting reverts to the deadline based on original received date plus paused/stopped days
       cases_remove_sar_deadline_extension_page.set_reason_for_removing_extension("Extension no longer needed")
       cases_remove_sar_deadline_extension_page.submit_button.click
-      expect(cases_show_page.notice.text).to eq "Deadline extension removed"
+      expect(cases_show_page.notice.text).to eq "The deadline extension has been removed."
 
       # 12th Nov is a Saturday, so next working day is 14th Nov
       expect(cases_show_page.case_status.deadlines.final.text).to eq("14 Nov 2022")

--- a/spec/features/cases/offender_sar/case_extending_deadline_spec.rb
+++ b/spec/features/cases/offender_sar/case_extending_deadline_spec.rb
@@ -61,10 +61,16 @@ feature "when extending an Offender SAR case deadline" do
       expect(cases_show_page).to be_displayed
       expect(cases_show_page.alert.text).to eq("SAR deadline cannot be extended")
 
-      # 6. Remove extension but final deadline should be based on original received date plus paused/stopped days
+      # 6. Removing shows the interstitial with the current and reverted deadlines
       cases_show_page.load(id: kase.id)
       cases_show_page.case_status.deadlines.actions.remove_sar_deadline_extension.click
-      expect(cases_show_page).to be_displayed
+      expect(cases_remove_sar_deadline_extension_page).to be_displayed
+      expect(page).to have_text("Current deadline: 10 January 2023")
+      expect(page).to have_text("New deadline: 14 November 2022")
+
+      # 7. Submitting reverts to the deadline based on original received date plus paused/stopped days
+      cases_remove_sar_deadline_extension_page.set_reason_for_removing_extension("Extension no longer needed")
+      cases_remove_sar_deadline_extension_page.submit_button.click
       expect(cases_show_page.notice.text).to eq "Deadline extension removed"
 
       # 12th Nov is a Saturday, so next working day is 14th Nov

--- a/spec/features/cases/sar/case_extending_deadline_spec.rb
+++ b/spec/features/cases/sar/case_extending_deadline_spec.rb
@@ -113,6 +113,19 @@ feature "when extending a SAR case deadline" do
       ]
       expect(cases_show_page.case_history.rows.first.details.text).to include(expected_case_history.join)
     end
+
+    scenario "warns on the remove page when reverting will make the case late" do
+      freeze_time do
+        late_kase = create :accepted_sar, :extended_deadline_sar, received_date: Date.new(2022, 6, 1)
+        login_as manager
+
+        cases_show_page.load(id: late_kase.id)
+        cases_show_page.case_status.deadlines.actions.remove_sar_deadline_extension.click
+
+        expect(cases_remove_sar_deadline_extension_page).to be_displayed
+        expect(page).to have_text("This will make the case late as the new deadline is in the past.")
+      end
+    end
   end
 
   context "with an approver" do

--- a/spec/features/cases/sar/case_extending_deadline_spec.rb
+++ b/spec/features/cases/sar/case_extending_deadline_spec.rb
@@ -45,9 +45,19 @@ feature "when extending a SAR case deadline" do
       expect(cases_show_page).to be_displayed
       expect(cases_show_page.alert.text).to eq("SAR deadline cannot be extended")
 
-      # 5. Remove extension should display initial deadline
+      # 5. Removing shows an interstitial page with the current and reverted deadlines
       cases_show_page.load(id: kase.id)
       cases_show_page.case_status.deadlines.actions.remove_sar_deadline_extension.click
+      expect(cases_remove_sar_deadline_extension_page).to be_displayed
+      expect(page).to have_text("Current deadline: 29 December 2022")
+      expect(page).to have_text("New deadline: 31 October 2022")
+      expect(page).to have_css("strong", text: "Current deadline:")
+      expect(page).to have_css("strong", text: "New deadline:")
+      expect(page).to have_text("Add your reasons for removing the deadline extension")
+
+      # 6. Submitting removes the extension and reverts to the initial deadline
+      cases_remove_sar_deadline_extension_page.set_reason_for_removing_extension("No longer required")
+      cases_remove_sar_deadline_extension_page.submit_button.click
       expect(cases_show_page).to be_displayed
       case_deadline_text_to_be(original_deadline.strftime("%-d %b %Y"))
     end
@@ -87,12 +97,18 @@ feature "when extending a SAR case deadline" do
       # Remove extension should display initial deadline 31 Oct 2022 plus the 4 paused days
       cases_show_page.load(id: kase.id)
       cases_show_page.case_status.deadlines.actions.remove_sar_deadline_extension.click
+      expect(cases_remove_sar_deadline_extension_page).to be_displayed
+      expect(page).to have_text("Current deadline: 4 January 2023")
+      expect(page).to have_text("New deadline: 4 November 2022")
+      cases_remove_sar_deadline_extension_page.set_reason_for_removing_extension("Paused for too long")
+      cases_remove_sar_deadline_extension_page.submit_button.click
       expect(cases_show_page.notice.text).to eq "Deadline extension removed"
       case_deadline_text_to_be("4 Nov 2022")
 
       expected_case_history = [
         "Deadline extension removed",
-        "Old final deadline: 4 January 2023 ",
+        "Paused for too long",
+        " Old final deadline: 4 January 2023 ",
         "New final deadline: 4 November 2022",
       ]
       expect(cases_show_page.case_history.rows.first.details.text).to include(expected_case_history.join)

--- a/spec/features/cases/sar/case_extending_deadline_spec.rb
+++ b/spec/features/cases/sar/case_extending_deadline_spec.rb
@@ -102,14 +102,14 @@ feature "when extending a SAR case deadline" do
       expect(page).to have_text("New deadline: 4 November 2022")
       cases_remove_sar_deadline_extension_page.set_reason_for_removing_extension("Paused for too long")
       cases_remove_sar_deadline_extension_page.submit_button.click
-      expect(cases_show_page.notice.text).to eq "Deadline extension removed"
+      expect(cases_show_page.notice.text).to eq "The deadline extension has been removed."
       case_deadline_text_to_be("4 Nov 2022")
 
       expected_case_history = [
         "Deadline extension removed",
-        "Paused for too long",
-        " Old final deadline: 4 January 2023 ",
-        "New final deadline: 4 November 2022",
+        "Previous deadline: 4 January 2023 ",
+        "New deadline: 4 November 2022 ",
+        "Reason: Paused for too long",
       ]
       expect(cases_show_page.case_history.rows.first.details.text).to include(expected_case_history.join)
     end

--- a/spec/services/case_extend_sar_deadline_service_spec.rb
+++ b/spec/services/case_extend_sar_deadline_service_spec.rb
@@ -30,7 +30,7 @@ describe CaseExtendSARDeadlineService do
               acting_team: acting_team,
               final_deadline: get_expected_deadline(3.months.since(kase.received_date)),
               original_final_deadline: initial_deadline,
-              message: "test\nDeadline extended by two calendar months\n\nOld final deadline: 31 October 2022\nNew final deadline: 29 December 2022",
+              message: "Previous deadline: 31 October 2022\nNew deadline: 29 December 2022\nReason: test",
             )
         end
 

--- a/spec/services/case_remove_sar_deadline_extension_service_spec.rb
+++ b/spec/services/case_remove_sar_deadline_extension_service_spec.rb
@@ -40,7 +40,7 @@ describe CaseRemoveSARDeadlineExtensionService do
           .with(
             acting_user: manager,
             acting_team: team_dacu,
-            message: "Old final deadline:  1 May 2025\nNew final deadline:  1 April 2025",
+            message: "Testing\nOld final deadline:  1 May 2025\nNew final deadline:  1 April 2025",
           )
       end
 
@@ -48,6 +48,27 @@ describe CaseRemoveSARDeadlineExtensionService do
         expect(sar_case.external_deadline).to eq initial_deadline
         expect(sar_case.external_deadline).to eq Date.new(2025, 4, 1)
         expect(sar_case.months_extended).to eq 0
+      end
+    end
+
+    context "when the reason is blank" do
+      let!(:sar_extension_remove_service_result) do
+        remove_sar_extension_service(manager, sar_case, reason: "").call
+      end
+
+      it { expect(sar_extension_remove_service_result).to eq :validation_error }
+
+      it "has an error message" do
+        expect(sar_case.errors[:reason_for_removing_extension]).to eq ["cannot be blank"]
+      end
+
+      it "does not reset the deadline" do
+        expect(sar_case.external_deadline).to eq Date.new(2025, 5, 1)
+        expect(sar_case.deadline_extended?).to be true
+      end
+
+      it "does not transition the case" do
+        expect(sar_case.state_machine).not_to have_received(:remove_sar_deadline_extension!)
       end
     end
 
@@ -95,10 +116,11 @@ describe CaseRemoveSARDeadlineExtensionService do
 
 private
 
-  def remove_sar_extension_service(user, kase)
+  def remove_sar_extension_service(user, kase, reason: "Testing")
     CaseRemoveSARDeadlineExtensionService.new(
       user,
       kase,
+      reason:,
     )
   end
 end

--- a/spec/services/case_remove_sar_deadline_extension_service_spec.rb
+++ b/spec/services/case_remove_sar_deadline_extension_service_spec.rb
@@ -40,7 +40,7 @@ describe CaseRemoveSARDeadlineExtensionService do
           .with(
             acting_user: manager,
             acting_team: team_dacu,
-            message: "Testing\nOld final deadline:  1 May 2025\nNew final deadline:  1 April 2025",
+            message: "Previous deadline:  1 May 2025\nNew deadline:  1 April 2025\nReason: Testing",
           )
       end
 

--- a/spec/services/csv_exporter_spec.rb
+++ b/spec/services/csv_exporter_spec.rb
@@ -200,6 +200,7 @@ describe CSVExporter do
             CaseRemoveSARDeadlineExtensionService.new(
               k.transitions.last.acting_user,
               k,
+              reason: "Extension no longer required",
             ).call
           end
         end

--- a/spec/site_prism/page_objects/pages/application.rb
+++ b/spec/site_prism/page_objects/pages/application.rb
@@ -108,6 +108,7 @@ module PageObjects
         confirm_destroy: "Cases::ConfirmDestroyPage",
         cases_extend_for_pit: "Cases::ExtendForPITPage",
         cases_extend_sar_deadline: "Cases::ExtendSARDeadlinePage",
+        cases_remove_sar_deadline_extension: "Cases::RemoveSARDeadlineExtensionPage",
         cases_stop_the_clock: "Cases::StopTheClockPage",
         data_request: "Cases::DataRequestPage",
         data_request_area: "Cases::DataRequestAreaPage",

--- a/spec/site_prism/page_objects/pages/cases/remove_sar_deadline_extension_page.rb
+++ b/spec/site_prism/page_objects/pages/cases/remove_sar_deadline_extension_page.rb
@@ -1,0 +1,27 @@
+module PageObjects
+  module Pages
+    module Cases
+      class RemoveSARDeadlineExtensionPage < SitePrism::Page
+        set_url "/cases/{id}/sar_extensions/edit"
+
+        section :primary_navigation,
+                PageObjects::Sections::PrimaryNavigationSection,
+                ".global-nav"
+
+        section :page_heading,
+                PageObjects::Sections::PageHeadingSection,
+                ".page-heading"
+
+        element :copy, ".action-copy"
+
+        element :reason_for_removing_extension, "#case_reason_for_removing_extension"
+
+        element :submit_button, ".button"
+
+        def set_reason_for_removing_extension(message)
+          reason_for_removing_extension.set(message)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/features/interactions.rb
+++ b/spec/support/features/interactions.rb
@@ -252,7 +252,7 @@ module Features
       rus.upload!
     end
 
-    def extend_sar_deadline_for(kase:, num_calendar_months:, reason: "The reason for extending")
+    def extend_sar_deadline_for(kase:, num_calendar_months:, reason: "The reason for extending") # rubocop:disable Lint/UnusedMethodArgument
       cases_show_page.load(id: kase.id)
       cases_show_page.case_status.deadlines.actions.extend_sar_deadline.click
 
@@ -267,15 +267,14 @@ module Features
       kase.reload
 
       expected_case_history = [
-        "Extended SAR deadline",
-        reason.to_s,
-        " Deadline extended by #{num_calendar_months == 1 ? 'one' : 'two'} calendar #{'month'.pluralize(num_calendar_months)}\n",
-        "Old final deadline: #{I18n.localize(old_final_deadline, format: :long)} ",
-        "New final deadline: #{I18n.localize(kase.external_deadline, format: :long)}",
+        "Deadline extended by 2 months",
+        "Previous deadline: #{I18n.localize(old_final_deadline, format: :long)} ",
+        "New deadline: #{I18n.localize(kase.external_deadline, format: :long)} ",
+        "Reason: #{reason}",
       ]
 
       expect(cases_show_page).to be_displayed
-      expect(cases_show_page.notice.text).to eq "Case extended for SAR"
+      expect(cases_show_page.notice.text).to eq "The deadline has been extended by 2 months."
       expect(cases_show_page.case_history.rows.first.details.text).to include(expected_case_history.join)
     end
 

--- a/spec/support/features/interactions/offender_sar.rb
+++ b/spec/support/features/interactions/offender_sar.rb
@@ -13,7 +13,7 @@ module Features
         cases_extend_sar_deadline_page.submit_button.click
 
         expect(cases_show_page).to be_displayed
-        expect(cases_show_page.notice.text).to eq "Case extended for Offender SAR"
+        expect(cases_show_page.notice.text).to eq "The deadline has been extended by 2 months."
       end
 
       def pause_offender_sar_for(kase:, reason: "Pausing to gather more information", date: Time.zone.today)


### PR DESCRIPTION
## Description
Introduces interstitial page when "Remove deadline extension", requiring a reason from the user and shows a late notice if applicable.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
#### Remove with late warning for deadline in the past
<img width="682" height="683" alt="Screenshot 2026-06-19 at 14 52 14" src="https://github.com/user-attachments/assets/445b0bba-ca8f-42af-96b4-9ad64b379223" />


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1083

### Deployment
N/A
### Manual testing instructions
Create SAR (Standard or Offender) and extend the deadline, then try to remove the deadline.
