### PR TITLE
[CDPTKAN-1227] Add nightly job to reindex all cases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,8 +118,12 @@ jobs:
 
           kubectl set image -n ${KUBE_NAMESPACE} cronjobs/close-expired-rejected-offender-sars \
             jobs="${{ vars.ECR_URL }}:$SHA"
-          
+
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/development/cronjob-bank-holidays.yaml
+
+          kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/development/cronjob-reindex-all-cases.yaml
+          kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-all-cases \
+            jobs="${{ vars.ECR_URL }}:$SHA"
 
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
           kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-dirty-cases \
@@ -194,8 +198,12 @@ jobs:
 
           kubectl set image -n ${KUBE_NAMESPACE} cronjobs/close-expired-rejected-offender-sars \
             jobs="${{ vars.ECR_URL }}:$SHA"
-          
+
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/staging/cronjob-bank-holidays.yaml
+
+          kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/staging/cronjob-reindex-all-cases.yaml
+          kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-all-cases \
+            jobs="${{ vars.ECR_URL }}:$SHA"
 
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
           kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-dirty-cases \
@@ -273,10 +281,14 @@ jobs:
 
           kubectl set image -n ${KUBE_NAMESPACE} cronjobs/send-chase-emails \
             jobs="${{ vars.ECR_URL }}:$SHA"
-          
+
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/qa/cronjob-bank-holidays.yaml
 
           kubectl set image -n ${KUBE_NAMESPACE} cronjobs/auto-close-paused-sar-cases \
+            jobs="${{ vars.ECR_URL }}:$SHA"
+
+          kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/qa/cronjob-reindex-all-cases.yaml
+          kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-all-cases \
             jobs="${{ vars.ECR_URL }}:$SHA"
 
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
@@ -362,8 +374,12 @@ jobs:
 
           kubectl set image -n ${KUBE_NAMESPACE} cronjobs/rpi-delete \
             jobs="${{ vars.ECR_URL }}:$SHA"
-          
+
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/production/cronjob-bank-holidays.yaml
+
+          kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/production/cronjob-reindex-all-cases.yaml
+          kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-all-cases \
+            jobs="${{ vars.ECR_URL }}:$SHA"
 
           kubectl -n ${KUBE_NAMESPACE} apply -f config/kubernetes/production/cronjob-reindex-dirty-cases.yaml
           kubectl set image -n ${KUBE_NAMESPACE} cronjobs/reindex-dirty-cases \

--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ group :test do
   gem "capybara-lockstep"
   gem "i18n-tasks"
   gem "rails-controller-testing", require: false
+  gem "ruby_event_store-rspec", require: false
   gem "shoulda-matchers", "~> 8.0"
   gem "simplecov"
   gem "simplecov-json", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,6 +497,10 @@ GEM
     rexml (3.4.4)
     rouge (5.0.0)
       strscan (~> 3.1)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
     rspec-collection_matchers (1.2.1)
       rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.13.6)
@@ -562,6 +566,8 @@ GEM
     ruby_event_store-browser (2.18.0)
       rack
       ruby_event_store (= 2.18.0)
+    ruby_event_store-rspec (3.0.0)
+      rspec (~> 3.0)
     rubyzip (2.4.1)
     sablon (0.4.3)
       nokogiri (>= 1.8.5)
@@ -749,6 +755,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   ruby-progressbar
+  ruby_event_store-rspec
   rubyzip (>= 1.2.4)
   sablon
   sass-rails (~> 6.0)

--- a/app/models/case/base.rb
+++ b/app/models/case/base.rb
@@ -30,7 +30,7 @@
 #  user_id                  :integer          default(-100), not null
 #  reason_for_lateness_id   :bigint
 #  reason_for_lateness_note :string
-#
+#  last_indexed_at          :datetime
 
 class Case::Base < ApplicationRecord
   TRIGGER_WORKFLOWS = %w[trigger full_approval].freeze

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -2,7 +2,6 @@ module Searchable
   extend ActiveSupport::Concern
 
   include SearchHelper
