### PR TITLE
[CDTPKAN-1233] Enforce permission when  Removing a Response

### DIFF
--- a/app/models/concerns/case_states.rb
+++ b/app/models/concerns/case_states.rb
@@ -32,7 +32,8 @@ module CaseStates
 
   def remove_response(current_user, attachment, acting_team: nil)
     attachment.destroy!
-    acting_team ||= current_user.case_team(self)
+    acting_team ||= current_user.case_team_for_event(self, :remove_response) || current_user.case_team(self)
+
     state_machine.remove_response! acting_user: current_user,
                                    acting_team:,
                                    filenames: attachment.filename,

--- a/app/policies/case/base_policy.rb
+++ b/app/policies/case/base_policy.rb
@@ -228,7 +228,7 @@ class Case::BasePolicy < ApplicationPolicy
 
   def can_remove_attachment?
     clear_failed_checks
-    check_can_trigger_event(:remove_response)
+    check_can_trigger_event_from_users_team(:remove_response)
   end
 
   def can_upload_request_attachment?
@@ -560,6 +560,14 @@ private
       event_name:,
       metadata: { acting_user: user },
     )
+  end
+
+  # Unlike :can_trigger_event, which passes if any of the user's roles across
+  # all their teams permits the event, this only passes if one of the teams
+  # the user would actually act for on this case can trigger it - mirroring
+  # how the acting team is chosen when the event is fired.
+  check :can_trigger_event_from_users_team do |event_name|
+    user.case_team_for_event(self.case, event_name).present?
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/policies/case/sar/standard_policy.rb
+++ b/app/policies/case/sar/standard_policy.rb
@@ -62,11 +62,6 @@ class Case::SAR::StandardPolicy < Case::BasePolicy
     check_can_trigger_event(:remove_sar_deadline_extension)
   end
 
-  def can_remove_attachment?
-    clear_failed_checks
-    check_can_trigger_event(:remove_response)
-  end
-
   def upload_responses?
     clear_failed_checks
     check(:user_is_a_manager_for_case) &&

--- a/spec/controllers/cases/attachments_controller_spec.rb
+++ b/spec/controllers/cases/attachments_controller_spec.rb
@@ -124,6 +124,22 @@ RSpec.describe Cases::AttachmentsController, type: :controller do
       end
     end
 
+    context "when a user who is both a manager and a member of the responding team" do
+      let(:manager_responder) do
+        create :user,
+               managing_teams: [kase.managing_team],
+               responding_teams: [kase.responding_team]
+      end
+
+      before { sign_in manager_responder }
+
+      it "deletes the attachment acting as the responding team" do
+        delete :destroy, params: { case_id: kase.id, id: attachment.id }
+        expect(kase.reload.attachments).not_to include(attachment)
+        expect(kase.transitions.last.acting_team).to eq kase.responding_team
+      end
+    end
+
     context "when a responder who has marked the case as responded" do
       let(:kase) { create(:responded_case) }
 

--- a/spec/models/concerns/case_states_spec.rb
+++ b/spec/models/concerns/case_states_spec.rb
@@ -99,6 +99,24 @@ RSpec.describe Case, type: :model do
           expect(kase.current_state).to eq "awaiting_dispatch"
         end
       end
+
+      context "when the user is both a manager and a member of the responding team" do
+        let(:manager_responder) do
+          create :user,
+                 managing_teams: [kase.managing_team],
+                 responding_teams: [kase.responding_team]
+        end
+
+        before do
+          allow(attachment).to receive(:remove_from_storage_bucket)
+        end
+
+        it "acts with the responding team rather than the managing team" do
+          kase.remove_response(manager_responder, attachment)
+          expect(kase.current_state).to eq "drafting"
+          expect(kase.transitions.last.acting_team).to eq kase.responding_team
+        end
+      end
     end
 
     describe "#remove_response from SAR case" do

--- a/spec/policies/case/base_policy_spec.rb
+++ b/spec/policies/case/base_policy_spec.rb
@@ -340,6 +340,31 @@ describe Case::BasePolicy do
       it { is_expected.not_to permit(another_responder, responded_case) }
       it { is_expected.not_to permit(manager,           responded_case) }
     end
+
+    context "when the user is both a manager and a member of the responding team" do
+      let(:manager_responder) do
+        create :user,
+               managing_teams: [managing_team],
+               responding_teams: [responding_team]
+      end
+      let(:kase) do
+        create :case_with_response,
+               responding_team:,
+               responder: manager_responder
+      end
+
+      it { is_expected.to permit(manager_responder, kase) }
+    end
+
+    context "when the user is a manager and a responder in a team not assigned to the case" do
+      let(:manager_other_responder) do
+        create :user,
+               managing_teams: [managing_team],
+               responding_teams: [create(:responding_team)]
+      end
+
+      it { is_expected.not_to permit(manager_other_responder, case_with_response) }
+    end
   end
 
   permissions :can_respond? do


### PR DESCRIPTION
## Description
Ensures users do not see an error page when Removing a response from an FOI case.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A
### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1233
### Deployment
N/A
### Manual testing instructions
N/A