### PR TITLE
[CDPTKAN-1234]  (Branston) Add acknowledgement deadline for standard offender SAR complaints 

### DIFF
--- a/app/decorators/case/sar/offender_complaint_decorator.rb
+++ b/app/decorators/case/sar/offender_complaint_decorator.rb
@@ -17,6 +17,12 @@ class Case::SAR::OffenderComplaintDecorator < Case::SAR::OffenderBaseDecorator
     h.t "helpers.label.offender_sar_complaint.complaint_type.#{object.complaint_type}"
   end
 
+  def acknowledgement_deadline
+    return nil if object.acknowledgement_deadline.blank?
+
+    I18n.l(object.acknowledgement_deadline, format: :default)
+  end
+
   def highlight_flag
     if object.high?
       h.content_tag :div, class: "#{object.type_abbreviation.downcase}-priority_flag" do

--- a/app/form_models/offender_sar_complaint_case_form.rb
+++ b/app/form_models/offender_sar_complaint_case_form.rb
@@ -84,6 +84,9 @@ private
     if [nil, "standard_complaint"].include? object["complaint_type"]
       params.merge!(external_deadline: object.deadline_calculator.external_deadline)
     end
+    if object["complaint_type"] == "standard_complaint"
+      params.merge!(acknowledgement_deadline: object.calculate_acknowledgement_deadline)
+    end
     params
   end
 

--- a/app/models/case/sar/offender_complaint.rb
+++ b/app/models/case/sar/offender_complaint.rb
@@ -35,9 +35,11 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
   include LinkableOriginalCase
 
   validates :original_case, presence: true
+  before_create :set_acknowledgement_deadline, if: :standard_complaint?
   after_create :stamp_on_original_case
 
   jsonb_accessor :properties,
+                 acknowledgement_deadline: :date,
                  complaint_type: :string,
                  complaint_subtype: :string,
                  ico_contact_name: :string,
@@ -109,6 +111,25 @@ class Case::SAR::OffenderComplaint < Case::SAR::Offender
   def validate_external_deadline
     validate_external_deadline_required
     validate_external_deadline_within_valid_range
+  end
+
+  def calculate_acknowledgement_deadline
+    return nil if received_date.blank?
+
+    # Day 1 is the next weekday after received_date. Bank holidays count as
+    # working days for the 10-day count, but if day 10 is a bank holiday we
+    # advance to the next non-bank-holiday weekday.
+    day = received_date + 1
+    day += 1 while day.saturday? || day.sunday?
+
+    9.times do
+      day += 1
+      day += 1 while day.saturday? || day.sunday?
+    end
+
+    day += 1 while england_and_wales_bank_holiday?(day) || day.saturday? || day.sunday?
+
+    day
   end
 
   def normal_priority?
@@ -277,6 +298,14 @@ private
 
   def has_total_cost?
     total_cost.present? && total_cost.positive?
+  end
+
+  def set_acknowledgement_deadline
+    self.acknowledgement_deadline = calculate_acknowledgement_deadline
+  end
+
+  def england_and_wales_bank_holiday?(date)
+    BankHoliday.bank_holiday?(date, regions: :england_and_wales)
   end
 
   # 'Q' denotes a complaint in the legacy system, carried into new system

--- a/app/views/cases/_case_status.html.slim
+++ b/app/views/cases/_case_status.html.slim
@@ -45,6 +45,13 @@
         .case-status__date-value
           = case_details.internal_deadline
 
+    - if case_details.offender_sar_complaint? && case_details.standard_complaint? && case_details.object.acknowledgement_deadline.present?
+      .case-status__group.acknowledgement
+        .case-status__date-title
+          = t('common.case.acknowledgement_deadline')
+        .case-status__date-value
+          = case_details.acknowledgement_deadline
+
     .case-status__group.external
       .case-status__date-title
         = t("common.case.external_deadline#{case_details.stopped? ? '_paused' : ''}")

--- a/app/views/cases/offender_sar_complaint/_acknowledgement_deadline.html.slim
+++ b/app/views/cases/offender_sar_complaint/_acknowledgement_deadline.html.slim
@@ -1,0 +1,5 @@
+- if case_details.standard_complaint? && case_details.object.acknowledgement_deadline.present?
+  tr.section.case-acknowledgement-deadline.section-acknowledgement-deadline
+    th = t('common.case.acknowledgement_deadline')
+    td = case_details.acknowledgement_deadline
+    td

