### PR TITLE
[CDPTKAN-1119] CT: Admin > B/H missing stored data section

### DIFF
--- a/app/presenters/system_log_event_presenter.rb
+++ b/app/presenters/system_log_event_presenter.rb
@@ -25,6 +25,7 @@ class SystemLogEventPresenter
 
   def details
     return email_details if email_failed_event?
+    return bank_holiday_ingest_failed_details if bank_holiday_ingest_failed_event?
 
     formatted_data
   end
@@ -35,6 +36,10 @@ class SystemLogEventPresenter
 
   def rpi_failed_event?
     event_type.start_with?("Events::RpiUnprocessed")
+  end
+
+  def bank_holiday_ingest_failed_event?
+    event_type.start_with?("Events::BankHolidayIngestFailed")
   end
 
 private
@@ -62,5 +67,13 @@ private
 
   def formatted_data
     data.to_json
+  end
+
+  def bank_holiday_ingest_failed_details
+    [
+      data[:reason],
+      data[:error_class].presence && data[:error_class].to_s,
+      data[:failed_at].presence && "at #{data[:failed_at]}",
+    ].compact.join(" | ")
   end
 end

--- a/app/pub_sub/events/bank_holiday_ingest_failed.rb
+++ b/app/pub_sub/events/bank_holiday_ingest_failed.rb
@@ -1,0 +1,4 @@
+module Events
+  class BankHolidayIngestFailed < SystemEvent
+  end
+end

--- a/app/services/bank_holidays_service.rb
+++ b/app/services/bank_holidays_service.rb
@@ -8,6 +8,7 @@ class BankHolidaysService
 
     @force = force
     @holidays = {}
+    @ingest_errored = false
 
     ingest
     backup
@@ -17,7 +18,11 @@ class BankHolidaysService
   # Pass force: true to write a new record even when the data is unchanged.
   def backup
     return unless holidays.is_a?(Hash)
-    return if holidays.empty?
+
+    if holidays.empty?
+      publish_ingest_failed_event(reason: "ingest returned empty data") unless @ingest_errored
+      return
+    end
 
     hash_value = Digest::MD5.hexdigest(JSON.generate(holidays))
 
@@ -35,10 +40,24 @@ class BankHolidaysService
 
     @holidays = JSON.parse(response_body)
   rescue StandardError => e
+    @ingest_errored = true
     Sentry.capture_message "BankHolidaysService ingest failure --- Error: #{e.message}"
     Sentry.capture_exception(e)
+    publish_ingest_failed_event(reason: e.message, error_class: e.class.name)
   ensure
     @holidays ||= {}
   end
   # rubocop:enable Naming/MemoizedInstanceVariableName
+
+private
+
+  def publish_ingest_failed_event(reason:, error_class: nil)
+    Rails.configuration.event_store.publish(
+      Events::BankHolidayIngestFailed.build(
+        reason: reason,
+        error_class: error_class,
+        failed_at: Time.current.iso8601,
+      ),
+    )
+  end
 end

--- a/app/views/admin/dashboard/_stored_data.html.slim
+++ b/app/views/admin/dashboard/_stored_data.html.slim
@@ -1,0 +1,28 @@
+.grid-row id='records'
+  .column-full
+    h2.heading-large Stored Data
+
+    - if bank_holidays.any?
+      table.report.table-font-xsmall
+        colgroup
+          col
+          col
+          col
+          col
+        thead
+          tr
+            th scope='col' ID
+            th scope='col' Hash
+            th scope='col' Created At
+            th scope='col' Updated At
+        tbody
+          - bank_holidays.each do |bh|
+            tr
+              td= bh.id
+              td= bh.hash_value
+              td= l(bh.created_at, format: "%B %d, %Y at %H:%M")
+              td= l(bh.updated_at, format: "%B %d, %Y at %H:%M")
+    - else
+      p No stored bank holiday data found.
+
+    = paginate bank_holidays

--- a/app/views/admin/dashboard/bank_holidays.html.slim
+++ b/app/views/admin/dashboard/bank_holidays.html.slim
@@ -52,4 +52,4 @@
 = render partial: 'bank_holiday_region', locals: { region: 'scotland', bank_holiday: latest_data }
 = render partial: 'bank_holiday_region', locals: { region: 'northern-ireland', bank_holiday: latest_data }
 
-= paginate @bank_holidays
+= render partial: 'stored_data', locals: { bank_holidays: @bank_holidays }

