### PR TITLE
[CDTPKAN-1233] Place transaction around remove_response event

### DIFF
--- a/app/controllers/cases/attachments_controller.rb
+++ b/app/controllers/cases/attachments_controller.rb
@@ -19,7 +19,11 @@ module Cases
     def destroy
       authorize @case, :can_remove_attachment?
 
-      @case.remove_response(current_user, @attachment)
+      begin
+        @case.remove_response(current_user, @attachment)
+      rescue StandardError
+        flash[:alert] = t("notices.remove_response_failed")
+      end
 
       if @case.attachments.empty? && request.format == :js
         render js: "window.location = '#{case_path(@case)}'"

--- a/app/models/concerns/case_states.rb
+++ b/app/models/concerns/case_states.rb
@@ -31,13 +31,18 @@ module CaseStates
   end
 
   def remove_response(current_user, attachment, acting_team: nil)
-    attachment.destroy!
-    acting_team ||= current_user.case_team_for_event(self, :remove_response) || current_user.case_team(self)
+    ActiveRecord::Base.transaction do
+      attachment.destroy!
 
-    state_machine.remove_response! acting_user: current_user,
-                                   acting_team:,
-                                   filenames: attachment.filename,
-                                   num_attachments: reload.attachments.size
+      acting_team ||= current_user.case_team_for_event(self, :remove_response) || current_user.case_team(self)
+
+      state_machine.remove_response!(
+        acting_user: current_user,
+        acting_team: acting_team,
+        filenames: attachment.filename,
+        num_attachments: reload.attachments.size,
+      )
+    end
   end
 
   def response_attachments

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1129,6 +1129,7 @@ en:
     case_closed: "You've closed this case"
     closure_details_updated: You have updated the closure details for this case.
     response_uploaded: You have uploaded the response for this case.
+    remove_response_failed: You are not allowed to remove this attachment.
     request_uploaded: You have uploaded the request files for this case.
     no_request_uploaded: No changes were made.
     progress_for_clearance: The Disclosure team has been notified this case is ready for clearance

--- a/spec/controllers/cases/attachments_controller_spec.rb
+++ b/spec/controllers/cases/attachments_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Cases::AttachmentsController, type: :controller do
     shared_examples "unauthorized user" do
       it "redirect to the login or root page" do
         get :download, params: { case_id: kase.id, id: attachment.id }
+
         if subject.current_user
           if subject.current_user.manager?
             expect(response).to redirect_to manager_root_path
@@ -84,6 +85,7 @@ RSpec.describe Cases::AttachmentsController, type: :controller do
     shared_examples "unauthorized user" do
       it "redirect to the login or root page" do
         delete :destroy, params: { case_id: kase.id, id: attachment.id }
+
         if subject.current_user
           if subject.current_user.manager?
             expect(response).to redirect_to manager_root_path
@@ -121,6 +123,22 @@ RSpec.describe Cases::AttachmentsController, type: :controller do
       it "deletes the attachment from the case" do
         delete :destroy, params: { case_id: kase.id, id: attachment.id }
         expect(kase.reload.attachments).not_to include(attachment)
+      end
+
+      context "when removing the attachment fails" do
+        before do
+          allow_any_instance_of(Case::Base) # rubocop:disable RSpec/AnyInstance
+            .to receive(:remove_response)
+            .and_raise(ActiveRecord::RecordNotDestroyed.new("remove failed", attachment))
+        end
+
+        it "redirects back to the case with an alert" do
+          delete :destroy, params: { case_id: kase.id, id: attachment.id }
+
+          expect(response).to redirect_to(case_path(kase))
+          expect(flash[:alert]).to eq(I18n.t("notices.remove_response_failed"))
+          expect(kase.reload.attachments).to include(attachment)
+        end
       end
     end
 

--- a/spec/models/concerns/case_states_spec.rb
+++ b/spec/models/concerns/case_states_spec.rb
@@ -117,6 +117,29 @@ RSpec.describe Case, type: :model do
           expect(kase.transitions.last.acting_team).to eq kase.responding_team
         end
       end
+
+      context "when state transition fails" do
+        before do
+          allow(attachment).to receive(:remove_from_storage_bucket)
+          allow(kase.state_machine).to receive(:remove_response!).and_raise(
+            ConfigurableStateMachine::InvalidEventError.new(
+              role: responder.responding_teams.first.role,
+              kase:,
+              user: responder,
+              event: :remove_response,
+              message: "No event remove_response for role manager and case state awaiting_dispatch",
+            ),
+          )
+        end
+
+        it "rolls back the attachment deletion" do
+          expect {
+            kase.remove_response(responder, attachment)
+          }.to raise_error(ConfigurableStateMachine::InvalidEventError)
+
+          expect(kase.reload.attachments).to include(attachment)
+        end
+      end
     end
 
     describe "#remove_response from SAR case" do


### PR DESCRIPTION
## Description
Adds further protection to 'remove' attachment from the 'Requst' panel in a SAR case. Follows on from #2872 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
N/A

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1233

### Deployment
N/A
### Manual testing instructions
N/A