### PR TITLE
[CDPTKAN-1099] CT: undefined method number for nil (SAR Internal Review)

### DIFF
--- a/app/decorators/case/sar/internal_review_decorator.rb
+++ b/app/decorators/case/sar/internal_review_decorator.rb
@@ -22,11 +22,9 @@ class Case::SAR::InternalReviewDecorator < Case::SAR::StandardDecorator
   end
 
   def subject_with_original_case_reference
-    if subject =~ /IR of ([0-9]+)\s-/
-      subject
-    else
-      "IR of #{original_case.number} - #{subject}"
-    end
+    return subject if original_case.nil? || subject =~ /IR of ([0-9]+)\s-/
+
+    "IR of #{original_case.number} - #{subject}"
   end
 
   def pretty_outcome_reasons

--- a/spec/decorators/case/sar/internal_review_decorator_spec.rb
+++ b/spec/decorators/case/sar/internal_review_decorator_spec.rb
@@ -59,5 +59,10 @@ describe Case::SAR::InternalReviewDecorator do
       kase = sar_ir_case_with_orignal_case_referenced_in_subject.decorate
       expect(kase.subject_with_original_case_reference).to eq subject_with_reference
     end
+
+    it "returns subject as-is when original case is not yet linked" do
+      kase = Case::SAR::InternalReview.new(subject: "some subject").decorate
+      expect(kase.subject_with_original_case_reference).to eq "some subject"
+    end
   end
 end


### PR DESCRIPTION
## Description
**Summary**                                                                                                      
    [sentry eror](https://ministryofjustice.sentry.io/issues/7543411297/?alert_rule_id=16790762&alert_type=issue&environment=production&notification_uuid=0308d6c6-1d22-446c-ba65-a56edfce41ec&project=5407956&referrer=slack   )                                                                                                     
  - Fixes a production crash (NoMethodError: undefined method 'number' for nil) on the SAR Internal Review new 
  case form at GET /cases/sar_internal_review/case-details                                                     
  - The subject field called subject_with_original_case_reference which assumed original_case was always       
  present — it isn't on a new, unsaved case before the original case has been linked in the multi-step form    
  
**Root cause**                                                                                                   
                                                                                                               
  Case::SAR::InternalReviewDecorator#subject_with_original_case_reference would fall through to "IR of         
  #{original_case.number} - #{subject}" whenever the subject didn't already match the IR of X - pattern. For a 
  brand new case (the new action builds an unsaved record with no linked cases), original_case is nil, raising 
  on .number.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions

Visit /cases/sar_internal_review/case-details as a user who can create SAR IRs — page should load without error and the subject field should render empty
