### PR TITLE
[CDTPKAN-1224] Add editable guard to prevent search re-indexing for no reason

### DIFF
--- a/app/jobs/search_index_updater_job.rb
+++ b/app/jobs/search_index_updater_job.rb
@@ -4,9 +4,10 @@ class SearchIndexUpdaterJob < ApplicationJob
   def perform(case_id)
     SentryContextProvider.set_context
     kase = Case::Base.find(case_id)
-    if kase
+
+    if kase && kase.editable?
       kase.update_index
-      kase.mark_as_clean if kase.dirty? && !kase.readonly?
+      kase.mark_as_clean if kase.dirty?
     end
   end
 end

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -5,6 +5,5 @@ namespace :search do
     case_ids.each do |case_id|
       SearchIndexUpdaterJob.perform_later(case_id)
     end
-    puts "Enqueued search reindexing for #{case_ids.size} dirty case(s)"
   end
 end


### PR DESCRIPTION
## Description
Adds guard to `SearchIndexUpdaterJob` to prevent re-indexing of already frozen cases.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1224

### Deployment
N/A
### Manual testing instructions
N/A