--- a/app/views/cases/offender_sar_complaint/_case_details.html.slim
+++ b/app/views/cases/offender_sar_complaint/_case_details.html.slim
@@ -28,6 +28,8 @@
 
         = render partial: 'cases/offender_sar_complaint/date_received', locals: { case_details: case_details, allow_editing: allow_editing }
 
+        = render partial: 'cases/offender_sar_complaint/acknowledgement_deadline', locals: { case_details: case_details, allow_editing: allow_editing }
+
         = render partial: 'cases/offender_sar_complaint/case_deadlines', locals: { case_details: case_details, allow_editing: allow_editing }
 
         - if case_details.has_date_draft_compliant?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1176,6 +1176,7 @@ en:
       exemptions_heading: Exemptions
       extend_for_pit: Extend for Public Interest Test
       extend_sar_deadline: Extend deadline
+      acknowledgement_deadline: Acknowledgement deadline
       external_deadline: Final deadline
       external_deadline_paused: Final deadline (paused)
       filename: File name

--- a/spec/models/case/sar/offender_complaint_spec.rb
+++ b/spec/models/case/sar/offender_complaint_spec.rb
@@ -908,4 +908,91 @@ describe Case::SAR::OffenderComplaint do
       expect(complaint.has_costs?).to eq true
     end
   end
+
+  describe "#calculate_acknowledgement_deadline" do
+    context "when received_date is nil" do
+      it "returns nil" do
+        kase = build(:offender_sar_complaint, received_date: nil)
+        expect(kase.calculate_acknowledgement_deadline).to be_nil
+      end
+    end
+
+    context "when received on a Tuesday (mid-week)" do
+      it "returns 10 weekdays later on a Tuesday" do
+        # Received Tue 21 Jul → Day 1 Wed 22 Jul → Day 10 Tue 4 Aug
+        kase = build(:offender_sar_complaint, received_date: Date.new(2026, 7, 21))
+        expect(kase.calculate_acknowledgement_deadline).to eq(Date.new(2026, 8, 4))
+      end
+    end
+
+    context "when received on a Friday" do
+      it "starts Day 1 on the following Monday" do
+        # Received Fri 17 Jul → Day 1 Mon 20 Jul → Day 10 Fri 31 Jul
+        kase = build(:offender_sar_complaint, received_date: Date.new(2026, 7, 17))
+        expect(kase.calculate_acknowledgement_deadline).to eq(Date.new(2026, 7, 31))
+      end
+    end
+
+    context "when received on a Thursday whose Day 10 spans a weekend" do
+      it "skips over weekends in the count" do
+        # Received Mon 17 Aug → Day 1 Tue 18 Aug → Day 10 Mon 31 Aug
+        # (bank holiday on Aug 31 stubbed away for this case)
+        kase = build(:offender_sar_complaint, received_date: Date.new(2026, 8, 17))
+        allow(BankHoliday).to receive(:bank_holiday?).and_return(false)
+        expect(kase.calculate_acknowledgement_deadline).to eq(Date.new(2026, 8, 31))
+      end
+    end
+
+    context "when Day 10 falls on a bank holiday" do
+      it "advances to the next working day" do
+        # Received Mon 17 Aug → Day 10 = Mon 31 Aug (bank holiday in fixture)
+        # Expected result: Tue 1 Sep
+        kase = build(:offender_sar_complaint, received_date: Date.new(2026, 8, 17))
+        allow(BankHoliday).to receive(:bank_holiday?)
+          .with(Date.new(2026, 8, 31), regions: :england_and_wales)
+          .and_return(true)
+        allow(BankHoliday).to receive(:bank_holiday?)
+          .with(Date.new(2026, 9, 1), regions: :england_and_wales)
+          .and_return(false)
+        expect(kase.calculate_acknowledgement_deadline).to eq(Date.new(2026, 9, 1))
+      end
+    end
+
+    context "when received on a Saturday" do
+      it "starts Day 1 on the following Monday" do
+        # Received Sat 18 Jul → Day 1 Mon 20 Jul → Day 10 Fri 31 Jul
+        kase = build(:offender_sar_complaint, received_date: Date.new(2026, 7, 18))
+        expect(kase.calculate_acknowledgement_deadline).to eq(Date.new(2026, 7, 31))
+      end
+    end
+  end
+
+  describe "before_create :set_acknowledgement_deadline" do
+    context "when complaint type is standard" do
+      it "persists acknowledgement_deadline on create" do
+        kase = create(:offender_sar_complaint,
+                      complaint_type: "standard_complaint",
+                      received_date: Date.new(2026, 7, 21))
+        expect(kase.acknowledgement_deadline).to eq(Date.new(2026, 8, 4))
+      end
+    end
+
+    context "when complaint type is ico" do
+      it "does not set acknowledgement_deadline" do
+        kase = create(:offender_sar_complaint,
+                      complaint_type: "ico_complaint",
+                      received_date: Date.new(2026, 7, 21))
+        expect(kase.acknowledgement_deadline).to be_nil
+      end
+    end
+
+    context "when complaint type is litigation" do
+      it "does not set acknowledgement_deadline" do
+        kase = create(:offender_sar_complaint,
+                      complaint_type: "litigation_complaint",
+                      received_date: Date.new(2026, 7, 21))
+        expect(kase.acknowledgement_deadline).to be_nil
+      end
+    end
+  end
 end