-  include Eventing
 
   included do
     include PgSearch::Model

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -29,7 +29,7 @@ module Searchable
       )
       total_reindexed = 0
 
-      in_batches(of: 1000) do |batch|
+      Case::Base.in_batches(of: 1000) do |batch|
         vectors = batch.map { |kase| [kase.id, kase.tsvector] }
 
         update_sql = <<~EOSQL

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -2,6 +2,7 @@ module Searchable
   extend ActiveSupport::Concern
 
   include SearchHelper
+  include Eventing
 
   included do
     include PgSearch::Model
@@ -23,20 +24,51 @@ module Searchable
 
   class_methods do
     def update_all_indexes
-      all.each(&:update_index)
+      Rails.configuration.event_store.publish(
+        Events::ReindexStarted.build({ started_at: Time.zone.now }),
+        stream_name: "ReindexCases",
+      )
+      total_reindexed = 0
+
+      Case::Base.in_batches(of: 1000).map do |batch|
+        vectors = batch.map { |kase| [kase.id, kase.tsvector] }
+
+        update_sql = <<~EOSQL
+          UPDATE #{table_name} AS t SET
+            document_tsvector = c.document_tsvector,
+            last_indexed_at = NOW()
+          FROM (VALUES
+            #{vectors.map { |id, vector| "(#{id}, #{vector})" }.join(",\n").chomp(',')}
+          ) AS c(id, document_tsvector)
+          WHERE c.id = t.id;
+        EOSQL
+
+        connection.execute(update_sql)
+        total_reindexed += batch.size
+      end
+
+      Rails.configuration.event_store.publish(
+        Events::ReindexCompleted.build({ completed_at: Time.zone.now, total_reindexed: total_reindexed }),
+        stream_name: "ReindexCases",
+      )
     end
   end
 
   def update_index
-    tsvector = self.class.searchable_fields_and_ranks.map { |field_name, rank|
-      field_data = self.class.connection.quote __send__(field_name) || ""
-      "setweight(to_tsvector('english', #{field_data}), '#{rank}')"
-    }.join(" || ")
     update_sql = <<~EOSQL
       UPDATE #{self.class.table_name}
-             SET document_tsvector=#{tsvector}
-             WHERE id=#{id};
+      SET document_tsvector=#{tsvector}, last_indexed_at = NOW()
+      WHERE id=#{id};
     EOSQL
-    self.class.connection.execute update_sql
+
+    self.class.connection.execute(update_sql)
+  end
+
+  def tsvector
+    self.class.searchable_fields_and_ranks.map { |field_name, rank|
+      field_data = self.class.connection.quote __send__(field_name) || ""
+
+      "setweight(to_tsvector('english', #{field_data}), '#{rank}')"
+    }.join(" || ")
   end
 end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -30,7 +30,7 @@ module Searchable
       )
       total_reindexed = 0
 
-      Case::Base.in_batches(of: 1000).map do |batch|
+      in_batches(of: 1000) do |batch|
         vectors = batch.map { |kase| [kase.id, kase.tsvector] }
 
         update_sql = <<~EOSQL
@@ -38,7 +38,7 @@ module Searchable
             document_tsvector = c.document_tsvector,
             last_indexed_at = NOW()
           FROM (VALUES
-            #{vectors.map { |id, vector| "(#{id}, #{vector})" }.join(",\n").chomp(',')}
+            #{vectors.map { |id, vector| "(#{id}, #{vector})" }.join(",\n")}
           ) AS c(id, document_tsvector)
           WHERE c.id = t.id;
         EOSQL

--- a/app/pub_sub/events/reindex_completed.rb
+++ b/app/pub_sub/events/reindex_completed.rb
@@ -1,0 +1,4 @@
+module Events
+  class ReindexCompleted < SystemEvent
+  end
+end

