### PR TITLE
[CDPTKAN-1027] Prevent multiple button hits for the various "Mark as..." buttons

### DIFF
--- a/app/controllers/cases/offender_sar_controller.rb
+++ b/app/controllers/cases/offender_sar_controller.rb
@@ -108,7 +108,10 @@ module Cases
         @case.state_machine.send("#{params[:transition_name]}!", params_for_transition)
         reload_case_page_on_success
       else
-        raise ArgumentError, "Bad transition, the action #{params[:transition_name]}is not allowed."
+        # The event is no longer available - typically a double-click or a stale
+        # case page where the case has already been moved on
+        flash[:alert] = t("cases.update.transition_unavailable", action: I18n.t("event.#{params[:transition_name]}"))
+        redirect_to case_path(@case)
       end
     end
 

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -77,7 +77,8 @@ module CasesHelper
               action_url,
               id: "action--#{link_text.parameterize}",
               class: "button state-action-button",
-              method: "patch"
+              method: "patch",
+              data: { disable_with: link_text }
     when :move_case_back
       link_to t("common.case/offender_sar.move_case_back"),
               move_case_back_case_sar_offender_path(@case),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1520,6 +1520,7 @@ en:
     update:
       case_updated: Case updated
       case_partial_flag_updated: Case updated
+      transition_unavailable: "Your request to %{action} was not successful. Case was already updated prior."
     filters:
       index:
         <<: *cases_list

--- a/spec/helpers/cases_helper_spec.rb
+++ b/spec/helpers/cases_helper_spec.rb
@@ -138,6 +138,15 @@ href=\"/cases/ico_fois/#{@case.id}/close\">Record ICO&#39;s decision</a>",
       end
     end
 
+    context "when event matches mark_as_*" do
+      it "generates HTML that links to the transition action with double-click protection" do
+        @case = create(:offender_sar_case, :ready_for_vetting).decorate
+        expect(action_button_for(:mark_as_vetting_in_progress)).to eq(
+          "<a id=\"action--mark-as-vetting-in-progress\" class=\"button state-action-button\" data-disable-with=\"Mark as vetting in progress\" rel=\"nofollow\" data-method=\"patch\" href=\"/cases/offender_sars/#{@case.id}/transitions/mark_as_vetting_in_progress\">Mark as vetting in progress</a>",
+        )
+      end
+    end
+
     context "when event == :progress_for_clearance" do
       it "generates HTML that links to the progress_for_clearance case action" do
         @case = create(:accepted_sar, :flagged)

--- a/spec/support/shared_examples/cases/edit_offender_sar_examples.rb
+++ b/spec/support/shared_examples/cases/edit_offender_sar_examples.rb
@@ -40,5 +40,20 @@ RSpec.shared_examples "edit offender sar spec" do |current_state, event_name|
         expect(offender_sar.current_state).not_to eq current_state
       end
     end
+
+    context "when the transition is no longer available" do
+      before do
+        2.times { patch :transition, params: }
+      end
+
+      it "flashes an alert" do
+        expect(controller.flash[:alert])
+          .to eq "Your request to #{I18n.t("event.#{event_name}")} was not successful. Case was already updated prior."
+      end
+
+      it "redirects to case details page" do
+        expect(response).to redirect_to(case_path(offender_sar))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
Error logged because someone (User A) has the case open in their browser and then in another window/tab the same person or someone else (User B) has already hit the same button. When User A sees the original button they hit it again and get a 500. This PR presents a nicer error.

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots

#### BEFORE - note nice message
<img width="1646" height="867" alt="Screenshot 2026-07-21 at 11 39 39" src="https://github.com/user-attachments/assets/df5c8a94-5eac-424c-88f6-bbe111be0b10" />


#### AFTER - note 500 error is gone
<img width="1625" height="883" alt="Screenshot 2026-07-21 at 11 38 52" src="https://github.com/user-attachments/assets/de24a22e-b7fa-47ef-9bb5-f1dd3e616721" />


### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1027

### Deployment
N/A
### Manual testing instructions
1. Have the same new Offender SAR open in two separate windows. Click an action in one of the windows, then click the same button in the other window (logged in as same person).
