### PR TITLE
[CDPTKAN-1153] CT: Force load latest bank holidays and show empty Bank Holiday dashboard

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -36,7 +36,7 @@ class Admin::DashboardController < AdminController
   end
 
   def load_bank_holidays
-    BankHolidaysService.new
+    BankHolidaysService.new(force: true)
     flash[:notice] = "Bank holidays loaded successfully."
   rescue StandardError => e
     flash[:alert] = "Failed to load bank holidays: #{e.message}"

--- a/app/helpers/bank_holidays_helper.rb
+++ b/app/helpers/bank_holidays_helper.rb
@@ -1,5 +1,7 @@
 module BankHolidaysHelper
   def bank_holidays_summary(bank_holiday)
+    return [[], 0] if bank_holiday.nil?
+
     regions = bank_holiday.data.keys
     num_holidays = regions.sum { |region| bank_holiday.data.dig(region, "events")&.size.to_i }
 
@@ -8,6 +10,8 @@ module BankHolidaysHelper
 
   # Invalid/missing dates sink to bottom of sorted events list
   def bank_holidays_for_region(bank_holiday, region)
+    return [] if bank_holiday.nil?
+
     events = bank_holiday.data.dig(region, "events")
     return [] unless events
 

--- a/app/services/bank_holidays_service.rb
+++ b/app/services/bank_holidays_service.rb
@@ -3,25 +3,27 @@ class BankHolidaysService
 
   attr_reader :holidays
 
-  def initialize
+  def initialize(force: false)
     SentryContextProvider.set_context
 
+    @force = force
     @holidays = {}
 
     ingest
     backup
   end
 
-  # Persist the latest snapshot of holidays if it has changed
+  # Persist the latest snapshot of holidays if it has changed.
+  # Pass force: true to write a new record even when the data is unchanged.
   def backup
     return unless holidays.is_a?(Hash)
     return if holidays.empty?
 
     hash_value = Digest::MD5.hexdigest(JSON.generate(holidays))
 
-    # Avoid writing duplicate records when the data hasn't changed
-    record = BankHoliday.last
-    return if record&.hash_value == hash_value
+    if !@force && (BankHoliday.last&.hash_value == hash_value)
+      return
+    end
 
     ::BankHoliday.create!(data: holidays, hash_value: hash_value)
   end

--- a/app/views/admin/dashboard/bank_holidays.html.slim
+++ b/app/views/admin/dashboard/bank_holidays.html.slim
@@ -30,7 +30,10 @@
       .case-status__date-title
         strong= "Last updated"
       .case-status__date-value
-        = l(latest_updated.updated_at, format: "%B %d, %Y at %H:%M")
+        - if latest_updated
+          = l(latest_updated.updated_at, format: "%B %d, %Y at %H:%M")
+        - else
+          | No data loaded yet
 
 .grid-row
   .column-full
@@ -42,7 +45,7 @@
       a.button href='#records' Jump to Stored Data
 
     = form_with url: admin_dashboard_load_bank_holidays_path, method: :post, local: true do |f|
-      = f.submit "Get latest bank holidays", class: "button"
+      = f.submit "Force get latest bank holidays", class: "button"
 
 
 = render partial: 'bank_holiday_region', locals: { region: 'england-and-wales', bank_holiday: latest_data }

--- a/spec/helpers/bank_holidays_helper_spec.rb
+++ b/spec/helpers/bank_holidays_helper_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe BankHolidaysHelper, type: :helper do
     it "returns an array of regions and total number of holidays" do
       expect(bank_holidays_summary(bank_holiday)).to match_array([%w[england-and-wales scotland northern-ireland], 9])
     end
+
+    it "returns empty regions and zero count when bank_holiday is nil" do
+      expect(bank_holidays_summary(nil)).to eq([[], 0])
+    end
   end
 
   describe "#bank_holidays_for_region" do
@@ -62,6 +66,12 @@ RSpec.describe BankHolidaysHelper, type: :helper do
 
       it "returns an empty array if the region is not found in data" do
         expect(bank_holidays_for_region(bank_holiday, "wales")).to eq([])
+      end
+    end
+
+    context "when bank_holiday is nil" do
+      it "returns an empty array" do
+        expect(bank_holidays_for_region(nil, "england-and-wales")).to eq([])
       end
     end
   end

--- a/spec/services/bank_holidays_service_spec.rb
+++ b/spec/services/bank_holidays_service_spec.rb
@@ -77,5 +77,14 @@ RSpec.describe BankHolidaysService, type: :service do
 
       expect { described_class.new }.to change(BankHoliday, :count).by(1)
     end
+
+    it "creates a new record even when data is unchanged when force: true" do
+      allow(Net::HTTP).to receive(:get).and_return(fixture_json)
+      described_class.new
+      expect(BankHoliday.count).to eq(1)
+
+      allow(Net::HTTP).to receive(:get).and_return(fixture_json)
+      expect { described_class.new(force: true) }.to change(BankHoliday, :count).by(1)
+    end
   end
 end


### PR DESCRIPTION
## Description
- Adds a "Force get latest bank holidays" button to /admin/dashboard/bank-holidays that triggers a fresh    
  fetch from the GOV.UK bank holidays API and always persists a new record, bypassing the SHA duplicate check 

- Fixes a crash on the bank holidays dashboard when the bank_holidays table is empty — the page now renders gracefully with zeroed counts and a "No data  loaded yet" message 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
