### PR TITLE
[CDPTKAN-1142] Re-build search indexing sequencing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,6 +121,10 @@ jobs:
           
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/development/cronjob-bank-holidays.yaml
 
+          kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
+          kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-dirty-cases \
+            jobs="${{ vars.ECR_URL }}:$SHA"
+
   notify-development:
     needs: [build, deploy-development]
     uses: ./.github/workflows/notification.yml
@@ -192,6 +196,10 @@ jobs:
             jobs="${{ vars.ECR_URL }}:$SHA"
           
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/staging/cronjob-bank-holidays.yaml
+
+          kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
+          kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-dirty-cases \
+            jobs="${{ vars.ECR_URL }}:$SHA"
 
   notify-staging:
     needs: [build, deploy-staging]
@@ -269,6 +277,10 @@ jobs:
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/qa/cronjob-bank-holidays.yaml
 
           kubectl set image -n ${KUBE_NAMESPACE} cronjobs/auto-close-paused-sar-cases \
+            jobs="${{ vars.ECR_URL }}:$SHA"
+
+          kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
+          kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-dirty-cases \
             jobs="${{ vars.ECR_URL }}:$SHA"
 
   notify-qa:
@@ -352,6 +364,10 @@ jobs:
             jobs="${{ vars.ECR_URL }}:$SHA"
           
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/production/cronjob-bank-holidays.yaml
+
+          kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/production/cronjob-reindex-dirty-cases.yaml
+          kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-dirty-cases \
+            jobs="${{ vars.ECR_URL }}:$SHA"
 
   notify-production:
     needs: [build, deploy-production]

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -431,9 +431,10 @@ class Case::Base < ApplicationRecord
                 :set_deadlines
   before_update :update_deadlines
   before_save :prevent_number_change,
-              :trigger_reindexing
+              :mark_for_reindexing
 
-  after_create :create_init_transition, :trigger_reindexing_after_creation
+  after_create :create_init_transition
+  after_commit :trigger_reindexing, on: %i[create update]
 
   delegate :available_events, to: :state_machine
 
@@ -1086,15 +1087,20 @@ private
     uploader.process_files(uploaded_request_files, :request)
   end
 
-  def trigger_reindexing
-    if (changed & indexable_fields).any? && id.present?
+  # The dirty flag is persisted in the same transaction as the change so that
+  # a case whose SearchIndexUpdaterJob never runs can be found and reindexed
+  # (see the search:reindex_dirty_cases rake task).
+  def mark_for_reindexing
+    if new_record? || (changed & indexable_fields).any?
       self.dirty = true
-      SearchIndexUpdaterJob.perform_later(id)
     end
   end
 
-  def trigger_reindexing_after_creation
-    SearchIndexUpdaterJob.perform_later(id)
+  # Enqueued after commit, not before save: the job reads the case back from
+  # the database, so enqueueing it mid-transaction lets it index the
+  # pre-commit state (e.g. an Offender SAR's old "R" case number).
+  def trigger_reindexing
+    SearchIndexUpdaterJob.perform_later(id) if dirty?
   end
 
   def validate_related_cases

--- a/config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: reindex-dirty-cases
+  namespace: track-a-query-development
 spec:
   schedule: "30 * * * *"
   concurrencyPolicy: Forbid

--- a/config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: reindex-dirty-cases
+spec:
+  schedule: "30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: track-a-query
+          containers:
+          - name: jobs
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:development.latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - sh
+              - "-c"
+              - "bundle exec rake 'search:reindex_dirty_cases'"
+            env:
+              - name: DATABASE_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-rds-output
+                    key: url
+              - name: REDIS_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: url
+              - name: REDIS_AUTH_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: auth_token
+              - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-s3-output
+                    key: bucket_name
+            envFrom:
+              - configMapRef:
+                  name: environment-variables
+              - secretRef:
+                  name: app-secrets
+          restartPolicy: OnFailure

