### PR TITLE
[CDPTKAN-785] Fix incorrect redirect route reference index_cases_path

### DIFF
--- a/app/controllers/cases/clearances_controller.rb
+++ b/app/controllers/cases/clearances_controller.rb
@@ -70,7 +70,7 @@ module Cases
         format.html do
           flash[:notice] = "Case has been de-escalated. #{get_de_escalated_undo_link}".html_safe
           if @case.type_abbreviation == "SAR"
-            redirect_to incoming_cases_path
+            redirect_to incoming_filter_path
           else
             redirect_to case_path(@case)
           end

--- a/spec/controllers/cases/clearances_controller_spec.rb
+++ b/spec/controllers/cases/clearances_controller_spec.rb
@@ -447,6 +447,22 @@ RSpec.describe Cases::ClearancesController, type: :controller do
             patch(:unflag_for_clearance, params:)
             expect(response).to have_http_status :found
           end
+
+          context "when the case is a SAR" do
+            let(:flagged_case) do
+              create(
+                :accepted_sar,
+                :flagged,
+                responding_team:,
+                approving_team: dacu_disclosure,
+              )
+            end
+
+            it "redirects to the incoming cases list" do
+              patch(:unflag_for_clearance, params:)
+              expect(response).to redirect_to(incoming_filter_path)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## Description
Wrong route used in the controller when unflag_for_clearance action is taken.

Claude:

```
Where the link appears — two places, and this is the key to the bug:

The case detail page — cases/show.html.slim:36
The incoming cases list — cases/filters/incoming.html.slim:45
Why only one of them 500s. The link sets:

remote: !current_page?(case_path(case_details.id))
From the incoming list, current_page? is false → remote: true → an AJAX/JS request → controller hits the format.js branch (renders unflag_for_clearance.js.erb), which never touches line 73.
From the case detail page, current_page? is true → remote: false → a full HTML PATCH → controller hits the format.html branch. For a SAR, that branch ran redirect_to incoming_cases_path and raised the NameError.
So the 500 occurs specifically when a DACU Disclosure approver clicks "De-escalate" on a SAR's case detail page — which matches the logged request exactly (format: html, path: /cases/182535/clearances/unflag_for_clearance).
```

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-785

### Deployment
N/A
### Manual testing instructions
Only applicable to SAR cases