--- a/spec/services/bank_holidays_service_spec.rb
+++ b/spec/services/bank_holidays_service_spec.rb
@@ -32,33 +32,85 @@ RSpec.describe BankHolidaysService, type: :service do
   end
 
   describe "#ingest" do
+    let(:event_store) { instance_double(RailsEventStore::Client, publish: true) }
+    let(:published_events) { [] }
+
+    before do
+      allow(Rails.configuration).to receive(:event_store).and_return(event_store)
+      allow(event_store).to receive(:publish) { |event| published_events << event }
+    end
+
     context "when endpoint is unreachable" do
-      it "returns an empty hash" do
-        allow(Net::HTTP).to receive(:get).and_raise(StandardError.new("boom"))
-        expect(Sentry).to receive(:capture_exception).with(StandardError)
+      before { allow(Net::HTTP).to receive(:get).and_raise(StandardError.new("boom")) }
+
+      it "returns an empty hash and does not save a record" do
+        allow(Sentry).to receive(:capture_exception)
 
         service = described_class.new
 
         expect(service.holidays).to eq({})
         expect(BankHoliday.count).to eq(0)
       end
+
+      it "publishes a BankHolidayIngestFailed event with the error details" do
+        allow(Sentry).to receive(:capture_exception)
+
+        described_class.new
+
+        expect(published_events.last).to be_a(Events::BankHolidayIngestFailed)
+        expect(published_events.last.data).to include(
+          reason: "boom",
+          error_class: "StandardError",
+        )
+      end
     end
 
     context "when retrieved data is not valid JSON" do
-      it "returns an empty hash" do
-        allow(Net::HTTP).to receive(:get).and_return("not-json")
-        expect(Sentry).to receive(:capture_exception).with(JSON::ParserError)
+      before { allow(Net::HTTP).to receive(:get).and_return("not-json") }
+
+      it "returns an empty hash and does not save a record" do
+        allow(Sentry).to receive(:capture_exception)
 
         service = described_class.new
 
         expect(service.holidays).to eq({})
-        # No backup should occur if there is no data
         expect(BankHoliday.count).to eq(0)
+      end
+
+      it "publishes a BankHolidayIngestFailed event indicating empty data" do
+        allow(Sentry).to receive(:capture_exception)
+
+        described_class.new
+
+        expect(published_events.last).to be_a(Events::BankHolidayIngestFailed)
+        expect(published_events.last.data).to include(error_class: "JSON::ParserError")
       end
     end
   end
 
   describe "#backup" do
+    context "when ingest succeeded but returned empty JSON (silent failure)" do
+      let(:event_store) { instance_double(RailsEventStore::Client, publish: true) }
+      let(:published_events) { [] }
+
+      before do
+        allow(Net::HTTP).to receive(:get).and_return("{}")
+        allow(Rails.configuration).to receive(:event_store).and_return(event_store)
+        allow(event_store).to receive(:publish) { |event| published_events << event }
+      end
+
+      it "publishes a BankHolidayIngestFailed event indicating empty data" do
+        described_class.new
+
+        expect(published_events.last).to be_a(Events::BankHolidayIngestFailed)
+        expect(published_events.last.data[:reason]).to eq("ingest returned empty data")
+      end
+
+      it "does not save a BankHoliday record" do
+        expect { described_class.new }.not_to change(BankHoliday, :count)
+      end
+    end
+
     it "creates a new record when data changes and skips duplicates" do
       # First load stores initial snapshot
       allow(Net::HTTP).to receive(:get).and_return(fixture_json)


### PR DESCRIPTION
## Description
- Restores the missing Stored Data section on the bank holidays admin dashboard (/admin/dashboard/bank-holidays#records).                                                                                                                                  
 - Adds a `Events::BankHolidayIngestFailed` event published by BankHolidaysService in two distinct failure scenarios:                                                               
    - Raised error — network failure, bad JSON, etc. Published alongside the existing Sentry capture, including reason, error_class, and failed_at.
     - Silent empty response — ingest `returns {}` without raising (e.g. unexpected API response). Previously this would silently skip the backup with no signal. An `@ingest_errored` flag prevents double-publishing when the raised-error path already fired.  

- Updates `SystemLogEventPresenter` to format `BankHolidayIngestFailed` events with human-readable details rather than raw JSON. Both failure modes now appear on the existing `/admin/dashboard/events` page alongside email and RPI failure events.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<img width="985" height="454" alt="Screenshot 2026-06-29 at 15 15 30" src="https://github.com/user-attachments/assets/09723454-fba6-4fb7-ae0f-567fa574e98f" />


### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
