### PR TITLE
[CDPTKAN-1079] Add guard to prevent NoMethodError with partial date value

### DIFF
--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -363,12 +363,12 @@ module Cases
     # @todo the following are all related to session data (case) cross different page
     # maybe worthy having another class for handling such thing together in a more abstract way
     def build_case_from_session(correspondence_type)
-      # regarding the `{ date_of_birth: nil }` below...
-      # this is needed to prevent "NoMethodError undefined method 'dd' for nil:NilClass"
-      # when a new Case::SAR::Offender is being created from scratch, because the field is not
-      # in the list of instance variables in the model at the point that the gov_uk_date_fields
-      # is adding its magic methods. This manifests when running tests or after rails server restart
-      values = session[session_state] || { date_of_birth: nil }
+      values = session[session_state] || {}
+
+      # Prevent NoMethodError from gov_uk_date_fields
+      unless date_of_birth_present_in?(values)
+        values["date_of_birth"] = nil
+      end
 
       # similar workaround needed for request dated
       request_dated_exists = values.fetch("request_dated", false)
@@ -377,6 +377,13 @@ module Cases
       rejected_set_current_state(values)
 
       correspondence_type.new(values).decorate
+    end
+
+    # date_of_birth is stored in the session as its date-part keys (date_of_birth_dd/mm/yyyy),
+    # but may also arrive as a whole value. Treat any of them as "present".
+    def date_of_birth_present_in?(values)
+      %w[date_of_birth date_of_birth_dd date_of_birth_mm date_of_birth_yyyy]
+        .any? { |key| values.key?(key) }
     end
 
     def rejected_set_current_state(values)

--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -380,10 +380,11 @@ module Cases
     end
 
     # date_of_birth is stored in the session as its date-part keys (date_of_birth_dd/mm/yyyy),
-    # but may also arrive as a whole value. Treat any of them as "present".
+    # but may also arrive as a whole value. Treat any of them as "present". Keys may be strings
+    # (serialised session) or symbols (passed directly in tests), so compare on string form.
     def date_of_birth_present_in?(values)
-      %w[date_of_birth date_of_birth_dd date_of_birth_mm date_of_birth_yyyy]
-        .any? { |key| values.key?(key) }
+      dob_keys = %w[date_of_birth date_of_birth_dd date_of_birth_mm date_of_birth_yyyy]
+      values.keys.any? { |key| dob_keys.include?(key.to_s) }
     end
 
     def rejected_set_current_state(values)

--- a/spec/controllers/cases/offender_sar_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_controller_spec.rb
@@ -67,6 +67,39 @@ RSpec.describe Cases::OffenderSARController, type: :controller do
       expect(assigns(:case_types)).to match_array %w[Case::SAR::Offender]
     end
 
+    # CDPTKAN-1079: date_of_birth is a virtual jsonb attribute, so gov_uk_date_fields does not
+    # populate its shadow FormDate on after_initialize. When the wizard session holds partial data
+    # without any date_of_birth, rendering `f.gov_uk_date_field :date_of_birth` used to raise
+    # "undefined method 'dd' for nil". See #build_case_from_session.
+    context "when the session holds partial data without a date_of_birth" do
+      before do
+        session[:offender_sar_state] = { "subject_full_name" => "A. N. Other" }
+      end
+
+      it "builds a case whose date_of_birth field can be rendered without raising" do
+        get :new, params: params.merge(step: "subject-details")
+
+        expect(response).to render_template(:new)
+        expect { assigns(:case).object.date_of_birth_dd }.not_to raise_error
+      end
+    end
+
+    context "when the session holds a partially entered date_of_birth" do
+      before do
+        session[:offender_sar_state] = {
+          "subject_full_name" => "A. N. Other",
+          "date_of_birth_dd" => "1",
+          "date_of_birth_mm" => "2",
+          "date_of_birth_yyyy" => "1990",
+        }
+      end
+
+      it "preserves the entered date_of_birth rather than clobbering it" do
+        get :new, params: params.merge(step: "subject-details")
+        expect(assigns(:case).object.date_of_birth).to eq Date.new(1990, 2, 1)
+      end
+    end
+
     context "when starting a rejected offender sar case" do
       let(:params) do
         {

--- a/spec/controllers/cases/offender_sar_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_controller_spec.rb
@@ -88,15 +88,15 @@ RSpec.describe Cases::OffenderSARController, type: :controller do
       before do
         session[:offender_sar_state] = {
           "subject_full_name" => "A. N. Other",
-          "date_of_birth_dd" => "1",
+          "date_of_birth_dd" => "",
           "date_of_birth_mm" => "2",
           "date_of_birth_yyyy" => "1990",
         }
       end
 
-      it "preserves the entered date_of_birth rather than clobbering it" do
+      it "sets date_of_birth to nil" do
         get :new, params: params.merge(step: "subject-details")
-        expect(assigns(:case).object.date_of_birth).to eq Date.new(1990, 2, 1)
+        expect(assigns(:case).object.date_of_birth).to be nil
       end
     end
 


### PR DESCRIPTION
## Description
While creating Offender SAR can have NoMethodError due to incomplete data value.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1079
### Deployment
N/A
### Manual testing instructions
Create Offender SAR with invalid or partly blank date value.