--- a/config/kubernetes/production/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/production/cronjob-reindex-dirty-cases.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: reindex-dirty-cases
+  namespace: track-a-query-production
 spec:
   schedule: "30 * * * *"
   concurrencyPolicy: Forbid

--- a/config/kubernetes/production/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/production/cronjob-reindex-dirty-cases.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: reindex-dirty-cases
+spec:
+  schedule: "30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: track-a-query
+          containers:
+          - name: jobs
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:production.latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - sh
+              - "-c"
+              - "bundle exec rake 'search:reindex_dirty_cases'"
+            env:
+              - name: DATABASE_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-rds-output
+                    key: url
+              - name: REDIS_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: url
+              - name: REDIS_AUTH_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: auth_token
+              - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-s3-output
+                    key: bucket_name
+            envFrom:
+              - configMapRef:
+                  name: environment-variables
+              - secretRef:
+                  name: app-secrets
+          restartPolicy: OnFailure

--- a/config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: reindex-dirty-cases
+spec:
+  schedule: "30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: track-a-query
+          containers:
+          - name: jobs
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:qa.latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - sh
+              - "-c"
+              - "bundle exec rake 'search:reindex_dirty_cases'"
+            env:
+              - name: DATABASE_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-rds-output
+                    key: url
+              - name: REDIS_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: url
+              - name: REDIS_AUTH_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: auth_token
+              - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-s3-output
+                    key: bucket_name
+            envFrom:
+              - configMapRef:
+                  name: environment-variables
+              - secretRef:
+                  name: app-secrets
+          restartPolicy: OnFailure

--- a/config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: reindex-dirty-cases
+  namespace: track-a-query-qa
 spec:
   schedule: "30 * * * *"
   concurrencyPolicy: Forbid

--- a/config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: reindex-dirty-cases
+  namespace: track-a-query-staging
 spec:
   schedule: "30 * * * *"
   concurrencyPolicy: Forbid

--- a/config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: reindex-dirty-cases
+spec:
+  schedule: "30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: track-a-query
+          containers:
+          - name: jobs
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:staging.latest
+            imagePullPolicy: IfNotPresent
+            command:
+              - sh
+              - "-c"
+              - "bundle exec rake 'search:reindex_dirty_cases'"
+            env:
+              - name: DATABASE_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-rds-output
+                    key: url
+              - name: REDIS_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: url
+              - name: REDIS_AUTH_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-elasticache-redis-output
+                    key: auth_token
+              - name: SETTINGS__CASE_UPLOADS_S3_BUCKET
+                valueFrom:
+                  secretKeyRef:
+                    name: track-a-query-s3-output
+                    key: bucket_name
+            envFrom:
+              - configMapRef:
+                  name: environment-variables
+              - secretRef:
+                  name: app-secrets
+          restartPolicy: OnFailure