--- a/spec/views/cases/_case_status_html_slim_spec.rb
+++ b/spec/views/cases/_case_status_html_slim_spec.rb
@@ -12,6 +12,7 @@ describe "cases/case_status.html.slim", type: :view do
                              who_its_with: "DACU",
                              type_of_offender_sar?: false,
                              offender_sar?: false,
+                             offender_sar_complaint?: false,
                              stopped?: false
 
     render partial: "cases/case_status", locals: { case_details: unassigned_case }
@@ -43,6 +44,7 @@ describe "cases/case_status.html.slim", type: :view do
                          who_its_with: "",
                          type_of_offender_sar?: false,
                          offender_sar?: false,
+                         offender_sar_complaint?: false,
                          stopped?: false
 
     render partial: "cases/case_status",
@@ -70,6 +72,7 @@ describe "cases/case_status.html.slim", type: :view do
                               who_its_with: "DACU",
                               type_of_offender_sar?: false,
                               offender_sar?: false,
+                              offender_sar_complaint?: false,
                               stopped?: false
 
     render partial: "cases/case_status",
@@ -99,6 +102,7 @@ describe "cases/case_status.html.slim", type: :view do
              who_its_with: "DACU",
              type_of_offender_sar?: false,
              offender_sar?: false,
+             offender_sar_complaint?: false,
              stopped?: false
     end
 
@@ -113,6 +117,7 @@ describe "cases/case_status.html.slim", type: :view do
                                 who_its_with: "DACU",
                                 type_of_offender_sar?: false,
                                 offender_sar?: false,
+                                offender_sar_complaint?: false,
                                 stopped?: false
 
       render partial: "cases/case_status",
@@ -144,6 +149,7 @@ describe "cases/case_status.html.slim", type: :view do
                         who_its_with: "DACU",
                         type_of_offender_sar?: false,
                         offender_sar?: false,
+                        offender_sar_complaint?: false,
                         stopped?: false
 
       render partial: "cases/case_status",
@@ -174,6 +180,7 @@ describe "cases/case_status.html.slim", type: :view do
         who_its_with: "Branston Registry",
         type_of_offender_sar?: false,
         offender_sar_complaint?: false,
+        standard_complaint?: false,
         offender_sar?: false,
         rejected?: false,
         page_count: "500",
@@ -240,6 +247,7 @@ describe "cases/case_status.html.slim", type: :view do
                         who_its_with: "DACU",
                         type_of_offender_sar?: false,
                         offender_sar?: false,
+                        offender_sar_complaint?: false,
                         stopped?: false
 
       render partial: "cases/case_status",
@@ -258,6 +266,60 @@ describe "cases/case_status.html.slim", type: :view do
       expect(partial.details.ico_ref_number_label.text)
         .to eq "ICO case reference number"
       expect(partial.details.ico_ref_number.text).to eq "123456789ABC"
