### PR TITLE
[CDPTKAN-948] Properly allow deny destroy_case event

### DIFF
--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -94,7 +94,7 @@ class Case::BasePolicy < ApplicationPolicy
 
   def destroy?
     clear_failed_checks
-    user.manager?
+    user.manager? && check_can_trigger_event(:destroy_case)
   end
 
   def destroy_case?

--- a/app/services/case_deletion_service.rb
+++ b/app/services/case_deletion_service.rb
@@ -10,18 +10,25 @@ class CaseDeletionService
 
   def call
     if @kase.related_case_links.present?
-      @kase.errors.add(:related_case_links,
-                       I18n.t("activerecord.errors.models.case.attributes.related_case_links.not_empty"))
+      @kase.errors.add(:related_case_links, I18n.t("activerecord.errors.models.case.attributes.related_case_links.not_empty"))
       @result = :error
-    elsif @kase.update(@update_parameters.merge(deleted: true))
-      clear_up_linked_cases
-      @kase.state_machine.destroy_case!(acting_user: @user, acting_team: @kase.managing_team)
-      @result = :ok
     else
-      @result = :error
+      ActiveRecord::Base.transaction do
+        if @kase.update(@update_parameters.merge(deleted: true))
+          clear_up_linked_cases
+          @kase.state_machine.destroy_case!(acting_user: @user, acting_team: @kase.managing_team)
+          @result = :ok
+        else
+          @result = :error
+        end
+      end
     end
 
     @result
+  rescue ConfigurableStateMachine::InvalidEventError
+    @kase.reload
+    @kase.errors.add(:base, I18n.t("activerecord.errors.models.case.attributes.base.invalid_deletion_state"))
+    @result = :error
   end
 
 private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,6 +101,8 @@ en:
               not_in_future: "cannot be in the future."
             related_case_links:
               not_empty: "are not empty. Please remove all linked cases in order to delete this case."
+            base:
+              invalid_deletion_state: "This case cannot be deleted in its current state."
             number_final_pages:
               not_whole_number: 'must be a positive whole number'
             number_exempt_pages:
@@ -475,6 +477,8 @@ en:
       can_remove_attachment?: 'You are not authorised to remove attachments from this case.'
       can_view_case_details?: 'You are not authorised to view this case.'
       delete?: You are not authorised to delete this case.
+      destroy?: You are not authorised to delete this case.
+      confirm_destroy?: You are not authorised to delete this case.
       edit?: You are not authorised to edit this case.
       new_case_link?: You are not authorised to link other cases to this case.
       show?: You are not authorised to view this case.

--- a/spec/controllers/cases_controller/destroy_spec.rb
+++ b/spec/controllers/cases_controller/destroy_spec.rb
@@ -58,5 +58,21 @@ describe CasesController, type: :controller do # rubocop:disable Rails/FilePath
         expect(kase.deleted?).to be true
       end
     end
+
+    context "when the case is in a state that does not permit deletion" do
+      let(:kase) { create :accepted_sar, :stopped }
+
+      it "does not mark the case as deleted" do
+        delete(:destroy, params:)
+        kase.reload
+        expect(kase.deleted?).to be false
+      end
+
+      it "redirects with an unauthorised message" do
+        delete(:destroy, params:)
+        expect(flash[:alert]).to eq "You are not authorised to delete this case."
+        expect(response).to redirect_to root_path
+      end
+    end
   end
 end

--- a/spec/policies/case/base_policy_spec.rb
+++ b/spec/policies/case/base_policy_spec.rb
@@ -309,6 +309,18 @@ describe Case::BasePolicy do
     it { is_expected.not_to permit(responder,              new_case) }
     it { is_expected.not_to permit(disclosure_specialist,  assigned_trigger_case) }
     it { is_expected.to     permit(manager,                new_case) }
+
+    context "when the case is in a state that permits the destroy_case event" do
+      let(:sar_being_drafted) { create :sar_being_drafted }
+
+      it { is_expected.to permit(manager, sar_being_drafted) }
+    end
+
+    context "when the case is in a state that does not permit the destroy_case event" do
+      let(:stopped_sar_case) { create :accepted_sar, :stopped }
+
+      it { is_expected.not_to permit(manager, stopped_sar_case) }
+    end
   end
 
   permissions :can_assign_case? do

--- a/spec/services/case_deletion_service_spec.rb
+++ b/spec/services/case_deletion_service_spec.rb
@@ -8,11 +8,11 @@ describe CaseDeletionService do
     let(:state_machine) { double ConfigurableStateMachine::Machine, destroy_case!: true } # rubocop:disable RSpec/VerifiedDoubles
     let(:service)       { described_class.new(user, kase, reason_for_deletion: "Because") }
 
-    before do
-      allow(kase).to receive(:state_machine).and_return(state_machine)
-    end
-
     context "when soft deleting a case" do
+      before do
+        allow(kase).to receive(:state_machine).and_return(state_machine)
+      end
+
       it "changes the attributes on the case" do
         service.call
         expect(kase.deleted?).to eq true
@@ -29,9 +29,32 @@ describe CaseDeletionService do
     end
 
     context "when anything fails in the transaction" do
+      before do
+        allow(kase).to receive(:state_machine).and_return(state_machine)
+      end
+
       it "raises an error when it saves" do
         allow(kase).to receive(:update).and_return(false)
         expect(service.call).to eq :error
+      end
+    end
+
+    context "when the case state does not permit the destroy_case event" do
+      let(:kase) { create :accepted_sar, :stopped }
+
+      it "sets result to :error" do
+        expect(service.call).to eq :error
+      end
+
+      it "does not soft delete the case" do
+        service.call
+        expect(kase.reload.deleted?).to eq false
+      end
+
+      it "adds an error to the case" do
+        service.call
+        expect(kase.errors[:base])
+          .to include(I18n.t("activerecord.errors.models.case.attributes.base.invalid_deletion_state"))
       end
     end
   end


### PR DESCRIPTION
## Description
A user without the correct permission now cannot delete a case which left the case deleted (even though it shouldn't have been) and without a case history. This is now fixed.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-948
### Deployment
N/A
### Manual testing instructions
N/A