### PR TITLE
[CDPTKAN-970] Nil error in SAR Complaint Controller

### DIFF
--- a/app/controllers/cases/offender_sar_complaint_controller.rb
+++ b/app/controllers/cases/offender_sar_complaint_controller.rb
@@ -103,7 +103,7 @@ module Cases
     end
 
     def back_link_url
-      if has_optional_flags? && @case.current_step == "confirm-offender-sar"
+      if has_optional_flags? && @case.current_step == "confirm-offender-sar" && @case.original_case
         case_path @case.original_case.id
       else
         super

--- a/spec/controllers/cases/offender_sar_complaint_controller_spec.rb
+++ b/spec/controllers/cases/offender_sar_complaint_controller_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe Cases::OffenderSARComplaintController, type: :controller do
       expect(response).to render_template(:new)
       expect(assigns(:case_types)).to match_array %w[Case::SAR::OffenderComplaint]
     end
+
+    context "when navigating directly to confirm-offender-sar without an original case in session" do
+      let(:params) do
+        {
+          step: "confirm-offender-sar",
+          flag_for_creation_from_sar_page: "true",
+        }
+      end
+
+      it "does not raise a NoMethodError and renders the new template" do
+        expect { get(:new, params:) }.not_to raise_error
+        expect(response).to render_template(:new)
+      end
+    end
   end
 
   describe "#create" do


### PR DESCRIPTION
## Description
[ Sentry error](https://ministryofjustice.sentry.io/issues/6979298332/?project=5407956):  NoMethodError: undefined method 'id' for nil in Cases::OffenderSARComplaintController#back_link_url  

This happened when a user navigated directly to `/cases/offender_sar_complaints/confirm-offender-sar` — via browser back/forward navigation or a bookmarked URL — without having gone through the preceding link-offender-sar-case step.                                                                                                                                           
                                                                                                                                                                                   
In that flow, the case is built from session state. With no original_case in the session, @case.original_case is nil, causing a crash when back_link_url called .id on it.       
                                                                                                                                                                                   
**Fix**                                                                                                                                                                              
                                                                                                                                                                                   
Added a nil guard on @case.original_case in the back_link_url condition. When original_case is absent, the method falls through to super, which returns the previous step URL or  new_case_path — a safe fallback that doesn't crash and sends the user somewhere sensible.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [x] (3) Tests passing
* [x] (4) Branch ready to be merged (not work in progress)
* [x] (5) No superfluous changes in diff
* [x] (6) No TODO's without new ticket numbers
* [x] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed

### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
[<!-- A link or list of links to relevant issues in Jira -->](https://dsdmoj.atlassian.net/browse/CDPTKAN-970)

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
Verify the happy path still works: creating a complaint via `start_complaint` and stepping through to` confirm-offender-sar` should still show the back link pointing to the  original SAR case