--- a/docs/decisions/003-enqueue-search-reindexing-after-commit.md
+++ b/docs/decisions/003-enqueue-search-reindexing-after-commit.md
@@ -1,0 +1,99 @@
+# 003 — Enqueue search reindexing after commit, with a dirty-case sweeper
+
+**Status:** Accepted
+**Date:** 2026-07-09
+**Deciders:** Mo Seedat
+
+## Context
+
+Case full-text search runs against `cases.document_tsvector`, which is an
+`ignored_column` as far as Active Record is concerned. The only writer is
+`Searchable#update_index`, executed asynchronously by
+`SearchIndexUpdaterJob` (Sidekiq): the job reloads the case from the
+database, rebuilds the weighted tsvector from
+`searchable_fields_and_ranks`, and clears the `dirty` flag.
+
+Previously the job was enqueued from a `before_save` callback
+(`trigger_reindexing`) and an `after_create` callback, i.e. **while the
+surrounding database transaction was still open**. On Rails 8 with Sidekiq
+and no `enqueue_after_transaction_commit` configured, `perform_later`
+pushes to Redis immediately, so the job could start before the transaction
+committed and index the case's *pre-commit* state.
+
+This surfaced as Offender SAR case numbers missing from the search index.
+Offender SAR is the only case type whose `number` can change after
+creation: validating a rejected case
+(`CaseValidateRejectedOffenderSARService`) replaces the `R`-prefixed
+number with a newly issued one, inside an `ActiveRecord::Base.transaction`
+that also runs the state machine transition. When the reindex job raced
+the commit it indexed the old `R` number; because tsquery prefix matching
+is left-anchored, searching for the case's real number then found nothing.
+The failure was silent and permanent: the job ran "successfully", the
+pre-commit snapshot it read still had `dirty = false` so the flag it left
+behind was inconsistent, and nothing ever reindexed dirty cases.
+
+Two compounding gaps:
+
+- On creation the `dirty` flag was never set at all, so a lost creation
+  job (Redis flush, pod killed mid-deploy) left a case unfindable with no
+  marker that anything was wrong.
+- There was no reconciliation mechanism — `dirty = true` was written by
+  updates but nothing swept it.
+
+## Decision
+
+Split "record that a case needs reindexing" from "enqueue the reindex",
+and put each on the correct side of the transaction boundary
+(`app/models/case/base.rb`):
+
+- `before_save :mark_for_reindexing` persists `dirty = true` **inside the
+  same transaction** as the change, whenever the record is new or a field
+  in `indexable_fields` changed. The flag now also marks freshly created,
+  not-yet-indexed cases.
+- `after_commit :trigger_reindexing, on: %i[create update]` enqueues
+  `SearchIndexUpdaterJob` only once the data the job will read is
+  committed, and only when the case is dirty. This replaces both the
+  `before_save` enqueue and the separate `trigger_reindexing_after_creation`
+  callback. `after_commit` fires once per record per transaction, so a
+  service that saves the case several times enqueues one job.
+
+The `dirty` flag therefore has a precise meaning: *the committed row may
+not match the search index*. The job clears it (`mark_as_clean`,
+`update_column`, so no callback loop) after rebuilding the tsvector.
+
+As a safety net for jobs that are enqueued but never run, a new rake task
+`search:reindex_dirty_cases` (`lib/tasks/search.rake`) re-enqueues
+indexing for every case still flagged dirty. It runs hourly via a
+Kubernetes CronJob in each environment
+(`config/kubernetes/*/cronjob-reindex-dirty-cases.yaml`, wired into
+`.github/workflows/deploy.yml` alongside the existing case cronjobs).
+
+Alternatives considered:
+
+- `config.active_job.enqueue_after_transaction_commit = :always` — fixes
+  the race globally but changes enqueue semantics for *every* job in the
+  app; rejected as disproportionate when only reindexing reads its own
+  row back.
+- A Postgres trigger maintaining the tsvector synchronously — would remove
+  the async gap entirely, but moves the field list and weighting into SQL,
+  duplicating `searchable_fields_and_ranks` (which subclasses override)
+  outside Ruby.
+
+## Consequences
+
+- Reindex jobs can no longer observe pre-commit state; the validated
+  rejected Offender SAR number is indexed correctly.
+- A save that rolls back no longer enqueues a reindex at all (previously
+  it did, harmlessly but wastefully).
+- A freshly created case is `dirty` until its index job runs. Specs that
+  asserted "clean after create" were updated; the `:clean` factory trait
+  gives a clean case where tests need one.
+- Any lost or failed reindex job now self-heals within an hour via the
+  sweeper, for creates as well as updates.
+- The guarantee only covers writes that run Active Record save callbacks.
+  `update_column`/`update_all`/raw SQL paths neither set the flag nor
+  enqueue; the existing `Assignment` path relies on its own
+  `mark_as_dirty` + delayed enqueue and is unchanged.
+- Historic cases whose index went stale *before* this change and whose
+  `dirty` flag is `false` are not picked up by the sweeper; a one-off
+  `Case::Base.update_all_indexes` is needed to repair them.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -8,7 +8,8 @@
 | ID | Title | Status | Date |
 |----|-------|--------|------|
 | [001](001-fixed-single-sar-deadline-extension.md) | Fixed single SAR deadline extension | Accepted | 2026-06-17 |