--- a/app/pub_sub/events/reindex_started.rb
+++ b/app/pub_sub/events/reindex_started.rb
@@ -1,0 +1,4 @@
+module Events
+  class ReindexStarted < SystemEvent
+  end
+end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -378,6 +378,29 @@
       "note": "False positive - see commit message"
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "e862a138d501fa181a10f135a4fdc22753d56c9d2bf0a968fae33a39aa4a2f58",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/concerns/searchable.rb",
+      "line": 46,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "connection.execute(\"UPDATE #{table_name} AS t SET\\n  document_tsvector = c.document_tsvector,\\n  last_indexed_at = NOW()\\nFROM (VALUES\\n  #{batch.map do\n [kase.id, kase.tsvector]\n end.map do\n \"(#{id}, #{vector})\"\n end.join(\",\\n\").chomp(\",\")}\\n) AS c(id, document_tsvector)\\nWHERE c.id = t.id;\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Searchable",
+        "method": "update_all_indexes"
+      },
+      "user_input": "batch.map do\n [kase.id, kase.tsvector]\n end.map do\n \"(#{id}, #{vector})\"\n end.join(\",\\n\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Remote Code Execution",
       "warning_code": 24,
       "fingerprint": "ebef895897b45d36e3ba01ffb7087e30bf21387b71814d99b5fc937f357a4a61",
@@ -424,5 +447,5 @@
       "note": ""
     }
   ],
-  "brakeman_version": "8.0.4"
+  "brakeman_version": "8.0.5"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,6 +24,29 @@
       "note": ""
     },
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "303b174bea813460c5695dcadf2fffd0a1648ef47d5b1a17c21f3969da538317",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/concerns/searchable.rb",
+      "line": 45,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "connection.execute(\"UPDATE #{table_name} AS t SET\\n  document_tsvector = c.document_tsvector,\\n  last_indexed_at = NOW()\\nFROM (VALUES\\n  #{batch.map do\n [kase.id, kase.tsvector]\n end.map do\n \"(#{id}, #{vector})\"\n end.join(\",\\n\")}\\n) AS c(id, document_tsvector)\\nWHERE c.id = t.id;\\n\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Searchable",
+        "method": "update_all_indexes"
+      },
+      "user_input": "batch.map do\n [kase.id, kase.tsvector]\n end.map do\n \"(#{id}, #{vector})\"\n end.join(\",\\n\")",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "388aeb272d6eebb62685ae89373c083785efc817ecc917441c61ed3066854267",
@@ -376,29 +399,6 @@
         470
       ],
       "note": "False positive - see commit message"