+    end
+  end
+
+  describe "acknowledgement deadline" do
+    let(:base_params) do
+      {
+        status: "To be assessed",
+        ico?: false,
+        internal_deadline: nil,
+        external_deadline: (Time.zone.now + 20.days).strftime(Settings.default_date_format),
+        current_state: "to_be_assessed",
+        type_abbreviation: "OFFENDER_SAR_COMPLAINT",
+        who_its_with: "Branston Registry",
+        type_of_offender_sar?: false,
+        offender_sar?: false,
+        offender_sar_complaint?: true,
+        stopped?: false,
+      }
+    end
+
+    it "displays the acknowledgement deadline above the final deadline for standard complaints" do
+      complaint = double Case::SAR::OffenderComplaintDecorator, # rubocop:disable RSpec/VerifiedDoubles
+                         base_params.merge(
+                           standard_complaint?: true,
+                           acknowledgement_deadline: "05 Aug 2026",
+                           object: double(acknowledgement_deadline: Date.new(2026, 8, 5)), # rubocop:disable RSpec/VerifiedDoubles
+                         )
+
+      render partial: "cases/case_status", locals: { case_details: complaint }
+
+      expect(rendered).to have_css(".case-status__group.acknowledgement")
+      expect(rendered).to include("Acknowledgement deadline")
+      expect(rendered).to include("05 Aug 2026")
+    end
+
+    it "does not display the acknowledgement deadline when it is blank" do
+      complaint = double Case::SAR::OffenderComplaintDecorator, # rubocop:disable RSpec/VerifiedDoubles
+                         base_params.merge(
+                           standard_complaint?: true,
+                           object: double(acknowledgement_deadline: nil), # rubocop:disable RSpec/VerifiedDoubles
+                         )
+
+      render partial: "cases/case_status", locals: { case_details: complaint }
+
+      expect(rendered).to have_no_css(".case-status__group.acknowledgement")
+    end
+
+    it "does not display the acknowledgement deadline for non-standard complaints" do
+      complaint = double Case::SAR::OffenderComplaintDecorator, # rubocop:disable RSpec/VerifiedDoubles
+                         base_params.merge(standard_complaint?: false)
+
+      render partial: "cases/case_status", locals: { case_details: complaint }
+
+      expect(rendered).to have_no_css(".case-status__group.acknowledgement")
     end
   end
 


### PR DESCRIPTION
## Description
  - Adds an acknowledgement deadline to CT (Branston) standard offender SAR complaints, calculated as 10 working days from the received date (weekends skipped throughout; if day 10 falls on a bank holiday, advances to the next working day)                                                                              
  - Persists the deadline via a before_create callback and stores it in the properties JSONB column under acknowledgement_deadline                              
  - Displays the deadline in two places: the case status sidebar and the case details table, visible only for standard complaints with a non-blank deadline     
  - The form model also recalculates and merges the deadline when building params for standard complaints 

## Self-review checklist
<!-- Action these things before requesting reviews -->
* [ ] (1) Quick stakeholder demo done OR
* [ ] (2) ...bug with before and after screenshots
* [ ] (3) Tests passing
* [ ] (4) Branch ready to be merged (not work in progress)
* [ ] (5) No superfluous changes in diff
* [ ] (6) No TODO's without new ticket numbers
* [ ] (7) PR Prefixed with ticket number e.g. `CT-7654 ...`
* [ ] (8) Data migration script is created if any of letter templates is changed


### Screenshots
<!-- Screenshots of the new changes if appropriate -->

### Related JIRA tickets
https://dsdmoj.atlassian.net/browse/CDPTKAN-1234

### Deployment
<!-- Notes about database migrations, new runtime dependencies, mitigating downtime, feature flags, etc -->

### Manual testing instructions
- Create a standard offender SAR complaint and confirm the acknowledgement deadline is set and visible in the case details and status sidebar
- Confirm ICO and litigation complaint types show no acknowledgement deadline                                                                             
- Create a standard complaint received on a Friday — verify Day 1 is the following Monday                                                                 
-Create a standard complaint whose Day 10 falls on a bank holiday — verify it advances to the next working day        
