### PR TITLE
[CDPTKAN-847] CT: Run Bank Holiday load via Admin

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -35,6 +35,15 @@ class Admin::DashboardController < AdminController
     @bank_holidays = BankHoliday.order(created_at: :desc).page(params[:page]).per(50)
   end
 
+  def load_bank_holidays
+    BankHolidaysService.new
+    flash[:notice] = "Bank holidays loaded successfully."
+  rescue StandardError => e
+    flash[:alert] = "Failed to load bank holidays: #{e.message}"
+  ensure
+    redirect_to admin_dashboard_bank_holidays_path
+  end
+
   def personal_information_requests
     @personal_information_requests = PersonalInformationRequest
                                       .unscoped

--- a/app/views/admin/dashboard/bank_holidays.html.slim
+++ b/app/views/admin/dashboard/bank_holidays.html.slim
@@ -41,6 +41,9 @@
       |
       a.button href='#records' Jump to Stored Data
 
+    = form_with url: admin_dashboard_load_bank_holidays_path, method: :post, local: true do |f|
+      = f.submit "Get latest bank holidays", class: "button"
+
 
 = render partial: 'bank_holiday_region', locals: { region: 'england-and-wales', bank_holiday: latest_data }
 = render partial: 'bank_holiday_region', locals: { region: 'scotland', bank_holiday: latest_data }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -309,6 +309,7 @@ Rails.application.routes.draw do
       get "/dashboard/list_queries" => "dashboard#list_queries"
       get "/dashboard/system" => "dashboard#system"
       get "/dashboard/bank-holidays" => "dashboard#bank_holidays"
+      post "/dashboard/bank-holidays/load" => "dashboard#load_bank_holidays", as: :dashboard_load_bank_holidays
       get "/dashboard/personal_information_requests" => "dashboard#personal_information_requests"
       get "/dashboard/events" => "dashboard#events"
     end

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -93,6 +93,28 @@ describe Admin::DashboardController do
     end
   end
 
+  describe "#load_bank_holidays" do
+    before { sign_in admin }
+
+    context "when the service succeeds" do
+      it "redirects to bank holidays page with a notice" do
+        allow(BankHolidaysService).to receive(:new)
+        post :load_bank_holidays
+        expect(response).to redirect_to(admin_dashboard_bank_holidays_path)
+        expect(flash[:notice]).to eq("Bank holidays loaded successfully.")
+      end
+    end
+
+    context "when the service raises an error" do
+      it "redirects to bank holidays page with an alert" do
+        allow(BankHolidaysService).to receive(:new).and_raise(StandardError, "connection failed")
+        post :load_bank_holidays
+        expect(response).to redirect_to(admin_dashboard_bank_holidays_path)
+        expect(flash[:alert]).to eq("Failed to load bank holidays: connection failed")
+      end
+    end
+  end
+
   describe "#personal_information_requests" do
     before do
       sign_in admin


### PR DESCRIPTION
## Description
- Adds a "Get latest bank holidays" button to the admin bank holidays dashboard page                        
- Clicking the button triggers BankHolidaysService to fetch and store the latest data from the GOV.UK bank  
  holidays API                                                                                                
- Displays a success notice or error alert via the existing flash message system depending on the outcome   

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots

<img width="1012" height="771" alt="Screenshot 2026-06-24 at 15 10 54" src="https://github.com/user-attachments/assets/2597fded-ce77-4cf6-997d-be6588d90bba" />


### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