-| [002](001-denormalise-location-for-metabase-reporting.md) | Denormalise location onto DataRequestArea and DataRequest for Metabase reporting | Accepted | 2026-07-07 |
+| [002](002-denormalise-location-for-metabase-reporting.md) | Denormalise location onto DataRequestArea and DataRequest for Metabase reporting | Accepted | 2026-07-07 |
+| [003](003-enqueue-search-reindexing-after-commit.md) | Enqueue search reindexing after commit, with a dirty-case sweeper | Accepted | 2026-07-09 |
 
 ## Template
 

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -1,0 +1,10 @@
+namespace :search do
+  desc "Re-enqueue search indexing for cases still flagged as dirty"
+  task reindex_dirty_cases: :environment do
+    case_ids = Case::Base.where(dirty: true).pluck(:id)
+    case_ids.each do |case_id|
+      SearchIndexUpdaterJob.perform_later(case_id)
+    end
+    puts "Enqueued search reindexing for #{case_ids.size} dirty case(s)"
+  end
+end

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -1439,9 +1439,11 @@ RSpec.describe Case::Base, type: :model do
   end
 
   describe "#mark_as_clean" do
-    it "update index and flag is clean afer creation" do
+    it "is cleared by the search index job after creation" do
       kase = create :case
-      expect(kase).not_to be_dirty
+      expect(kase).to be_dirty
+      SearchIndexUpdaterJob.perform_now(kase.id)
+      expect(kase.reload).not_to be_dirty
     end
 
     it "clears the dirty flag" do
@@ -1503,10 +1505,10 @@ RSpec.describe Case::Base, type: :model do
     context "when creating a new record" do
       let(:kase) { build :case }
 
-      it "sets the dirty flag" do
+      it "sets the dirty flag until the index job has run" do
         expect(kase).not_to be_dirty
         kase.save!
-        expect(kase).not_to be_dirty
+        expect(kase.reload).to be_dirty
       end
 
       it "queues the job" do
@@ -1550,6 +1552,21 @@ RSpec.describe Case::Base, type: :model do
               kase.update(name: "John Smith")
             end
           }.to have_enqueued_job(SearchIndexUpdaterJob)
+        end
+
+        it "does not queue the job until the transaction commits" do
+          kase
+          queue_adapter = ActiveJob::Base.queue_adapter
+          queue_adapter.enqueued_jobs.clear
+
+          jobs_queued_mid_transaction = nil
+          ActiveRecord::Base.transaction do
+            kase.update!(name: "John Smith")
+            jobs_queued_mid_transaction = queue_adapter.enqueued_jobs.count { |job| job[:job] == SearchIndexUpdaterJob }
+          end
+
+          expect(jobs_queued_mid_transaction).to eq 0
+          expect(queue_adapter.enqueued_jobs.count { |job| job[:job] == SearchIndexUpdaterJob }).to eq 1
         end
       end
     end


### PR DESCRIPTION
## Description
Changes the mechanics for re-indexing cases by splitting the marking of a case 'as dirty' and then following up with the asynchronous background job to perform the index. This issue was affecting Offender SAR records whos case number changes depending on the current status.
 
Introduces a new rake task and related cronjob to mop-up bad indexes:

```
bundle exec rake search:reindex_dirty_cases
```

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/a
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1142

### Deployment
N/A
### Manual testing instructions
Create an Offender SAR and reject it so that the case number changes and the case goes into a 'rejected' state.