-    },
-    {
-      "warning_type": "SQL Injection",
-      "warning_code": 0,
-      "fingerprint": "e862a138d501fa181a10f135a4fdc22753d56c9d2bf0a968fae33a39aa4a2f58",
-      "check_name": "SQL",
-      "message": "Possible SQL injection",
-      "file": "app/models/concerns/searchable.rb",
-      "line": 46,
-      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "connection.execute(\"UPDATE #{table_name} AS t SET\\n  document_tsvector = c.document_tsvector,\\n  last_indexed_at = NOW()\\nFROM (VALUES\\n  #{batch.map do\n [kase.id, kase.tsvector]\n end.map do\n \"(#{id}, #{vector})\"\n end.join(\",\\n\").chomp(\",\")}\\n) AS c(id, document_tsvector)\\nWHERE c.id = t.id;\\n\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Searchable",
-        "method": "update_all_indexes"
-      },
-      "user_input": "batch.map do\n [kase.id, kase.tsvector]\n end.map do\n \"(#{id}, #{vector})\"\n end.join(\",\\n\")",
-      "confidence": "Medium",
-      "cwe_id": [
-        89
-      ],
-      "note": ""
     },
     {
       "warning_type": "Remote Code Execution",

--- a/config/initializers/rails_event_store.rb
+++ b/config/initializers/rails_event_store.rb
@@ -9,6 +9,8 @@ require_relative "../../app/pub_sub/events/email_sent"
 require_relative "../../app/pub_sub/events/rpi_received"
 require_relative "../../app/pub_sub/events/rpi_processed"
 require_relative "../../app/pub_sub/events/rpi_unprocessed"
+require_relative "../../app/pub_sub/events/reindex_started"
+require_relative "../../app/pub_sub/events/reindex_completed"
 
 Rails.configuration.to_prepare do
   Rails.configuration.event_store = RailsEventStore::JSONClient.new

--- a/config/kubernetes/development/cronjob-reindex-all-cases.yaml
+++ b/config/kubernetes/development/cronjob-reindex-all-cases.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: reindex-dirty-cases
-  namespace: track-a-query-production
+  name: reindex-all-cases
+  namespace: track-a-query-development
 spec:
-  schedule: "60 * * * *"
+  schedule: "0 2 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -15,12 +15,12 @@ spec:
           serviceAccountName: track-a-query
           containers:
           - name: jobs
-            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:production.latest
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:development.latest
             imagePullPolicy: IfNotPresent
             command:
               - sh
               - "-c"
-              - "bundle exec rake 'search:reindex_dirty_cases'"
+              - "bundle exec rake 'search:reindex_all_cases'"
             env:
               - name: DATABASE_URL
                 valueFrom:

--- a/config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
@@ -4,7 +4,7 @@ metadata:
   name: reindex-dirty-cases
   namespace: track-a-query-development
 spec:
-  schedule: "30 * * * *"
+  schedule: "60 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/development/cronjob-reindex-dirty-cases.yaml
@@ -4,7 +4,7 @@ metadata:
   name: reindex-dirty-cases
   namespace: track-a-query-development
 spec:
-  schedule: "60 * * * *"
+  schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/config/kubernetes/production/cronjob-reindex-all-cases.yaml
+++ b/config/kubernetes/production/cronjob-reindex-all-cases.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: reindex-dirty-cases
+  name: reindex-all-cases
   namespace: track-a-query-production
 spec:
-  schedule: "60 * * * *"
+  schedule: "0 2 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -20,7 +20,7 @@ spec:
             command:
               - sh
               - "-c"
-              - "bundle exec rake 'search:reindex_dirty_cases'"
+              - "bundle exec rake 'search:reindex_all_cases'"
             env:
               - name: DATABASE_URL
                 valueFrom:

--- a/config/kubernetes/production/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/production/cronjob-reindex-dirty-cases.yaml
@@ -4,7 +4,7 @@ metadata:
   name: reindex-dirty-cases
   namespace: track-a-query-production
 spec:
-  schedule: "60 * * * *"
+  schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/config/kubernetes/qa/cronjob-reindex-all-cases.yaml
+++ b/config/kubernetes/qa/cronjob-reindex-all-cases.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: reindex-dirty-cases
-  namespace: track-a-query-production
+  name: reindex-all-cases
+  namespace: track-a-query-qa
 spec:
-  schedule: "60 * * * *"
+  schedule: "0 2 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -15,12 +15,12 @@ spec:
           serviceAccountName: track-a-query
           containers:
           - name: jobs
-            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:production.latest
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:qa.latest
             imagePullPolicy: IfNotPresent
             command:
               - sh
               - "-c"
-              - "bundle exec rake 'search:reindex_dirty_cases'"
+              - "bundle exec rake 'search:reindex_all_cases'"
             env:
               - name: DATABASE_URL
                 valueFrom:

--- a/config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
@@ -4,7 +4,7 @@ metadata:
   name: reindex-dirty-cases
   namespace: track-a-query-qa
 spec:
-  schedule: "60 * * * *"
+  schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/qa/cronjob-reindex-dirty-cases.yaml
@@ -4,7 +4,7 @@ metadata:
   name: reindex-dirty-cases
   namespace: track-a-query-qa
 spec:
-  schedule: "30 * * * *"
+  schedule: "60 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/config/kubernetes/staging/cronjob-reindex-all-cases.yaml
+++ b/config/kubernetes/staging/cronjob-reindex-all-cases.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: reindex-dirty-cases
-  namespace: track-a-query-production
+  name: reindex-all-cases
+  namespace: track-a-query-staging
 spec:
-  schedule: "60 * * * *"
+  schedule: "0 2 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -15,12 +15,12 @@ spec:
           serviceAccountName: track-a-query
           containers:
           - name: jobs
-            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:production.latest
+            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/correspondence/track-a-query-ecr:staging.latest
             imagePullPolicy: IfNotPresent
             command:
               - sh
               - "-c"
-              - "bundle exec rake 'search:reindex_dirty_cases'"
+              - "bundle exec rake 'search:reindex_all_cases'"
             env:
               - name: DATABASE_URL
                 valueFrom:

--- a/config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
@@ -4,7 +4,7 @@ metadata:
   name: reindex-dirty-cases
   namespace: track-a-query-staging
 spec:
-  schedule: "60 * * * *"
+  schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
+++ b/config/kubernetes/staging/cronjob-reindex-dirty-cases.yaml
@@ -4,7 +4,7 @@ metadata:
   name: reindex-dirty-cases
   namespace: track-a-query-staging
 spec:
-  schedule: "30 * * * *"
+  schedule: "60 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/db/migrate/20260714122524_add_last_indexed_at_to_cases.rb
+++ b/db/migrate/20260714122524_add_last_indexed_at_to_cases.rb
@@ -1,0 +1,5 @@
+class AddLastIndexedAtToCases < ActiveRecord::Migration[8.1]
+  def change
+    add_column :cases, :last_indexed_at, :datetime, null: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -443,7 +443,8 @@ CREATE TABLE public.cases (
     reason_for_deletion character varying,
     user_id integer DEFAULT '-100'::integer NOT NULL,
     reason_for_lateness_id bigint,
-    reason_for_lateness_note character varying
+    reason_for_lateness_note character varying,
+    last_indexed_at timestamp(6) without time zone
 );
 
 
@@ -2631,6 +2632,7 @@ ALTER TABLE ONLY public.data_request_areas
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260714122524'),
 ('20260630090000'),
 ('20260617003452'),
 ('20260610120000'),

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -6,4 +6,9 @@ namespace :search do
       SearchIndexUpdaterJob.perform_later(case_id)
     end
   end
+
+  desc "Re-index all cases"
+  task reindex_all_cases: :environment do
+    Case::Base.update_all_indexes
+  end
 end

--- a/spec/models/case/base_spec.rb
+++ b/spec/models/case/base_spec.rb
@@ -30,7 +30,7 @@
 #  user_id                  :integer          default(-100), not null
 #  reason_for_lateness_id   :bigint
 #  reason_for_lateness_note :string
-#
+#  last_indexed_at          :datetime
 
 require "rails_helper"
 

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "ruby_event_store/rspec"
 
 # rubocop:disable RSpec/InstanceVariable
 RSpec.describe Searchable do
@@ -64,7 +65,8 @@ RSpec.describe Searchable do
     it "updates all cases" do
       @searchable.class.update_all_indexes
 
-      expect(@searchable.class.all).to all have_received :update_index
+      expect(Rails.configuration.event_store).to have_published(an_event(Events::ReindexStarted)).in_stream("ReindexCases")
+      expect(Rails.configuration.event_store).to have_published(an_event(Events::ReindexCompleted)).in_stream("ReindexCases")
     end
   end
 
@@ -81,9 +83,10 @@ RSpec.describe Searchable do
 
       update_sql = <<~EOSQL
         UPDATE searchable
-               SET document_tsvector=setweight(to_tsvector('english', 'foobar'), 'A') || setweight(to_tsvector('english', 'barfoo'), 'B')
-               WHERE id=1;
+        SET document_tsvector=setweight(to_tsvector('english', 'foobar'), 'A') || setweight(to_tsvector('english', 'barfoo'), 'B'), last_indexed_at = NOW()
+        WHERE id=1;
       EOSQL
+
       expect(connection).to have_received(:execute).with(update_sql)
     end
   end


### PR DESCRIPTION
## Description
Re-implements the existing `Case::Base.update_all_indexes` so that the entire set of Cases are re-indexed everyday at 2am UTC. This is in addition to re-indexing 'dirty' cases every 60 minutes throughout the day. Between these two jobs and the changes to the sequencing of indexing, any historic records and new records should be correctly indexed.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1227

### Deployment
N/A
### Manual testing instructions
Check job runs as expected.
