### PR TITLE
[CDPTKAN-1097] CT: Duplicate CasesUsersTransitionsTracker causes error …when searching and opening cases

### DIFF
--- a/app/models/cases_users_transitions_tracker.rb
+++ b/app/models/cases_users_transitions_tracker.rb
@@ -25,17 +25,13 @@ class CasesUsersTransitionsTracker < ApplicationRecord
   class << self
     def sync_for_case_and_user(kase, user)
       latest_transition = kase.message_transitions.last
-      if latest_transition.present?
-        tracker = find_by(case: kase, user:)
-        if tracker
-          # Pretty sure this can't fail, but its a good pattern to use ! methods
-          tracker.update! case_transition_id: latest_transition.id
-        else
-          create! case: kase,
-                  user:,
-                  case_transition_id: latest_transition.id
-        end
-      end
+      return if latest_transition.blank?
+
+      upsert(
+        { case_id: kase.id, user_id: user.id, case_transition_id: latest_transition.id },
+        unique_by: %i[case_id user_id],
+        update_only: %i[case_transition_id],
+      )
     end
   end
 

--- a/db/migrate/20260630090000_deduplicate_and_index_cases_users_transitions_trackers.rb
+++ b/db/migrate/20260630090000_deduplicate_and_index_cases_users_transitions_trackers.rb
@@ -1,0 +1,24 @@
+class DeduplicateAndIndexCasesUsersTransitionsTrackers < ActiveRecord::Migration[8.1]
+  def up
+    # Remove duplicate rows created by the race condition in sync_for_case_and_user,
+    # keeping the most recently updated record per case/user pair.
+    execute <<~SQL
+      DELETE FROM cases_users_transitions_trackers
+      WHERE id NOT IN (
+        SELECT DISTINCT ON (case_id, user_id) id
+        FROM cases_users_transitions_trackers
+        ORDER BY case_id, user_id, updated_at DESC NULLS LAST, id DESC
+      )
+    SQL
+
+    add_index :cases_users_transitions_trackers,
+              %i[case_id user_id],
+              unique: true,
+              name: "index_cutt_on_case_id_and_user_id"
+  end
+
+  def down
+    remove_index :cases_users_transitions_trackers,
+                 name: "index_cutt_on_case_id_and_user_id"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2237,6 +2237,13 @@ CREATE INDEX index_contacts_on_contact_type_id ON public.contacts USING btree (c
 
 
 --
+-- Name: index_cutt_on_case_id_and_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_cutt_on_case_id_and_user_id ON public.cases_users_transitions_trackers USING btree (case_id, user_id);
+
+
+--
 -- Name: index_data_request_areas_on_case_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2624,6 +2631,7 @@ ALTER TABLE ONLY public.data_request_areas
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260630090000'),
 ('20260617003452'),
 ('20260610120000'),
 ('20260327090000'),
@@ -2814,3 +2822,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20160802134012'),
 ('20160802130203'),
 ('20160722121207');
+

--- a/spec/models/cases_users_transitions_tracker_spec.rb
+++ b/spec/models/cases_users_transitions_tracker_spec.rb
@@ -56,6 +56,19 @@ describe CasesUsersTransitionsTracker do
         end
       end
     end
+
+    context "when called concurrently for the same case and user" do
+      before do
+        create :case_transition_add_message_to_case, case: kase
+      end
+
+      it "does not create duplicate trackers" do
+        described_class.sync_for_case_and_user(kase, user)
+        described_class.sync_for_case_and_user(kase, user)
+
+        expect(kase.users_transitions_trackers.where(user:).count).to eq 1
+      end
+    end
   end
 
   context "when tracker does not exists for given case and user" do


### PR DESCRIPTION
## Description
  - CasesUsersTransitionsTracker.sync_for_case_and_user had a race condition where concurrent calls (e.g. from search + opening a case simultaneously) could insert duplicate rows for the same `case_id/user_id` pair, causing subsequent queries to error                                                                                                           
  - Replace the find-then-create/update logic with a single upsert on `[case_id, user_id]`, which is atomic and idempotent                                                           
  - Add a migration to deduplicate existing rows and enforce a unique index on `[case_id, user_id]` so the constraint is guaranteed at the database level     

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
<!-- A link or list of links to relevant issues in Jira -->

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
<!-- Step-by-step instructions for the reviewer to manually test the changes -->
