### PR TITLE
[CDTPKAN-1152] Alter system log event presenter

### DIFF
--- a/app/presenters/system_log_event_presenter.rb
+++ b/app/presenters/system_log_event_presenter.rb
@@ -12,19 +12,19 @@ class SystemLogEventPresenter
   end
 
   def recipient
-    return unless email_event?
+    return unless email_failed_event?
 
     data[:recipient]
   end
 
   def subject
-    return unless email_event?
+    return unless email_failed_event?
 
     data[:subject]
   end
 
   def details
-    return email_details if email_event?
+    return email_details if email_failed_event?
 
     formatted_data
   end

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -159,5 +159,73 @@ describe Admin::DashboardController do
       expect(assigns(:email_failed_events_count)).to eq 1
       expect(assigns(:rpi_failed_events_count)).to eq 1
     end
+
+    describe "the presented events (SystemLogEventPresenter)" do
+      let(:events) { assigns(:events) }
+
+      def presenter_for(name)
+        events.find { |event| event.name == name }
+      end
+
+      it "presents every published event" do
+        expect(events).to all(be_a(SystemLogEventPresenter))
+        expect(events.map(&:name))
+          .to contain_exactly("Email sent", "Email failed", "Rpi unprocessed")
+      end
+
+      context "with an email failed event" do
+        subject(:presenter) { presenter_for("Email failed") }
+
+        it "flags it as an email failed event" do
+          expect(presenter.email_failed_event?).to be true
+        end
+
+        it "exposes the recipient" do
+          expect(presenter.recipient).to eq "test@test.com"
+        end
+
+        it "exposes the subject" do
+          expect(presenter.subject).to eq "Subject Access Request - 12345"
+        end
+
+        it "humanises the failure details into a pipe-separated summary" do
+          expect(presenter.details).to eq(
+            "Commissioning document | Commissioning email | Permanent failure | " \
+            "External | Case 12345 | Notify notify-123",
+          )
+        end
+      end
+
+      context "with an email sent event" do
+        subject(:presenter) { presenter_for("Email sent") }
+
+        it "is not treated as an email failed event" do
+          expect(presenter.email_failed_event?).to be false
+        end
+
+        it "does not expose a recipient or subject" do
+          expect(presenter.recipient).to be_nil
+          expect(presenter.subject).to be_nil
+        end
+
+        it "renders the raw event data as JSON for the details" do
+          expect(presenter.details)
+            .to include("test@test.com")
+            .and include("commissioning_document")
+        end
+      end
+
+      context "with an rpi unprocessed event" do
+        subject(:presenter) { presenter_for("Rpi unprocessed") }
+
+        it "flags it as an rpi failed event" do
+          expect(presenter.rpi_failed_event?).to be true
+        end
+
+        it "renders the raw event data as JSON for the details" do
+          expect(presenter.details).to include("submission-123")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
Alters new System Log Presenter to allow it to show different types of events without error.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="1065" height="672" alt="Screenshot 2026-06-24 at 20 32 17" src="https://github.com/user-attachments/assets/c4dbcc6a-a217-4a00-915f-1880adaa5b30" />

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1152

### Deployment
N/A
### Manual testing instructions
Log in as admin and look at Admin -> Events
